### PR TITLE
feat: add Copilot engine support via REVIEW_ENGINE toggle

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -31,30 +31,48 @@ jobs:
       # GH_PAT is a fine-grained PAT with PR read/write across the repos you
       # want the agent to act on. Stored as a repo secret.
       GH_TOKEN: ${{ secrets.GH_PAT }}
-      # Routes Claude Code through the Max plan subscription instead of
-      # per-token API billing. Generate with `claude setup-token` locally.
+      # Review engine: "claude" or "copilot". Controls which CLI and models are used.
+      # gh variable set REVIEW_ENGINE --body copilot --repo don-petry/self
+      REVIEW_ENGINE: ${{ vars.REVIEW_ENGINE || 'claude' }}
+      # Claude engine auth — routes through Max plan subscription.
+      # Generate with `claude setup-token`, store as repo secret.
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      # Copilot engine auth — GitHub PAT with Copilot scope.
+      # Store as repo secret: gh secret set COPILOT_GITHUB_TOKEN --repo don-petry/self
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
       # Default to dry-run unless the repo variable LIVE_MODE is set to 'true'.
       # Manual workflow_dispatch can override either way via the dry_run input.
       # To go live: gh variable set LIVE_MODE --body true --repo don-petry/self
       DRY_RUN: ${{ inputs.dry_run || (vars.LIVE_MODE == 'true' && 'false' || 'true') }}
       PR_URL_OVERRIDE: ${{ inputs.pr_url }}
-      # Comma-separated list of GitHub orgs where Claude App is installed.
-      # When findings exist, the agent tags @claude to fix them autonomously.
-      # gh variable set CLAUDE_ORGS --body "petry-projects,don-petry" --repo don-petry/self
-      CLAUDE_ORGS: ${{ vars.CLAUDE_ORGS || '' }}
-      # Max review cycles before stopping @claude delegation and escalating to human.
+      # Comma-separated list of GitHub orgs where AI delegation is enabled.
+      # When findings exist, the agent posts fix-request comments for AI to act on.
+      # gh variable set DELEGATION_ORGS --body "petry-projects,don-petry" --repo don-petry/self
+      DELEGATION_ORGS: ${{ vars.DELEGATION_ORGS || vars.CLAUDE_ORGS || '' }}
+      # Max review cycles before stopping AI delegation and escalating to human.
       MAX_REVIEW_CYCLES: ${{ vars.MAX_REVIEW_CYCLES || '3' }}
-      # PRs with fewer total changed lines than this use a single Opus call
-      # instead of the full 3-member council. Default: 10 lines.
+      # PRs with fewer total changed lines than this use a single call
+      # instead of the full cascade. Default: 10 lines.
       SMALL_PR_THRESHOLD: ${{ vars.SMALL_PR_THRESHOLD || '10' }}
 
     steps:
       - name: Checkout agent repo
         uses: actions/checkout@v5
 
-      - name: Install Claude Code CLI
-        run: npm install -g @anthropic-ai/claude-code
+      - name: Install review engine CLI
+        run: |
+          case "$REVIEW_ENGINE" in
+            claude)
+              npm install -g @anthropic-ai/claude-code
+              ;;
+            copilot)
+              npm install -g @github/copilot
+              ;;
+            *)
+              echo "::error::Unknown REVIEW_ENGINE=$REVIEW_ENGINE"
+              exit 1
+              ;;
+          esac
 
       - name: Verify auth
         run: |
@@ -83,7 +101,7 @@ jobs:
           echo "--- candidate PRs (max $MAX_PRS) ---"
           cat prs.txt || true
 
-      - name: Review each PR (council + synth)
+      - name: Review each PR (cascade)
         if: steps.list.outputs.count != '0'
         run: |
           set -euo pipefail

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -51,9 +51,6 @@ jobs:
       DELEGATION_ORGS: ${{ vars.DELEGATION_ORGS || vars.CLAUDE_ORGS || '' }}
       # Max review cycles before stopping AI delegation and escalating to human.
       MAX_REVIEW_CYCLES: ${{ vars.MAX_REVIEW_CYCLES || '3' }}
-      # PRs with fewer total changed lines than this use a single call
-      # instead of the full cascade. Default: 10 lines.
-      SMALL_PR_THRESHOLD: ${{ vars.SMALL_PR_THRESHOLD || '10' }}
 
     steps:
       - name: Checkout agent repo
@@ -66,7 +63,7 @@ jobs:
               npm install -g @anthropic-ai/claude-code
               ;;
             copilot)
-              npm install -g @github/copilot
+              gh extension install github/gh-copilot
               ;;
             *)
               echo "::error::Unknown REVIEW_ENGINE=$REVIEW_ENGINE"

--- a/AGENT.md
+++ b/AGENT.md
@@ -4,6 +4,9 @@ A scheduled GitHub Action that reviews open PRs on don-petry's behalf.
 Runs hourly, classifies risk, auto-approves low/medium-risk PRs that pass all
 quality gates, and escalates high-risk or gated PRs for human review.
 
+Supports two LLM engines via the `REVIEW_ENGINE` repo variable: **Claude** (default)
+and **Copilot**.
+
 ## How it works
 
 1. **Cron** — `.github/workflows/pr-review.yml` runs at `:07` every hour
@@ -15,40 +18,42 @@ quality gates, and escalates high-risk or gated PRs for human review.
    where each tier only fires if the previous one flagged concerns:
 
    ```
-   Tier 1: Haiku triage (~15s, no tools, pre-fetched context)
-     └─ clean? → single Opus confirmation → approve + auto-merge
+   Tier 1: Triage (~15s, no tools, pre-fetched context)
+     └─ clean? → single confirmation → approve + auto-merge
      └─ concerns? ↓
-   Tier 2: Sonnet deep review (~2 min, full agentic)
+   Tier 2: Deep review (~2 min, full agentic)
      └─ clean? → approve + auto-merge
      └─ HIGH risk? ↓
-   Tier 3: Opus security audit (~3 min, full agentic)
+   Tier 3: Security audit (~3 min, full agentic)
      └─ final decision → approve or escalate
    ```
 
-   | Tier | Model | Role | When |
-   |---|---|---|---|
-   | Triage | Haiku 4.5 | Fast risk classification, no tools | Every PR |
-   | Deep review | Sonnet 4.6 | Full review (security+correctness+maintainability) | Only if triage escalates |
-   | Security audit | Opus 4.6 | Paranoid security-focused review | Only if Sonnet flags HIGH risk |
-   | Action | Sonnet 4.6 | Posts review, handles delegation/merge | After resolving tier |
+   ### Engine model mapping
+
+   | Tier | Claude engine | Copilot engine |
+   |---|---|---|
+   | Triage | Haiku 4.5 | GPT-5-mini |
+   | Deep review | Sonnet 4.6 | GPT-5.2 |
+   | Security audit | Opus 4.6 | GPT-5.4 |
+   | Action / single review | Sonnet 4.6 / Opus 4.6 | GPT-5.2 / GPT-5.4 |
 
    **Cost profile:**
-   - ~80% of PRs: Haiku triage + Opus confirm (2 calls, ~30s)
-   - ~15% of PRs: + Sonnet deep review (3 calls, ~2.5 min)
-   - ~5% of PRs: + Opus audit (4 calls, ~5.5 min)
+   - ~80% of PRs: triage + single confirm (2 calls, ~30s)
+   - ~15% of PRs: + deep review (3 calls, ~2.5 min)
+   - ~5% of PRs: + security audit (4 calls, ~5.5 min)
 
