### PR TITLE
Go-live improvements for PR review agent

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -63,7 +63,12 @@ jobs:
           if [ -n "${PR_URL_OVERRIDE}" ]; then
             echo "${PR_URL_OVERRIDE}" > prs.txt
           else
-            bash scripts/list-prs.sh | head -n "$MAX_PRS" > prs.txt
+            bash scripts/list-prs.sh > prs_all.txt
+            TOTAL=$(wc -l < prs_all.txt | tr -d ' ')
+            head -n "$MAX_PRS" prs_all.txt > prs.txt
+            if [ "$TOTAL" -gt "$MAX_PRS" ]; then
+              echo "::notice::Backlog has $TOTAL PRs but MAX_PRS=$MAX_PRS — reviewing first $MAX_PRS only. Remaining will be picked up in subsequent runs."
+            fi
           fi
           echo "count=$(wc -l < prs.txt | tr -d ' ')" >> "$GITHUB_OUTPUT"
           echo "--- candidate PRs (max $MAX_PRS) ---"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   review:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     env:
       # GH_PAT is a fine-grained PAT with PR read/write across the repos you
       # want the agent to act on. Stored as a repo secret.
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout agent repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code
@@ -54,15 +54,19 @@ jobs:
 
       - name: Enumerate candidate PRs
         id: list
+        env:
+          # Cap how many PRs one cron tick reviews to stay within timeout.
+          # Override via repo variable: gh variable set MAX_PRS --body 20 --repo don-petry/self
+          MAX_PRS: ${{ vars.MAX_PRS || '10' }}
         run: |
           set -euo pipefail
           if [ -n "${PR_URL_OVERRIDE}" ]; then
             echo "${PR_URL_OVERRIDE}" > prs.txt
           else
-            bash scripts/list-prs.sh > prs.txt
+            bash scripts/list-prs.sh | head -n "$MAX_PRS" > prs.txt
           fi
           echo "count=$(wc -l < prs.txt | tr -d ' ')" >> "$GITHUB_OUTPUT"
-          echo "--- candidate PRs ---"
+          echo "--- candidate PRs (max $MAX_PRS) ---"
           cat prs.txt || true
 
       - name: Review each PR (council + synth)

--- a/AGENT.md
+++ b/AGENT.md
@@ -132,8 +132,7 @@ gh workflow run pr-review.yml --repo don-petry/self -f dry_run=false
   job timeout (~5 min per PR with 3 council members). Override:
   `gh variable set MAX_PRS --body 15 --repo don-petry/self`
 - **Models** — change model IDs in `scripts/review-one-pr.sh` (`run_member`
-  calls). Current: security=opus-4-6, correctness=sonnet-4-6,
-  maintainability=sonnet-4-6, synthesis=sonnet-4-6.
+  calls and the synthesis invocation). See the script for current assignments.
 
 ## Cost
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -123,13 +123,21 @@ gh workflow run pr-review.yml --repo don-petry/self -f dry_run=false
 
 ## Tuning
 
-- **Risk rules** live in `prompts/review-pr.md`. Edit there.
+- **Risk rules** — edit `prompts/shared.md` (taxonomy), or per-lens in
+  `prompts/council/{security,correctness,maintainability}.md`.
 - **Cron frequency** — change the `cron:` line in the workflow file.
 - **Scope** — edit `scripts/list-prs.sh` to add/remove queries (e.g. to include
   PRs from a specific org, or to exclude certain repos).
+- **Max PRs per run** — defaults to 10 per cron tick to stay within the 60-min
+  job timeout (~5 min per PR with 3 council members). Override:
+  `gh variable set MAX_PRS --body 15 --repo don-petry/self`
+- **Models** — change model IDs in `scripts/review-one-pr.sh` (`run_member`
+  calls). Current: security=opus-4-6, correctness=sonnet-4-6,
+  maintainability=sonnet-4-6, synthesis=sonnet-4-6.
 
 ## Cost
 
-Hourly cron × ~30 days = ~720 runs/month. If most hours have zero candidate PRs
-the cost is just GitHub Actions minutes (~10s each). Anthropic API cost scales
-with PR count and diff size — expect a few cents per non-trivial PR review.
+Uses the Claude Max plan via OAuth token — no per-token API billing. GitHub
+Actions cost is ~720 runs/month (hourly × 30 days). Runs with zero candidate
+PRs finish in ~10s. Each PR reviewed costs ~5 min of runner time (4 model
+invocations: 3 council + 1 synthesis).