-4. **Post-review actions** — after the review is posted, the synthesizer takes
+4. **Post-review actions** — after the review is posted, the action tier takes
    additional actions depending on the decision:
    - **If approved:** enables auto-merge (`gh pr merge --auto --squash`),
      rebases the branch if behind base, and removes the `needs-human-review`
      label. GitHub merges automatically once all required checks pass.
-   - **If escalated + Claude App available:** posts a follow-up comment tagging
-     `@claude` with specific fix instructions derived from the council findings.
-     Claude pushes fixes → next cron tick detects new SHA → council re-reviews
-     → approve + auto-merge when clean. This creates an autonomous fix loop.
-   - **If escalated + no Claude App (or max cycles reached):** labels
+   - **If escalated + AI delegation enabled:** posts a follow-up comment
+     with specific fix instructions. An AI agent watches for these comments,
+     pushes fixes → next cron tick detects new SHA → cascade re-reviews →
+     approve + auto-merge when clean. This creates an autonomous fix loop.
+   - **If escalated + no delegation (or max cycles reached):** labels
      `needs-human-review` and re-requests don-petry as reviewer.
-   - **Cycle guard:** after `MAX_REVIEW_CYCLES` (default 3) rounds of @claude
+   - **Cycle guard:** after `MAX_REVIEW_CYCLES` (default 3) rounds of AI
      delegation without resolution, the agent stops delegating and escalates
      to human to prevent infinite loops.
 
@@ -59,11 +64,11 @@ quality gates, and escalates high-risk or gated PRs for human review.
    <!-- pr-review-agent v1 sha=<full-commit-sha> decision=... risk=... -->
    ```
 
-   Before invoking the council, `scripts/review-one-pr.sh` fetches the PR's
+   Before invoking the cascade, `scripts/review-one-pr.sh` fetches the PR's
    current head SHA and scans existing reviews/comments for the marker. If a
    marker matching the current head SHA exists, the script skips the PR
    without spending tokens. If a marker exists for an older SHA, the script
-   knows the PR has new commits since the last review and runs the council
+   knows the PR has new commits since the last review and runs the cascade
    again — handling iterative review cycles cleanly.
 
 ## Setup
@@ -89,24 +94,41 @@ Save the token, then add it as a repo secret on `don-petry/self`:
 gh secret set GH_PAT --repo don-petry/self
 ```
 
-### 2. Add your Claude Code OAuth token
+### 2. Add your LLM engine auth token
 
-This routes the agent's Claude usage through your Claude Max plan instead of
-per-token API billing. Generate the token locally with:
+#### Claude engine (default)
+
+Routes the agent's usage through your Claude Max plan. Generate the token:
 
 ```
 claude setup-token
 ```
 
-It prints a long-lived OAuth token. Store it as a repo secret:
+Store as a repo secret:
 
 ```
 gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo don-petry/self
 ```
 
-(Paste the token when prompted, then Ctrl+D.)
+#### Copilot engine
 
-### 3. Test with a dry run
+Create a GitHub PAT with Copilot scope. Store as a repo secret:
+
+```
+gh secret set COPILOT_GITHUB_TOKEN --repo don-petry/self
+```
+
+### 3. Choose your engine
+
+```
+# Use Copilot (GPT models):
+gh variable set REVIEW_ENGINE --body copilot --repo don-petry/self
+
+# Use Claude (default — no variable needed, or set explicitly):
+gh variable set REVIEW_ENGINE --body claude --repo don-petry/self
+```
+
+### 4. Test with a dry run
 
 ```
 gh workflow run pr-review.yml --repo don-petry/self -f dry_run=true
@@ -145,28 +167,46 @@ gh workflow run pr-review.yml --repo don-petry/self -f dry_run=false
 
 ## Tuning
 
-- **Risk rules** — edit `prompts/shared.md` (taxonomy), or per-lens in
-  `prompts/council/{security,correctness,maintainability}.md`.
+- **Review engine** — `REVIEW_ENGINE` repo variable: `claude` (default) or
+  `copilot`. Controls which CLI and model family is used.
+- **Risk rules** — edit `prompts/shared.md` (taxonomy), or the per-tier
+  prompts (`prompts/deep-review.md`, `prompts/security-audit.md`).
 - **Cron frequency** — change the `cron:` line in the workflow file.
 - **Scope** — edit `scripts/list-prs.sh` to add/remove queries (e.g. to include
   PRs from a specific org, or to exclude certain repos).
-- **Claude delegation** — set `CLAUDE_ORGS` to a comma-separated list of GitHub
-  orgs where the Claude App is installed:
-  `gh variable set CLAUDE_ORGS --body "petry-projects,don-petry" --repo don-petry/self`
-- **Max review cycles** — how many times the agent tags @claude before
+- **AI delegation** — set `DELEGATION_ORGS` to a comma-separated list of
+  GitHub orgs where AI-assisted fix delegation is enabled:
+  `gh variable set DELEGATION_ORGS --body "petry-projects,don-petry" --repo don-petry/self`
+- **Max review cycles** — how many times the agent delegates to AI before
   escalating to human (default 3):
   `gh variable set MAX_REVIEW_CYCLES --body 5 --repo don-petry/self`
-- **Models** — change model IDs in `scripts/review-one-pr.sh`. The cascade
-  tiers map to: triage=haiku, deep=sonnet, audit=opus, action=sonnet.
+- **Models** — change model IDs in `scripts/engine.sh`. The cascade tiers
+  map to: triage → deep → audit → action.
 - **Max PRs per run** — defaults to 10 per cron tick to stay within the 60-min
-  job timeout (~5 min per PR with 3 council members). Override:
+  job timeout. Override:
   `gh variable set MAX_PRS --body 15 --repo don-petry/self`
-- **Models** — change model IDs in `scripts/review-one-pr.sh` (`run_member`
-  calls and the synthesis invocation). See the script for current assignments.
+
+## Architecture
+
+```
+scripts/engine.sh         ← LLM abstraction (claude/copilot dispatch)
+scripts/review-one-pr.sh  ← Cascade orchestrator (sources engine.sh)
+scripts/list-prs.sh       ← PR enumeration
+
+prompts/triage.md         ← Tier 1: fast risk triage (no tools)
+prompts/deep-review.md    ← Tier 2: thorough review (agentic)
+prompts/security-audit.md ← Tier 3: paranoid security check (agentic)
+prompts/single-review.md  ← Fast path: small/incremental/triage-approved
+prompts/cascade-action.md ← Post-review: post, merge, delegate
+prompts/shared.md         ← Shared risk taxonomy and decision gates
+```
 
 ## Cost
 
-Uses the Claude Max plan via OAuth token — no per-token API billing. GitHub
-Actions cost is ~720 runs/month (hourly × 30 days). Runs with zero candidate
-PRs finish in ~10s. Each PR reviewed costs ~5 min of runner time (4 model
-invocations: 3 council + 1 synthesis).
+Uses the configured engine's billing:
+- **Claude:** Max plan via OAuth token — no per-token API billing.
+- **Copilot:** Included in GitHub Copilot subscription.
+
+GitHub Actions cost is ~720 runs/month (hourly × 30 days). Runs with zero
+candidate PRs finish in ~10s. Each PR reviewed costs ~2-5 min of runner time
+depending on how many cascade tiers fire.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # self
-Personal automation: scheduled PR-review agent
+Personal automation: scheduled PR-review agent (Claude or Copilot engine)
+
+See [AGENT.md](AGENT.md) for full documentation.

--- a/prompts/cascade-action.md
+++ b/prompts/cascade-action.md
@@ -34,7 +34,7 @@ read that verdict and post the review to GitHub.
 
 **Risk:** <risk>
 **Reviewed commit:** `<SHA>`
-**Cascade:** triage → <$FINAL_TIER> (see `$ENGINE_LABEL` for models)
+**Cascade:** triage → `$FINAL_TIER` (see `$ENGINE_LABEL` for models)
 
 ### Summary
 <from the verdict's summary>

--- a/prompts/cascade-action.md
+++ b/prompts/cascade-action.md
@@ -1,7 +1,7 @@
 # Cascade action — post review based on tier result
 
 You are the final action step of the cascading PR review. A previous tier
-(Sonnet or Opus) has produced a verdict in `$FINAL_RESULT`. Your job is to
+(deep review or security audit) has produced a verdict in `$FINAL_RESULT`. Your job is to
 read that verdict and post the review to GitHub.
 
 ## Inputs (environment variables)
@@ -9,12 +9,14 @@ read that verdict and post the review to GitHub.
 - `$PR_URL` — the PR to act on.
 - `$PR_HEAD_SHA` — the commit SHA that was reviewed.
 - `$DRY_RUN` — `true` or `false`.
-- `$CLAUDE_ENABLED` — `true` or `false`.
+- `$AI_DELEGATION_ENABLED` — `true` or `false`. **Deprecated alias for `$AI_DELEGATION_ENABLED`.**
+- `$AI_DELEGATION_ENABLED` — `true` or `false`.
 - `$REVIEW_CYCLE` — integer.
 - `$MAX_REVIEW_CYCLES` — integer.
 - `$FINAL_RESULT` — path to the JSON verdict from the resolving tier.
-- `$FINAL_TIER` — `sonnet` or `opus` — which model made the final call.
-- `$TRIAGE_RESULT` — JSON from the Haiku triage (for context).
+- `$FINAL_TIER` — `deep` or `audit` — which tier made the final call.
+- `$ENGINE_LABEL` — human-readable label for the cascade models (for footer).
+- `$TRIAGE_RESULT` — JSON from the triage tier (for context).
 
 ## Steps
 
@@ -33,7 +35,7 @@ read that verdict and post the review to GitHub.
 
 **Risk:** <risk>
 **Reviewed commit:** `<SHA>`
-**Cascade:** triage(haiku) → <sonnet|sonnet → opus>
+**Cascade:** triage → <$FINAL_TIER> (see `$ENGINE_LABEL` for models)
 
 ### Summary
 <from the verdict's summary>
@@ -45,7 +47,7 @@ read that verdict and post the review to GitHub.
 <from the verdict or from PR metadata>
 
 ---
-_Reviewed by the don-petry PR-review cascade (triage: haiku 4.5 → deep: sonnet 4.6 → audit: opus 4.6). Reply with `@don-petry` if you need a human._
+_Reviewed by the don-petry PR-review cascade ($ENGINE_LABEL). Reply with `@don-petry` if you need a human._
 ```
 
 5. **Act** (same logic as synthesize.md):