--- a/scripts/list-prs.sh
+++ b/scripts/list-prs.sh
@@ -1,20 +1,18 @@
 #!/usr/bin/env bash
-# Enumerate open PRs the agent should consider reviewing.
+# Enumerate open, non-draft PRs the agent should consider reviewing.
 #
 # Two buckets, deduped:
 #   1. PRs authored by @me across all repos (self-review).
 #   2. PRs where @me is a requested reviewer across all repos.
 #
-# Output: one PR URL per line on stdout.
+# Output: one PR URL per line on stdout. Drafts are excluded.
 
 set -euo pipefail
 
-ME="$(gh api user --jq '.login')"
-
-# gh search prs respects $GH_TOKEN. --json url is portable across versions.
 authored=$(gh search prs \
   --state open \
   --author "@me" \
+  --draft=false \
   --limit 100 \
   --json url \
   --jq '.[].url')
@@ -22,13 +20,11 @@ authored=$(gh search prs \
 review_requested=$(gh search prs \
   --state open \
   --review-requested "@me" \
+  --draft=false \
   --limit 100 \
   --json url \
   --jq '.[].url')
 
-# Skip drafts — agent should not review WIP PRs.
-# We re-query each URL's isDraft via gh pr view in the review step too,
-# but filtering here saves API calls for the obvious cases.
 {
   printf '%s\n' "$authored"
   printf '%s\n' "$review_requested"

--- a/scripts/review-one-pr.sh
+++ b/scripts/review-one-pr.sh
@@ -30,9 +30,12 @@ export PR_HEAD_SHA
 echo "    head SHA: $PR_HEAD_SHA"
 
 # 2. Idempotency: look for our marker at this SHA in existing reviews+comments
+# Extract the most recent SHA from our review marker in existing PR comments/reviews.
+# Uses (array + array) to concatenate safely when either is empty, then iterates
+# .body with null guard. The 2>/dev/null catches GraphQL field-access errors.
 EXISTING_MARKER_SHA=$(
   gh pr view "$PR_URL" --json reviews,comments \
-    --jq '[(.reviews // [])[] | .body // empty, (.comments // [])[] | .body // empty] | .[] | select(. != null)' 2>/dev/null \
+    --jq '((.reviews // []) + (.comments // [])) | .[].body | select(. != null)' 2>/dev/null \
   | grep -oE '<!-- pr-review-agent v1 sha=[a-f0-9]+' \
   | grep -oE '[a-f0-9]+$' \
   | tail -1 || true

--- a/scripts/review-one-pr.sh
+++ b/scripts/review-one-pr.sh
@@ -32,7 +32,7 @@ echo "    head SHA: $PR_HEAD_SHA"
 # 2. Idempotency: look for our marker at this SHA in existing reviews+comments
 EXISTING_MARKER_SHA=$(
   gh pr view "$PR_URL" --json reviews,comments \
-    --jq '[.reviews[].body, .comments[].body] | .[] | select(. != null)' 2>/dev/null \
+    --jq '[(.reviews // [])[] | .body // empty, (.comments // [])[] | .body // empty] | .[] | select(. != null)' 2>/dev/null \
   | grep -oE '<!-- pr-review-agent v1 sha=[a-f0-9]+' \
   | grep -oE '[a-f0-9]+$' \
   | tail -1 || true


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` v4→v5 (Node.js 20 deprecation fix)
- Add `MAX_PRS` cap (default 10) so hourly cron stays within timeout on large backlogs
- Filter draft PRs at enumeration time (`--draft=false`) to avoid wasting council invocations
- Fix idempotency jq query that could fail on PRs with zero reviews/comments
- Remove unused variable, update docs to reflect council architecture

## Test plan
- [ ] Dispatch workflow with `dry_run=true` against this PR (dogfood)
- [ ] Verify council runs (3 members + synth) complete without errors
- [ ] Verify draft filtering works in list-prs.sh
- [ ] Verify MAX_PRS cap truncates PR list correctly
- [ ] Merge when council approves

Closes: go-live readiness for the PR review agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)