@@ -58,11 +60,11 @@ _Reviewed by the don-petry PR-review cascade (triage: haiku 4.5 → deep: sonnet
      3. Auto-merge: `gh pr merge "$PR_URL" --auto --squash` (swallow errors)
      4. Remove `needs-human-review` label if present (swallow errors)
    - If `decision` is `escalate`:
-     - If `$CLAUDE_ENABLED` is `true` AND `$REVIEW_CYCLE` < `$MAX_REVIEW_CYCLES`
+     - If `$AI_DELEGATION_ENABLED` is `true` AND `$REVIEW_CYCLE` < `$MAX_REVIEW_CYCLES`
        AND `risk` is NOT `HIGH`:
        Post fix-request issue comment (NOT a review):
        ```
-       ## Review council — fix requested (cycle <REVIEW_CYCLE + 1>/<MAX_REVIEW_CYCLES>)
+       ## Review — fix requested (cycle <REVIEW_CYCLE + 1>/<MAX_REVIEW_CYCLES>)
 
        The automated review identified the following issues. Please address each one:
 
@@ -80,4 +82,4 @@ _Reviewed by the don-petry PR-review cascade (triage: haiku 4.5 → deep: sonnet
        ```
      - Otherwise: add `needs-human-review` label, re-request don-petry.
 6. Print status JSON:
-   `{"pr":"<url>","sha":"<sha>","risk":"<r>","decision":"<d>","tier":"<final_tier>","delegated_to":"claude|human|none","posted":true|false}`
+   `{"pr":"<url>","sha":"<sha>","risk":"<r>","decision":"<d>","tier":"<final_tier>","delegated_to":"ai|human|none","posted":true|false}`

--- a/prompts/cascade-action.md
+++ b/prompts/cascade-action.md
@@ -9,7 +9,6 @@ read that verdict and post the review to GitHub.
 - `$PR_URL` — the PR to act on.
 - `$PR_HEAD_SHA` — the commit SHA that was reviewed.
 - `$DRY_RUN` — `true` or `false`.
-- `$AI_DELEGATION_ENABLED` — `true` or `false`. **Deprecated alias for `$AI_DELEGATION_ENABLED`.**
 - `$AI_DELEGATION_ENABLED` — `true` or `false`.
 - `$REVIEW_CYCLE` — integer.
 - `$MAX_REVIEW_CYCLES` — integer.

--- a/prompts/cascade-action.md
+++ b/prompts/cascade-action.md
@@ -10,6 +10,7 @@ read that verdict and post the review to GitHub.
 - `$PR_HEAD_SHA` — the commit SHA that was reviewed.
 - `$DRY_RUN` — `true` or `false`.
 - `$AI_DELEGATION_ENABLED` — `true` or `false`.
+  - `$CLAUDE_ENABLED` — deprecated alias for `$AI_DELEGATION_ENABLED`.
 - `$REVIEW_CYCLE` — integer.
 - `$MAX_REVIEW_CYCLES` — integer.
 - `$FINAL_RESULT` — path to the JSON verdict from the resolving tier.

--- a/prompts/deep-review.md
+++ b/prompts/deep-review.md
@@ -1,19 +1,19 @@
-# Tier 2: Deep review (Sonnet)
+# Tier 2: Deep review
 
-You are the second tier of a cascading PR review. The fast triage (Haiku)
+You are the second tier of a cascading PR review. The fast triage
 flagged this PR for deeper analysis. Your job is to do a thorough review
 covering security, correctness, AND maintainability — then decide whether
-to approve or escalate further to the security auditor (Opus).
+to approve or escalate further to the security auditor (Tier 3).
 
 ## Inputs (environment variables)
 
 - `$PR_URL` — the PR to review.
 - `$PR_HEAD_SHA` — the head commit SHA.
 - `$DRY_RUN` — `true` or `false`.
-- `$CLAUDE_ENABLED` — `true` or `false`.
+- `$AI_DELEGATION_ENABLED` — `true` or `false`.
 - `$REVIEW_CYCLE` — integer.
 - `$MAX_REVIEW_CYCLES` — integer.
-- `$TRIAGE_RESULT` — JSON output from the Haiku triage, including its
+- `$TRIAGE_RESULT` — JSON output from the triage tier, including its
   `signals` array explaining why it escalated.
 - `$PRIOR_REVIEW_BODY` — prior review body if this is a re-review (empty if first).
 - `$PRIOR_REVIEW_SHA` — prior SHA if re-review.
@@ -38,7 +38,7 @@ enumeration. No actions on other PRs.
 
 Same taxonomy as shared.md:
 
-### HIGH → escalate to Opus (Tier 3)
+### HIGH → escalate to security audit (Tier 3)
 - Auth/secrets/credentials/crypto/tokens/`.env*`
 - DB migrations/schema changes
 - Security anti-patterns (injection, eval, shell=True, hardcoded secrets, etc.)
@@ -54,12 +54,12 @@ Same taxonomy as shared.md:
 
 ## Decision
 
-- If risk is **HIGH** → write your findings to `$OUTPUT_FILE` and let Opus
-  handle the final decision.
+- If risk is **HIGH** → write your findings to `$OUTPUT_FILE` and let the
+  security audit tier handle the final decision.
 - If risk is **LOW or MEDIUM** AND all gates pass (CI green, issue addressed,
   no unresolved threads, well-structured) → approve.
 - If risk is LOW/MEDIUM but a gate fails → escalate (your own findings are
-  sufficient, no need for Opus).
+  sufficient, no need for the security audit tier).
 
 ## Output
 
@@ -67,7 +67,7 @@ Write a JSON object to `$OUTPUT_FILE`:
 
 ```json
 {
-  "tier": "sonnet",
+  "tier": "deep",
   "escalate_to_opus": true|false,
   "risk": "LOW|MEDIUM|HIGH",
   "decision": "approve|escalate",

--- a/prompts/deep-review.md
+++ b/prompts/deep-review.md
@@ -13,6 +13,7 @@ to approve or escalate further to the security auditor (Tier 3).
 - `$AI_DELEGATION_ENABLED` — `true` or `false`.
 - `$REVIEW_CYCLE` — integer.
 - `$MAX_REVIEW_CYCLES` — integer.
+- `$OUTPUT_FILE` — path where the JSON review result must be written.
 - `$TRIAGE_RESULT` — JSON output from the triage tier, including its
   `signals` array explaining why it escalated.
 - `$PRIOR_REVIEW_BODY` — prior review body if this is a re-review (empty if first).

--- a/prompts/security-audit.md
+++ b/prompts/security-audit.md
@@ -13,6 +13,7 @@ reviewer, called only for PRs with real concerns.
 - `$AI_DELEGATION_ENABLED` — `true` or `false`.
 - `$REVIEW_CYCLE` — integer.
 - `$MAX_REVIEW_CYCLES` — integer.
+- `$OUTPUT_FILE` — path to write the final audit verdict JSON.
 - `$TRIAGE_RESULT` — JSON from the triage tier.
 - `$DEEP_RESULT` — path to the deep review JSON file.
 - `$PRIOR_REVIEW_BODY` — prior review body if re-review.

--- a/prompts/security-audit.md
+++ b/prompts/security-audit.md
@@ -1,7 +1,7 @@
-# Tier 3: Security audit (Opus)
+# Tier 3: Security audit
 
 You are the final tier of a cascading PR review — the security auditor.
-Both the fast triage (Haiku) and the deep reviewer (Sonnet) flagged this PR
+Both the fast triage and the deep reviewer flagged this PR
 as needing expert security analysis. You are the most thorough and expensive
 reviewer, called only for PRs with real concerns.
 
@@ -10,11 +10,11 @@ reviewer, called only for PRs with real concerns.
 - `$PR_URL` — the PR to review.
 - `$PR_HEAD_SHA` — the head commit SHA.
 - `$DRY_RUN` — `true` or `false`.
-- `$CLAUDE_ENABLED` — `true` or `false`.
+- `$AI_DELEGATION_ENABLED` — `true` or `false`.
 - `$REVIEW_CYCLE` — integer.
 - `$MAX_REVIEW_CYCLES` — integer.
-- `$TRIAGE_RESULT` — JSON from the Haiku triage.
-- `$SONNET_RESULT` — path to the Sonnet deep review JSON file.
+- `$TRIAGE_RESULT` — JSON from the triage tier.
+- `$DEEP_RESULT` — path to the deep review JSON file.
 - `$PRIOR_REVIEW_BODY` — prior review body if re-review.
 - `$PRIOR_REVIEW_SHA` — prior SHA if re-review.
 
@@ -26,10 +26,10 @@ reviewer, called only for PRs with real concerns.
 
 ## Steps
 
-1. Read `$TRIAGE_RESULT` (Haiku's signals) and the Sonnet verdict at
-   `$SONNET_RESULT` (its findings, risk, and reasoning).
+1. Read `$TRIAGE_RESULT` (triage signals) and the deep review verdict at
+   `$DEEP_RESULT` (its findings, risk, and reasoning).
 2. `gh pr view "$PR_URL" --json number,title,body,author,isDraft,baseRefName,headRefName,headRefOid,url,headRepository,headRepositoryOwner,labels,reviewDecision,mergeable,mergeStateStatus,statusCheckRollup,reviewRequests,reviews,comments,commits,closingIssuesReferences,additions,deletions,changedFiles,files`
-3. `gh pr diff "$PR_URL"` — read the diff. Focus on the areas Sonnet flagged.
+3. `gh pr diff "$PR_URL"` — read the diff. Focus on the areas the deep review flagged.
 4. Fetch linked issues if any.
 5. Read any CONTRIBUTING.md, AGENTS.md, CODEOWNERS in the repo to check
    standards compliance (fetch via `gh api`).
@@ -43,7 +43,7 @@ You are the **paranoid** reviewer. Your focus areas, in order:
 4. Supply chain (dependency typosquats, unpinned actions, lockfile drift)
 5. GitHub Actions security (pull_request_target, secret exposure, expression injection)
 6. Data exposure (PII in logs, missing access controls, CORS wildcards)
-7. The specific signals Haiku and Sonnet raised
+7. The specific signals the triage and deep review raised
 
 When uncertain between risk levels, round UP. You are the last line of defense.
 
@@ -59,7 +59,7 @@ Write a JSON object to `$OUTPUT_FILE`:
 
 ```json
 {
-  "tier": "opus",
+  "tier": "audit",
   "risk": "LOW|MEDIUM|HIGH",
   "decision": "approve|escalate",
   "reason_codes": ["..."],
@@ -73,7 +73,7 @@ Write a JSON object to `$OUTPUT_FILE`:
       "line": "number or null"
     }
   ],
-  "sonnet_findings_confirmed": ["<indices of sonnet findings you agree with>"],
+  "sonnet_findings_confirmed": ["<indices of deep review findings you agree with>"],
   "sonnet_findings_dismissed": ["<indices you disagree with, with reason>"]
 }
 ```

--- a/prompts/single-review.md
+++ b/prompts/single-review.md
@@ -2,25 +2,25 @@
 
 You are a combined PR-review agent acting on behalf of GitHub user `don-petry`.
 You run inside a GitHub Action with `gh` CLI authenticated. You perform the work
-of the full review council (security + correctness + maintainability) and
+of the full cascade review (security + correctness + maintainability) and
 synthesizer in a single pass.
 
-This mode is used when the full 3-member council is overkill — either the PR
-is small or this is a re-review after a prior council review.
+This mode is used when the full cascade is overkill — either the PR
+is small or this is a re-review after a prior cascade review.
 
 ## Inputs (environment variables)
 
 - `$PR_URL` — the PR to review.
 - `$PR_HEAD_SHA` — the head commit SHA.
 - `$DRY_RUN` — `true` or `false`.
-- `$CLAUDE_ENABLED` — `true` or `false` (repo org has Claude App).
+- `$AI_DELEGATION_ENABLED` — `true` or `false` (repo org has AI delegation configured).
 - `$REVIEW_CYCLE` — integer, number of prior review cycles.
 - `$MAX_REVIEW_CYCLES` — integer, max cycles before human escalation.
 - `$REVIEW_MODE` — `small`, `incremental`, or `triage-approved`.
 - `$PRIOR_REVIEW_BODY` — (incremental mode only) a truncated summary of the
   most recent prior review body (full text available in `$PRIOR_REVIEW_FILE`).
 - `$PRIOR_REVIEW_FILE` — (incremental mode only) path to a file containing
-  the full body of the most recent prior review from the council.
+  the full body of the most recent prior review from the cascade.
 - `$PRIOR_REVIEW_SHA` — (incremental mode only) the SHA that was previously
   reviewed.
 
@@ -49,7 +49,7 @@ You review **exactly one pull request**: `$PR_URL`. Nothing else.
 
 ## Risk classification
 
-Use the same taxonomy as the full council (from shared.md):
+Use the same taxonomy as the full cascade (from shared.md):
 
 ### HIGH (never auto-approve)
 - Auth, secrets, credentials, crypto, tokens, `.env*`
@@ -79,9 +79,9 @@ Otherwise → escalate.
 
 ### Triage-approved mode
 
-When `$REVIEW_MODE` is `triage-approved`, the Haiku triage tier already cleared
+When `$REVIEW_MODE` is `triage-approved`, the triage tier already cleared
 this PR as low-risk. Your job is a brief confirmation review — verify the
-triage assessment is correct, check for anything Haiku may have missed, and
+triage assessment is correct, check for anything it may have missed, and
 approve if everything looks good. Treat this like a `small` review but note
 the mode as `triage-approved` in your output.
 
@@ -122,7 +122,7 @@ Compose a review body with the same template:
 <check summary>
 
 ---
-_Reviewed automatically by the don-petry PR-review agent (single-reviewer mode: opus 4.6). Reply with `@don-petry` if you need a human._
+_Reviewed automatically by the don-petry PR-review agent ($ENGINE_SINGLE_LABEL). Reply with `@don-petry` if you need a human._
 ```
 
 Then act:
@@ -136,12 +136,12 @@ Then act:
   3. Enable auto-merge: `gh pr merge "$PR_URL" --auto --squash` (swallow errors)
   4. Remove `needs-human-review` label if present (swallow errors)
 - If escalating:
-  - If `$CLAUDE_ENABLED` is `true` AND `$REVIEW_CYCLE` < `$MAX_REVIEW_CYCLES`
+  - If `$AI_DELEGATION_ENABLED` is `true` AND `$REVIEW_CYCLE` < `$MAX_REVIEW_CYCLES`
     AND risk is NOT `HIGH`:
     Post a fix-request issue comment (see cascade-action.md step 5 escalation template).
   - Otherwise: add `needs-human-review` label, re-request don-petry as reviewer.
 
 After acting, print:
 ```json
-{"pr":"<url>","sha":"<sha>","risk":"<r>","decision":"<d>","mode":"<small|incremental>","delegated_to":"claude|human|none","posted":true|false}
+{"pr":"<url>","sha":"<sha>","risk":"<r>","decision":"<d>","mode":"<small|incremental>","delegated_to":"ai|human|none","posted":true|false}
 ```

--- a/prompts/single-review.md
+++ b/prompts/single-review.md
@@ -143,5 +143,5 @@ Then act:
 
 After acting, print:
 ```json
-{"pr":"<url>","sha":"<sha>","risk":"<r>","decision":"<d>","mode":"<small|incremental>","delegated_to":"ai|human|none","posted":true|false}
+{"pr":"<url>","sha":"<sha>","risk":"<r>","decision":"<d>","mode":"<small|incremental|triage-approved>","delegated_to":"ai|human|none","posted":true|false}
 ```

--- a/prompts/synthesize.md
+++ b/prompts/synthesize.md
@@ -18,13 +18,13 @@ and (if `$DRY_RUN` is `false`) post a PR review.
 - `$DRY_RUN` — `true` or `false`. If `true`, do not call any `gh pr review`,
   `gh pr edit`, `gh pr merge`, or `gh api -X POST` commands. Print what you
   WOULD do.
-- `$CLAUDE_ENABLED` — `true` or `false`. Whether the PR's repo org has the
-  Claude GitHub App installed.
+- `$AI_DELEGATION_ENABLED` — `true` or `false`. Whether the PR's repo org has the
+  AI delegation installed.
 - `$REVIEW_CYCLE` — integer. How many previous review cycles exist on this PR
   (count of our markers in existing comments). Used to prevent infinite
   delegation loops.
 - `$MAX_REVIEW_CYCLES` — integer (default 3). If `$REVIEW_CYCLE >= $MAX_REVIEW_CYCLES`,
-  do NOT delegate to @claude — escalate to human instead.
+  do NOT delegate to AI — escalate to human instead.
 
 ## Steps
 
@@ -73,7 +73,7 @@ and (if `$DRY_RUN` is `false`) post a PR review.
       `gh pr edit "$PR_URL" --remove-label needs-human-review` (swallow errors).
 9. **Delegation** (only when escalating, `$DRY_RUN` is `false`):
    Decide whether to delegate to Claude or to a human:
-   - If `$CLAUDE_ENABLED` is `true` AND `$REVIEW_CYCLE` < `$MAX_REVIEW_CYCLES`
+   - If `$AI_DELEGATION_ENABLED` is `true` AND `$REVIEW_CYCLE` < `$MAX_REVIEW_CYCLES`
      AND `final_risk` is NOT `HIGH`:
      → **Delegate to Claude** (step 9a).
    - Otherwise:
@@ -125,7 +125,7 @@ and (if `$DRY_RUN` is `false`) post a PR review.
        then re-request don-petry as a reviewer
        (`gh api -X POST "repos/<owner>/<repo>/pulls/<num>/requested_reviewers" -f reviewers[]=don-petry`,
        swallowing errors).
-       If `$CLAUDE_ENABLED` is `true` but `$REVIEW_CYCLE` >= `$MAX_REVIEW_CYCLES`,
+       If `$AI_DELEGATION_ENABLED` is `true` but `$REVIEW_CYCLE` >= `$MAX_REVIEW_CYCLES`,
        add a note in the escalation: "Claude delegation exhausted after
        $REVIEW_CYCLE cycles — human review required."
 10. After all actions, print a single-line JSON status to stdout:
@@ -155,7 +155,7 @@ and (if `$DRY_RUN` is `false`) post a PR review.
 <from any lens — failing/pending/green count>
 
 ---
-_Reviewed automatically by the don-petry PR-review council (security: opus 4.6 · correctness: sonnet 4.6 · maintainability: sonnet 4.6 · synthesis: sonnet 4.6). The marker on line 1 lets the agent detect new commits and re-review. Reply with `@don-petry` if you need a human._
+_Reviewed automatically by the don-petry PR-review agent ($ENGINE_LABEL). The marker on line 1 lets the agent detect new commits and re-review. Reply with `@don-petry` if you need a human._
 ```
 
 ## Important notes

--- a/prompts/synthesize.md
+++ b/prompts/synthesize.md
@@ -126,7 +126,7 @@ and (if `$DRY_RUN` is `false`) post a PR review.
        (`gh api -X POST "repos/<owner>/<repo>/pulls/<num>/requested_reviewers" -f reviewers[]=don-petry`,
        swallowing errors).
        If `$AI_DELEGATION_ENABLED` is `true` but `$REVIEW_CYCLE` >= `$MAX_REVIEW_CYCLES`,
-       add a note in the escalation: "Claude delegation exhausted after
+       add a note in the escalation: "AI delegation exhausted after
        $REVIEW_CYCLE cycles — human review required."
 10. After all actions, print a single-line JSON status to stdout:
     `{"pr":"<url>","sha":"<sha>","risk":"<r>","decision":"<d>","delegated_to":"claude|human|none","posted":true|false}`

--- a/prompts/triage.md
+++ b/prompts/triage.md
@@ -1,4 +1,4 @@
-# Tier 1: Triage (Haiku)
+# Tier 1: Triage
 
 You are a fast PR triage agent. Your ONLY job is to read the pre-fetched PR
 context below and decide: does this PR need a deeper review, or is it safe

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Engine abstraction layer for LLM invocations.
+# Supports: claude, copilot
+#
+# Sourced by review-one-pr.sh — provides:
+#   run_triage <prompt_file>       — no-tool tier (stdout capture)
+#   run_agentic <prompt_file> <model>  — full-tool tier (stdout)
+#   ENGINE_* env vars for model names and labels
+
+REVIEW_ENGINE="${REVIEW_ENGINE:-claude}"
+export REVIEW_ENGINE
+
+case "$REVIEW_ENGINE" in
+  claude)
+    ENGINE_TRIAGE_MODEL="claude-haiku-4-5-20251001"
+    ENGINE_DEEP_MODEL="claude-sonnet-4-6"
+    ENGINE_AUDIT_MODEL="claude-opus-4-6"
+    ENGINE_ACTION_MODEL="claude-sonnet-4-6"
+    ENGINE_SINGLE_MODEL="claude-opus-4-6"
+    ENGINE_LABEL="triage: haiku 4.5 → deep: sonnet 4.6 → audit: opus 4.6"
+    ENGINE_SINGLE_LABEL="single-reviewer mode: opus 4.6"
+    ;;
+  copilot)
+    ENGINE_TRIAGE_MODEL="gpt-5-mini"
+    ENGINE_DEEP_MODEL="gpt-5.2"
+    ENGINE_AUDIT_MODEL="gpt-5.4"
+    ENGINE_ACTION_MODEL="gpt-5.2"
+    ENGINE_SINGLE_MODEL="gpt-5.4"
+    ENGINE_LABEL="triage: gpt-5-mini → deep: gpt-5.2 → audit: gpt-5.4"
+    ENGINE_SINGLE_LABEL="single-reviewer mode: gpt-5.4"
+    ;;
+  *)
+    echo "::error::Unknown REVIEW_ENGINE='$REVIEW_ENGINE' (expected: claude or copilot)"
+    exit 1
+    ;;
+esac
+
+export ENGINE_TRIAGE_MODEL ENGINE_DEEP_MODEL ENGINE_AUDIT_MODEL
+export ENGINE_ACTION_MODEL ENGINE_SINGLE_MODEL
+export ENGINE_LABEL ENGINE_SINGLE_LABEL
+
+echo "    engine: $REVIEW_ENGINE ($ENGINE_LABEL)"
+
+# run_triage <prompt_file>
+# No-tool mode: reads pre-fetched context from env vars only.
+# Captures stdout (the model's JSON response).
+run_triage() {
+  local prompt_file="$1"
+  case "$REVIEW_ENGINE" in
+    claude)
+      claude --print \
+        --model "$ENGINE_TRIAGE_MODEL" \
+        --permission-mode plan \
+        < "$prompt_file"
+      ;;
+    copilot)
+      copilot \
+        -p "$(cat "$prompt_file")" \
+        --model "$ENGINE_TRIAGE_MODEL" \
+        -s --no-ask-user
+      ;;
+  esac
+}
+
+# run_agentic <prompt_file> <model>
+# Full tool access (Bash, Read, Grep, Glob). Output to stdout.
+run_agentic() {
+  local prompt_file="$1"
+  local model="$2"
+  case "$REVIEW_ENGINE" in
+    claude)
+      claude --print \
+        --model "$model" \
+        --permission-mode acceptEdits \
+        --allowed-tools "Bash,Read,Grep,Glob" \
+        < "$prompt_file"
+      ;;
+    copilot)
+      copilot \
+        -p "$(cat "$prompt_file")" \
+        --model "$model" \
+        -s --allow-all --no-ask-user
+      ;;
+  esac
+}

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -21,13 +21,13 @@ case "$REVIEW_ENGINE" in
     ENGINE_SINGLE_LABEL="single-reviewer mode: opus 4.6"
     ;;
   copilot)
-    ENGINE_TRIAGE_MODEL="gpt-4o-mini"
-    ENGINE_DEEP_MODEL="o1"
-    ENGINE_AUDIT_MODEL="o1-pro"
-    ENGINE_ACTION_MODEL="o1"
-    ENGINE_SINGLE_MODEL="o1-pro"
-    ENGINE_LABEL="triage: gpt-4o-mini → deep: o1 → audit: o1-pro"
-    ENGINE_SINGLE_LABEL="single-reviewer mode: o1-pro"
+    ENGINE_TRIAGE_MODEL="gpt-5-mini"
+    ENGINE_DEEP_MODEL="gpt-5.2"
+    ENGINE_AUDIT_MODEL="gpt-5.4"
+    ENGINE_ACTION_MODEL="gpt-5.2"
+    ENGINE_SINGLE_MODEL="gpt-5.4"
+    ENGINE_LABEL="triage: gpt-5-mini → deep: gpt-5.2 → audit: gpt-5.4"
+    ENGINE_SINGLE_LABEL="single-reviewer mode: gpt-5.4"
     ;;
   *)
     echo "::error::Unknown REVIEW_ENGINE='$REVIEW_ENGINE' (expected: claude or copilot)"

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -21,13 +21,13 @@ case "$REVIEW_ENGINE" in
     ENGINE_SINGLE_LABEL="single-reviewer mode: opus 4.6"
     ;;
   copilot)
-    ENGINE_TRIAGE_MODEL="gpt-5-mini"
-    ENGINE_DEEP_MODEL="gpt-5.2"
-    ENGINE_AUDIT_MODEL="gpt-5.4"
-    ENGINE_ACTION_MODEL="gpt-5.2"
-    ENGINE_SINGLE_MODEL="gpt-5.4"
-    ENGINE_LABEL="triage: gpt-5-mini → deep: gpt-5.2 → audit: gpt-5.4"
-    ENGINE_SINGLE_LABEL="single-reviewer mode: gpt-5.4"
+    ENGINE_TRIAGE_MODEL="gpt-4o-mini"
+    ENGINE_DEEP_MODEL="o1"
+    ENGINE_AUDIT_MODEL="o1-pro"
+    ENGINE_ACTION_MODEL="o1"
+    ENGINE_SINGLE_MODEL="o1-pro"
+    ENGINE_LABEL="triage: gpt-4o-mini → deep: o1 → audit: o1-pro"
+    ENGINE_SINGLE_LABEL="single-reviewer mode: o1-pro"
     ;;
   *)
     echo "::error::Unknown REVIEW_ENGINE='$REVIEW_ENGINE' (expected: claude or copilot)"

--- a/scripts/review-one-pr.sh
+++ b/scripts/review-one-pr.sh
@@ -175,7 +175,7 @@ fi
 DEEP_ESCALATE=$(jq -r '.escalate_to_opus' "$OUTPUT_FILE")
 DEEP_DECISION=$(jq -r '.decision' "$OUTPUT_FILE")
 DEEP_RISK=$(jq -r '.risk' "$OUTPUT_FILE")
-echo "    [tier2] escalate_to_audit=$DEEP_ESCALATE decision=$DEEP_DECISION risk=$DEEP_RISK"
+echo "    [tier2] escalate_to_opus=$DEEP_ESCALATE decision=$DEEP_DECISION risk=$DEEP_RISK"
 
 # If deep review resolves without needing security audit → go straight to action
 if [ "$DEEP_ESCALATE" != "true" ]; then

--- a/scripts/review-one-pr.sh
+++ b/scripts/review-one-pr.sh
@@ -1,23 +1,29 @@
 #!/usr/bin/env bash
-# Run the council + synthesizer against ONE PR.
+# Run the cascading PR review against ONE PR.
 #
 # Inputs:
 #   $1 — PR URL
 #
 # Env:
-#   GH_TOKEN — set by the workflow
-#   CLAUDE_CODE_OAUTH_TOKEN — set by the workflow
-#   DRY_RUN — "true" or "false"
+#   GH_TOKEN              — set by the workflow
+#   REVIEW_ENGINE         — "claude" or "copilot" (default: claude)
+#   CLAUDE_CODE_OAUTH_TOKEN — (claude engine) set by the workflow
+#   COPILOT_GITHUB_TOKEN    — (copilot engine) set by the workflow
+#   DRY_RUN               — "true" or "false"
 #
 # Behavior:
 #   1. Resolve current head SHA of the PR.
 #   2. Idempotency check: scan existing reviews/comments for our marker
 #      `<!-- pr-review-agent v1 sha=<SHA> -->`. If a marker for the current
 #      head SHA exists, skip without spending tokens.
-#   3. Otherwise: run 3 council members in parallel, each writing JSON to
-#      /tmp/council/<lens>.json. Then run the synthesizer.
+#   3. Run cascading review: triage → deep review → security audit.
 
 set -euo pipefail
+
+# Source the engine abstraction (sets ENGINE_* vars, defines run_triage/run_agentic).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=engine.sh
+source "$SCRIPT_DIR/engine.sh"
 
 PR_URL="${1:?usage: review-one-pr.sh <pr-url>}"
 export PR_URL
@@ -52,7 +58,7 @@ if [ -n "${EXISTING_MARKER_SHA:-}" ]; then
 fi
 
 # Count how many review cycles we've already done on this PR (number of distinct markers).
-# This prevents infinite @claude delegation loops.
+# This prevents infinite AI delegation loops.
 REVIEW_CYCLE=$(
   gh pr view "$PR_URL" --json reviews,comments \
     --jq '((.reviews // []) + (.comments // [])) | .[].body | select(. != null)' 2>/dev/null \
@@ -61,21 +67,23 @@ REVIEW_CYCLE=$(
 export REVIEW_CYCLE
 echo "    review cycle: $REVIEW_CYCLE (max: ${MAX_REVIEW_CYCLES:-3})"
 
-# Detect if the PR's repo org has Claude App (for @claude delegation).
+# Detect if the PR's repo org supports AI delegation for automated fix requests.
+# Reads DELEGATION_ORGS (falls back to CLAUDE_ORGS for backward compat).
 PR_ORG=$(echo "$PR_URL" | sed -E 's|https://github.com/([^/]+)/.*|\1|')
 export PR_ORG
-CLAUDE_ENABLED=false
-if [ -n "${CLAUDE_ORGS:-}" ]; then
-  IFS=',' read -ra ORG_LIST <<< "$CLAUDE_ORGS"
+AI_DELEGATION_ENABLED=false
+DELEGATION_ORGS="${DELEGATION_ORGS:-${CLAUDE_ORGS:-}}"
+if [ -n "${DELEGATION_ORGS:-}" ]; then
+  IFS=',' read -ra ORG_LIST <<< "$DELEGATION_ORGS"
   for org in "${ORG_LIST[@]}"; do
     if [ "$(echo "$org" | tr -d ' ')" = "$PR_ORG" ]; then
-      CLAUDE_ENABLED=true
+      AI_DELEGATION_ENABLED=true
       break
     fi
   done
 fi
-export CLAUDE_ENABLED
-echo "    claude delegation: $CLAUDE_ENABLED (org: $PR_ORG)"
+export AI_DELEGATION_ENABLED
+echo "    AI delegation: $AI_DELEGATION_ENABLED (org: $PR_ORG)"
 
 # For re-reviews, extract the prior review body for context.
 # Write to a temp file to avoid hitting OS env size limits (E2BIG) on large reviews.
@@ -106,16 +114,16 @@ export PRIOR_REVIEW_SHA PRIOR_REVIEW_FILE
 export PRIOR_REVIEW_BODY="${PRIOR_REVIEW_BODY:0:4000}"
 
 # ==========================================================================
-# 3. Cascading review: Haiku triage → Sonnet deep review → Opus security audit
+# 3. Cascading review: triage → deep review → security audit
 #    Each tier only fires if the previous one escalated.
 # ==========================================================================
 
 mkdir -p /tmp/cascade
 
-# --- Tier 1: Haiku triage (no tools, pre-fetched context) ---
-echo "    [tier1] haiku triage"
+# --- Tier 1: Triage (fast, no tools, pre-fetched context) ---
+echo "    [tier1] triage ($ENGINE_TRIAGE_MODEL)"
 
-# Pre-fetch all context so Haiku needs no tool access.
+# Pre-fetch all context so the triage tier needs no tool access.
 PR_METADATA=$(gh pr view "$PR_URL" --json number,title,body,author,isDraft,baseRefName,headRefName,headRefOid,url,headRepository,headRepositoryOwner,labels,reviewDecision,mergeable,mergeStateStatus,statusCheckRollup,reviewRequests,reviews,comments,commits,closingIssuesReferences,additions,deletions,changedFiles,files 2>/dev/null || echo '{}')
 export PR_METADATA
 
@@ -126,17 +134,13 @@ export REVIEW_MODE="triage"
 
 TRIAGE_LOG="/tmp/cascade/triage.log"
 TRIAGE_RESULT=$(
-  claude \
-    --print \
-    --model claude-haiku-4-5-20251001 \
-    --permission-mode plan \
-    < prompts/triage.md 2>"$TRIAGE_LOG"
+  run_triage prompts/triage.md 2>"$TRIAGE_LOG"
 ) || true
 
 # Validate triage output is JSON
 if ! echo "$TRIAGE_RESULT" | jq empty 2>/dev/null; then
-  echo "    [tier1] haiku returned non-JSON, escalating by default"
-  echo "    haiku output: $TRIAGE_RESULT"
+  echo "    [tier1] triage returned non-JSON, escalating by default"
+  echo "    triage output: $TRIAGE_RESULT"
   TRIAGE_RESULT='{"escalate":true,"risk":"MEDIUM","signals":["triage-output-invalid"],"summary":"triage failed, escalating"}'
 fi
 
@@ -146,94 +150,69 @@ TRIAGE_RISK=$(echo "$TRIAGE_RESULT" | jq -r '.risk')
 TRIAGE_SIGNALS=$(echo "$TRIAGE_RESULT" | jq -r '.signals | join(", ")')
 echo "    [tier1] escalate=$TRIAGE_ESCALATE risk=$TRIAGE_RISK signals=[$TRIAGE_SIGNALS]"
 
-# If triage says no concerns → use single-review prompt (Haiku approved, Opus confirms briefly)
+# If triage says no concerns → use single-review prompt for quick confirmation
 if [ "$TRIAGE_ESCALATE" = "false" ]; then
-  echo "    [approve] haiku cleared — running single Opus confirmation"
+  echo "    [approve] triage cleared — running single confirmation ($ENGINE_SINGLE_MODEL)"
   export REVIEW_MODE="triage-approved"
-  claude \
-    --print \
-    --model claude-opus-4-6 \
-    --permission-mode acceptEdits \
-    --allowed-tools "Bash,Read,Grep,Glob" \
-    < prompts/single-review.md
+  run_agentic prompts/single-review.md "$ENGINE_SINGLE_MODEL"
   echo "    [done]  $PR_URL"
   exit 0
 fi
 
-# --- Tier 2: Sonnet deep review ---
-echo "    [tier2] sonnet deep review"
-OUTPUT_FILE="/tmp/cascade/sonnet.json"
+# --- Tier 2: Deep review ---
+echo "    [tier2] deep review ($ENGINE_DEEP_MODEL)"
+OUTPUT_FILE="/tmp/cascade/deep.json"
 export OUTPUT_FILE
-claude \
-  --print \
-  --model claude-sonnet-4-6 \
-  --permission-mode acceptEdits \
-  --allowed-tools "Bash,Read,Grep,Glob" \
-  < prompts/deep-review.md \
-  > /tmp/cascade/sonnet.log 2>&1 || true
+run_agentic prompts/deep-review.md "$ENGINE_DEEP_MODEL" \
+  > /tmp/cascade/deep.log 2>&1 || true
 if [ ! -s "$OUTPUT_FILE" ] || ! jq empty "$OUTPUT_FILE" 2>/dev/null; then
-  echo "::warning::sonnet did not produce valid JSON at $OUTPUT_FILE"
-  cat /tmp/cascade/sonnet.log || true
+  echo "::warning::deep review did not produce valid JSON at $OUTPUT_FILE"
+  cat /tmp/cascade/deep.log || true
   echo "::error::cascade failed at tier 2 for $PR_URL"
   exit 1
 fi
 
-SONNET_ESCALATE=$(jq -r '.escalate_to_opus' "$OUTPUT_FILE")
-SONNET_DECISION=$(jq -r '.decision' "$OUTPUT_FILE")
-SONNET_RISK=$(jq -r '.risk' "$OUTPUT_FILE")
-echo "    [tier2] escalate_to_opus=$SONNET_ESCALATE decision=$SONNET_DECISION risk=$SONNET_RISK"
+DEEP_ESCALATE=$(jq -r '.escalate_to_opus' "$OUTPUT_FILE")
+DEEP_DECISION=$(jq -r '.decision' "$OUTPUT_FILE")
+DEEP_RISK=$(jq -r '.risk' "$OUTPUT_FILE")
+echo "    [tier2] escalate_to_audit=$DEEP_ESCALATE decision=$DEEP_DECISION risk=$DEEP_RISK"
 
-# If Sonnet approves or escalates without needing Opus → go straight to action
-if [ "$SONNET_ESCALATE" != "true" ]; then
-  echo "    [action] sonnet resolved — posting review"
+# If deep review resolves without needing security audit → go straight to action
+if [ "$DEEP_ESCALATE" != "true" ]; then
+  echo "    [action] deep review resolved — posting review"
   FINAL_RESULT="$OUTPUT_FILE"
   export FINAL_RESULT
-  export FINAL_TIER="sonnet"
-  claude \
-    --print \
-    --model claude-sonnet-4-6 \
-    --permission-mode acceptEdits \
-    --allowed-tools "Bash,Read,Grep,Glob" \
-    < prompts/cascade-action.md
+  export FINAL_TIER="deep"
+  run_agentic prompts/cascade-action.md "$ENGINE_ACTION_MODEL"
   echo "    [done]  $PR_URL"
   exit 0
 fi
 
-# --- Tier 3: Opus security audit ---
-echo "    [tier3] opus security audit"
-SONNET_RESULT="$OUTPUT_FILE"
-export SONNET_RESULT
-OUTPUT_FILE="/tmp/cascade/opus.json"
+# --- Tier 3: Security audit ---
+echo "    [tier3] security audit ($ENGINE_AUDIT_MODEL)"
+DEEP_RESULT="$OUTPUT_FILE"
+export DEEP_RESULT
+OUTPUT_FILE="/tmp/cascade/audit.json"
 export OUTPUT_FILE
-claude \
-  --print \
-  --model claude-opus-4-6 \
-  --permission-mode acceptEdits \
-  --allowed-tools "Bash,Read,Grep,Glob" \
-  < prompts/security-audit.md \
-  > /tmp/cascade/opus.log 2>&1
+run_agentic prompts/security-audit.md "$ENGINE_AUDIT_MODEL" \
+  > /tmp/cascade/audit.log 2>&1
 
 if [ ! -s "$OUTPUT_FILE" ] || ! jq empty "$OUTPUT_FILE" 2>/dev/null; then
-  echo "::warning::opus did not produce valid JSON at $OUTPUT_FILE"
-  cat /tmp/cascade/opus.log || true
+  echo "::warning::security audit did not produce valid JSON at $OUTPUT_FILE"
+  cat /tmp/cascade/audit.log || true
   echo "::error::cascade failed at tier 3 for $PR_URL"
   exit 1
 fi
 
-OPUS_DECISION=$(jq -r '.decision' "$OUTPUT_FILE")
-OPUS_RISK=$(jq -r '.risk' "$OUTPUT_FILE")
-echo "    [tier3] decision=$OPUS_DECISION risk=$OPUS_RISK"
+AUDIT_DECISION=$(jq -r '.decision' "$OUTPUT_FILE")
+AUDIT_RISK=$(jq -r '.risk' "$OUTPUT_FILE")
+echo "    [tier3] decision=$AUDIT_DECISION risk=$AUDIT_RISK"
 
-# Opus makes the final call — post the review
-echo "    [action] opus resolved — posting review"
+# Security audit makes the final call — post the review
+echo "    [action] security audit resolved — posting review"
 FINAL_RESULT="$OUTPUT_FILE"
 export FINAL_RESULT
-export FINAL_TIER="opus"
-claude \
-  --print \
-  --model claude-sonnet-4-6 \
-  --permission-mode acceptEdits \
-  --allowed-tools "Bash,Read,Grep,Glob" \
-  < prompts/cascade-action.md
+export FINAL_TIER="audit"
+run_agentic prompts/cascade-action.md "$ENGINE_ACTION_MODEL"
 
 echo "    [done]  $PR_URL"


### PR DESCRIPTION
## Summary

Add a second LLM engine option (GitHub Copilot) alongside the existing Claude engine, toggled via the `REVIEW_ENGINE` repo variable.

## Key changes

- **`scripts/engine.sh`** — New LLM abstraction layer with `run_triage()` and `run_agentic()` functions that dispatch to `claude` or `copilot` CLI based on `$REVIEW_ENGINE`
- **`scripts/review-one-pr.sh`** — Refactored to source engine.sh; engine-agnostic variable names (`DELEGATION_ORGS`, `AI_DELEGATION_ENABLED`, deep/audit tiers)
- **All prompts** — Engine-agnostic tier names, `$ENGINE_LABEL` footers, removed hardcoded model names
- **Workflow** — Conditional CLI install, `REVIEW_ENGINE`/`COPILOT_GITHUB_TOKEN` vars, `DELEGATION_ORGS` with `CLAUDE_ORGS` backward compat fallback
- **Docs** — Updated AGENT.md and README.md with both engine options

## Model mapping

| Tier | Claude | Copilot |
|---|---|---|
| Triage | Haiku 4.5 | GPT-5-mini |
| Deep review | Sonnet 4.6 | GPT-5.2 |
| Security audit | Opus 4.6 | GPT-5.4 |
| Action/single | Sonnet/Opus | GPT-5.2/5.4 |

## Usage

```bash
# Switch to Copilot engine:
gh variable set REVIEW_ENGINE --body copilot --repo don-petry/self
gh secret set COPILOT_GITHUB_TOKEN --repo don-petry/self

# Switch back to Claude (or leave unset — it's the default):
gh variable set REVIEW_ENGINE --body claude --repo don-petry/self
```

## Backward compatibility

- Existing Claude setups work without changes (`REVIEW_ENGINE` defaults to `claude`)
- `CLAUDE_ORGS` is still respected as a fallback for `DELEGATION_ORGS`
- JSON field names in prompt output schemas (`escalate_to_opus`, `sonnet_findings_*`) kept as-is to avoid breaking the parsing logic