### PR TITLE
feat: cross-engine adversarial rubber duck review

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -56,20 +56,12 @@ jobs:
       - name: Checkout agent repo
         uses: actions/checkout@v5
 
-      - name: Install review engine CLI
+      - name: Install review engine CLIs
         run: |
-          case "$REVIEW_ENGINE" in
-            claude)
-              npm install -g @anthropic-ai/claude-code
-              ;;
-            copilot)
-              gh extension install github/gh-copilot
-              ;;
-            *)
-              echo "::error::Unknown REVIEW_ENGINE=$REVIEW_ENGINE"
-              exit 1
-              ;;
-          esac
+          # Install both engines — the primary runs the cascade, the opposite
+          # engine runs the adversarial "rubber duck" review in parallel.
+          npm install -g @anthropic-ai/claude-code || true
+          gh extension install github/gh-copilot || true
 
       - name: Verify auth
         run: |

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -58,10 +58,21 @@ jobs:
 
       - name: Install review engine CLIs
         run: |
-          # Install both engines — the primary runs the cascade, the opposite
-          # engine runs the adversarial "rubber duck" review in parallel.
-          npm install -g @anthropic-ai/claude-code || true
-          gh extension install github/gh-copilot || true
+          # Primary engine must install successfully; duck engine is best-effort.
+          case "$REVIEW_ENGINE" in
+            claude)
+              npm install -g @anthropic-ai/claude-code
+              gh extension install github/gh-copilot || true
+              ;;
+            copilot)
+              gh extension install github/gh-copilot
+              npm install -g @anthropic-ai/claude-code || true
+              ;;
+            *)
+              echo "::error::Unknown REVIEW_ENGINE=$REVIEW_ENGINE"
+              exit 1
+              ;;
+          esac
 
       - name: Verify auth
         run: |

--- a/AGENT.md
+++ b/AGENT.md
@@ -21,26 +21,48 @@ and **Copilot**.
    Tier 1: Triage (~15s, no tools, pre-fetched context)
      └─ clean? → single confirmation → approve + auto-merge
      └─ concerns? ↓
-   Tier 2: Deep review (~2 min, full agentic)
+   Tier 2: Deep review + Rubber duck (~2 min, parallel, cross-engine)
+     └─ synthesize verdicts from both engines
      └─ clean? → approve + auto-merge
      └─ HIGH risk? ↓
    Tier 3: Security audit (~3 min, full agentic)
      └─ final decision → approve or escalate
    ```
 
+   ### Cross-engine adversarial review (Rubber Duck)
+
+   At tier 2, two reviewers analyze the PR **in parallel** using different
+   model families. The primary engine runs the deep review; the **opposite**
+   engine runs an adversarial "rubber duck" review. A synthesis step merges
+   both verdicts before deciding whether to approve or escalate.
+
+   This approach is inspired by [GitHub Copilot CLI's rubber duck feature](https://github.blog/ai-and-ml/github-copilot/github-copilot-cli-combines-model-families-for-a-second-opinion/),
+   which shows cross-model review closes ~75% of the performance gap between
+   model tiers. Different model families have different blind spots — running
+   both catches issues that either alone would miss.
+
+   The rubber duck is **always the opposite engine**: if `REVIEW_ENGINE=claude`,
+   the duck is Copilot (GPT-5.4), and vice versa. No extra configuration needed.
+
+   **Graceful degradation:** if the rubber duck fails (missing credentials,
+   CLI not installed, timeout), the cascade continues with the primary deep
+   review only. The duck is additive, never blocking.
+
    ### Engine model mapping
 
-   | Tier | Claude engine | Copilot engine |
+   | Tier | Claude primary | Copilot primary |
    |---|---|---|
    | Triage | Haiku 4.5 | GPT-5-mini |
    | Deep review | Sonnet 4.6 | GPT-5.2 |
+   | Rubber duck | GPT-5.4 (cross) | Sonnet 4.6 (cross) |
+   | Synthesis | Sonnet 4.6 | GPT-5.2 |
    | Security audit | Opus 4.6 | GPT-5.4 |
    | Action / single review | Sonnet 4.6 / Opus 4.6 | GPT-5.2 / GPT-5.4 |
 
    **Cost profile:**
    - ~80% of PRs: triage + single confirm (2 calls, ~30s)
-   - ~15% of PRs: + deep review (3 calls, ~2.5 min)
-   - ~5% of PRs: + security audit (4 calls, ~5.5 min)
+   - ~15% of PRs: + deep + duck + synthesis (5 calls, ~3 min)
+   - ~5% of PRs: + security audit (6 calls, ~6 min)
 
 4. **Post-review actions** — after the review is posted, the action tier takes
    additional actions depending on the decision:

--- a/prompts/cascade-action.md
+++ b/prompts/cascade-action.md
@@ -14,8 +14,10 @@ read that verdict and post the review to GitHub.
 - `$REVIEW_CYCLE` — integer.
 - `$MAX_REVIEW_CYCLES` — integer.
 - `$FINAL_RESULT` — path to the JSON verdict from the resolving tier.
-- `$FINAL_TIER` — `deep` or `audit` — which tier made the final call.
+- `$FINAL_TIER` — `deep+duck`, `deep`, or `audit` — which tier made the final call.
 - `$ENGINE_LABEL` — human-readable label for the cascade models (for footer).
+- `$DUCK_ENGINE` — which engine ran the rubber duck (`claude` or `copilot`).
+- `$DUCK_MODEL` — which model ran the rubber duck.
 - `$TRIAGE_RESULT` — JSON from the triage tier (for context).
 
 ## Steps
@@ -40,8 +42,14 @@ read that verdict and post the review to GitHub.
 ### Summary
 <from the verdict's summary>
 
+### Cross-engine agreement
+<If $FINAL_TIER is "deep+duck" and the verdict JSON has an "agreement" field,
+report the agreement level and highlight findings where both engines converged.
+If $FINAL_TIER is "deep" (no duck), omit this section.>
+
 ### Findings
-<from the verdict's findings, grouped by severity>
+<from the verdict's findings, grouped by severity. If findings have a "sources"
+array, note which engine(s) flagged each finding.>
 
 ### CI status
 <from the verdict or from PR metadata>

--- a/prompts/rubber-duck.md
+++ b/prompts/rubber-duck.md
@@ -1,0 +1,109 @@
+# Cross-engine adversarial review (Rubber Duck)
+
+You are a cross-engine adversarial reviewer — the "rubber duck." You run on a
+**different model family** from the primary deep reviewer, providing an
+independent second opinion. Your job is to catch issues the primary reviewer's
+model family is likely to miss: different blind spots, different strengths.
+
+Default to skepticism. Assume the diff has gaps until the evidence says
+otherwise. Prioritize concrete findings over vague concerns.
+
+## Inputs (environment variables)
+
+- `$PR_URL` — the PR to review.
+- `$PR_HEAD_SHA` — the head commit SHA.
+- `$DRY_RUN` — `true` or `false`.
+- `$REVIEW_CYCLE` — integer.
+- `$MAX_REVIEW_CYCLES` — integer.
+- `$TRIAGE_RESULT` — JSON output from the triage tier, including its
+  `signals` array explaining why it escalated.
+- `$PRIOR_REVIEW_BODY` — prior review body if this is a re-review (empty if first).
+- `$PRIOR_REVIEW_SHA` — prior SHA if re-review.
+
+## Scope
+
+You review **exactly one PR**: `$PR_URL`. You have `gh` CLI available.
+
+**FORBIDDEN**: `gh search prs`, `gh pr list`, `gh pr status`, or any
+enumeration. No actions on other PRs.
+
+## Steps
+
+1. Read `$TRIAGE_RESULT` to understand why triage escalated — but don't limit
+   yourself to those signals. Your value comes from finding what others miss.
+2. `gh pr view "$PR_URL" --json number,title,body,author,isDraft,baseRefName,headRefName,headRefOid,url,repository,labels,reviewDecision,mergeable,mergeStateStatus,statusCheckRollup,reviewRequests,reviews,comments,commits,closingIssuesReferences,additions,deletions,changedFiles,files`
+3. `gh pr diff "$PR_URL"` — read the diff thoroughly.
+4. Fetch linked issues if any.
+5. Check `statusCheckRollup` for CI status.
+
+## Adversarial focus areas
+
+Go beyond the standard review checklist. Specifically look for:
+
+- **Subtle logic errors** — off-by-one, race conditions, null/undefined paths
+  that only manifest under specific conditions.
+- **Implicit assumptions** — does the code assume ordering, uniqueness, or
+  availability that isn't guaranteed?
+- **Missing error paths** — what happens when the network is down, the file
+  doesn't exist, the API returns unexpected shapes?
+- **Security blind spots** — TOCTOU, path traversal, prototype pollution,
+  deserialization attacks, timing side channels.
+- **Integration risks** — does this change interact safely with the rest of the
+  system? Are there downstream consumers that will break?
+- **Testing gaps** — are the tests actually testing the right thing? Do they
+  cover the failure modes?
+
+## Risk classification
+
+Same taxonomy as the primary reviewer:
+
+### HIGH → always escalate
+- Auth/secrets/credentials/crypto/tokens/`.env*`
+- DB migrations/schema changes
+- Security anti-patterns (injection, eval, shell=True, hardcoded secrets, etc.)
+- CI security scanner warnings
+- Org/project standards violations
+- GitHub Actions security smells
+
+### MEDIUM → approve if all gates pass
+- Non-trivial logic changes, new deps, cross-module refactors
+
+### LOW → approve if all gates pass
+- Docs, comments, typos, tests-only, lockfile updates
+
+## Decision gates
+
+Approve only if ALL:
+1. Risk is LOW or MEDIUM (never HIGH)
+2. All required CI checks are green
+3. Linked issue substantively addressed
+4. No unresolved review threads
+5. Well-structured PR
+
+Otherwise → escalate.
+
+## Output
+
+Write a JSON object to `$OUTPUT_FILE`:
+
+```json
+{
+  "tier": "rubber-duck",
+  "model": "<the model you are running as>",
+  "risk": "LOW|MEDIUM|HIGH",
+  "decision": "approve|escalate",
+  "reason_codes": ["..."],
+  "summary": "2-3 sentences — focus on what you found that the primary might miss",
+  "findings": [
+    {
+      "severity": "info|minor|major|critical",
+      "category": "...",
+      "message": "...",
+      "file": "path or null",
+      "line": "number or null"
+    }
+  ]
+}
+```
+
+Write with `cat > "$OUTPUT_FILE" <<'JSON' ... JSON`. Ensure it parses with `jq`.

--- a/prompts/rubber-duck.md
+++ b/prompts/rubber-duck.md
@@ -19,6 +19,7 @@ otherwise. Prioritize concrete findings over vague concerns.
   `signals` array explaining why it escalated.
 - `$PRIOR_REVIEW_BODY` — prior review body if this is a re-review (empty if first).
 - `$PRIOR_REVIEW_SHA` — prior SHA if re-review.
+- `$OUTPUT_FILE` — absolute path where you MUST write your JSON verdict.
 
 ## Scope
 

--- a/prompts/synthesize-duck.md
+++ b/prompts/synthesize-duck.md
@@ -1,0 +1,97 @@
+# Synthesize deep review + rubber duck verdicts
+
+Two reviewers analyzed the same PR in parallel using **different model
+families** — one as the primary deep reviewer, the other as the adversarial
+"rubber duck." Your job: read both verdicts, reconcile them, and produce
+a single combined verdict.
+
+## Inputs (environment variables)
+
+- `$PR_URL` — the PR under review.
+- `$PR_HEAD_SHA` — the head commit SHA.
+- `$DRY_RUN` — `true` or `false`.
+- `$REVIEW_CYCLE` — integer.
+- `$MAX_REVIEW_CYCLES` — integer.
+- `$TRIAGE_RESULT` — JSON from the triage tier.
+- `$DEEP_RESULT` — path to the primary deep review JSON.
+- `$DUCK_RESULT` — path to the rubber duck review JSON.
+- `$OUTPUT_FILE` — path where you MUST write your combined verdict.
+- `$DUCK_ENGINE` — which engine ran the rubber duck (`claude` or `copilot`).
+- `$DUCK_MODEL` — which model ran the rubber duck.
+
+## Steps
+
+1. Read both JSON files:
+   ```
+   jq . "$DEEP_RESULT"
+   jq . "$DUCK_RESULT"
+   ```
+2. Compare the two verdicts across all dimensions.
+3. Synthesize a combined verdict following the rules below.
+4. Write the combined JSON to `$OUTPUT_FILE`.
+
+## Synthesis rules
+
+### Risk
+- `final_risk` = the **higher** of the two. If either says HIGH, the combined
+  risk is HIGH. HIGH > MEDIUM > LOW.
+
+### Decision
+- If **either** reviewer says `escalate` → combined decision is `escalate`.
+- Both must say `approve` for the combined decision to be `approve`.
+
+### Escalation
+- `escalate_to_opus` = `true` if combined risk is HIGH, OR if either reviewer
+  flagged a finding with severity `critical`.
+
+### Findings
+- **Union** all findings from both reviewers.
+- **Deduplicate**: if both flagged the same file+line+category, keep one entry
+  and add a `"sources": ["deep", "rubber-duck"]` field noting both agreed.
+  Cross-engine agreement on a finding is a strong signal — bump its severity
+  up one level if it was `info` or `minor`.
+- For findings from only one reviewer, add `"sources": ["deep"]` or
+  `"sources": ["rubber-duck"]`.
+- Preserve the original severity unless cross-engine agreement triggers a bump.
+
+### Summary
+Write a 2-4 sentence combined summary that:
+- Notes the overall risk assessment and whether the reviewers agreed or disagreed.
+- Highlights any findings where both engines converged (strongest signal).
+- Calls out findings unique to the rubber duck (cross-model diversity value).
+
+## Output
+
+Write a JSON object to `$OUTPUT_FILE`:
+
+```json
+{
+  "tier": "combined",
+  "primary_engine": "<REVIEW_ENGINE>",
+  "duck_engine": "<DUCK_ENGINE>",
+  "risk": "LOW|MEDIUM|HIGH",
+  "decision": "approve|escalate",
+  "escalate_to_opus": true|false,
+  "reason_codes": ["..."],
+  "agreement": "full|partial|divergent",
+  "summary": "2-4 sentences",
+  "findings": [
+    {
+      "severity": "info|minor|major|critical",
+      "category": "...",
+      "message": "...",
+      "file": "path or null",
+      "line": "number or null",
+      "sources": ["deep", "rubber-duck"]
+    }
+  ]
+}
+```
+
+`agreement` values:
+- `full` — same risk AND same decision
+- `partial` — same decision but different risk, OR same risk but different decision
+- `divergent` — different risk AND different decision
+
+Write with `cat > "$OUTPUT_FILE" <<'JSON' ... JSON`. Ensure it parses with `jq`.
+After writing, exit. Do not do anything else.

--- a/prompts/synthesize-duck.md
+++ b/prompts/synthesize-duck.md
@@ -33,7 +33,7 @@ a single combined verdict.
 ## Synthesis rules
 
 ### Risk
-- `final_risk` = the **higher** of the two. If either says HIGH, the combined
+- `risk` = the **higher** of the two. If either says HIGH, the combined
   risk is HIGH. HIGH > MEDIUM > LOW.
 
 ### Decision
@@ -48,11 +48,12 @@ a single combined verdict.
 - **Union** all findings from both reviewers.
 - **Deduplicate**: if both flagged the same file+line+category, keep one entry
   and add a `"sources": ["deep", "rubber-duck"]` field noting both agreed.
-  Cross-engine agreement on a finding is a strong signal — bump its severity
-  up one level if it was `info` or `minor`.
+  Cross-engine agreement on a finding is a strong signal — apply this exact
+  severity mapping to the deduplicated finding: `info` → `minor`, `minor` →
+  `major`, and leave `major` / `critical` unchanged.
 - For findings from only one reviewer, add `"sources": ["deep"]` or
   `"sources": ["rubber-duck"]`.
-- Preserve the original severity unless cross-engine agreement triggers a bump.
+- Otherwise preserve the original severity.
 
 ### Summary
 Write a 2-4 sentence combined summary that:

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -96,12 +96,14 @@ run_agentic() {
 # run_duck <prompt_file> <model>
 # Cross-engine adversarial "rubber duck" review.
 # Always uses the OPPOSITE engine from REVIEW_ENGINE. Output to stdout.
+# Strips the opposing engine's credentials to prevent cross-engine leakage.
 run_duck() {
   local prompt_file="$1"
   local model="$2"
   case "$DUCK_ENGINE" in
     claude)
-      claude --print \
+      unset COPILOT_GITHUB_TOKEN 2>/dev/null || true
+      timeout 300 claude --print \
         --model "$model" \
         --permission-mode acceptEdits \
         --allowed-tools "Bash,Read,Grep,Glob" \
@@ -109,10 +111,15 @@ run_duck() {
         < "$prompt_file"
       ;;
     copilot)
-      copilot \
+      unset CLAUDE_CODE_OAUTH_TOKEN 2>/dev/null || true
+      timeout 300 copilot \
         -p "$(cat "$prompt_file")" \
         --model "$model" \
         -s --allow-all --no-ask-user
+      ;;
+    *)
+      echo "::error::Unknown DUCK_ENGINE='$DUCK_ENGINE'" >&2
+      return 1
       ;;
   esac
 }

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -5,7 +5,9 @@
 # Sourced by review-one-pr.sh — provides:
 #   run_triage <prompt_file>       — no-tool tier (stdout capture)
 #   run_agentic <prompt_file> <model>  — full-tool tier (stdout)
+#   run_duck <prompt_file> <model>     — cross-engine adversarial (stdout)
 #   ENGINE_* env vars for model names and labels
+#   DUCK_ENGINE / DUCK_MODEL for rubber-duck cross-engine review
 
 REVIEW_ENGINE="${REVIEW_ENGINE:-claude}"
 export REVIEW_ENGINE
@@ -17,8 +19,11 @@ case "$REVIEW_ENGINE" in
     ENGINE_AUDIT_MODEL="claude-opus-4-6"
     ENGINE_ACTION_MODEL="claude-sonnet-4-6"
     ENGINE_SINGLE_MODEL="claude-opus-4-6"
-    ENGINE_LABEL="triage: haiku 4.5 → deep: sonnet 4.6 → audit: opus 4.6"
+    ENGINE_LABEL="triage: haiku 4.5 → deep: sonnet 4.6 + duck: gpt-5.4 → audit: opus 4.6"
     ENGINE_SINGLE_LABEL="single-reviewer mode: opus 4.6"
+    # Cross-engine rubber duck: always the opposite engine
+    DUCK_ENGINE="copilot"
+    DUCK_MODEL="gpt-5.4"
     ;;
   copilot)
     ENGINE_TRIAGE_MODEL="gpt-5-mini"
@@ -26,8 +31,11 @@ case "$REVIEW_ENGINE" in
     ENGINE_AUDIT_MODEL="gpt-5.4"
     ENGINE_ACTION_MODEL="gpt-5.2"
     ENGINE_SINGLE_MODEL="gpt-5.4"
-    ENGINE_LABEL="triage: gpt-5-mini → deep: gpt-5.2 → audit: gpt-5.4"
+    ENGINE_LABEL="triage: gpt-5-mini → deep: gpt-5.2 + duck: sonnet 4.6 → audit: gpt-5.4"
     ENGINE_SINGLE_LABEL="single-reviewer mode: gpt-5.4"
+    # Cross-engine rubber duck: always the opposite engine
+    DUCK_ENGINE="claude"
+    DUCK_MODEL="claude-sonnet-4-6"
     ;;
   *)
     echo "::error::Unknown REVIEW_ENGINE='$REVIEW_ENGINE' (expected: claude or copilot)"
@@ -38,6 +46,7 @@ esac
 export ENGINE_TRIAGE_MODEL ENGINE_DEEP_MODEL ENGINE_AUDIT_MODEL
 export ENGINE_ACTION_MODEL ENGINE_SINGLE_MODEL
 export ENGINE_LABEL ENGINE_SINGLE_LABEL
+export DUCK_ENGINE DUCK_MODEL
 
 echo "    engine: $REVIEW_ENGINE ($ENGINE_LABEL)"
 
@@ -73,6 +82,30 @@ run_agentic() {
         --model "$model" \
         --permission-mode acceptEdits \
         --allowed-tools "Bash,Read,Grep,Glob" \
+        < "$prompt_file"
+      ;;
+    copilot)
+      copilot \
+        -p "$(cat "$prompt_file")" \
+        --model "$model" \
+        -s --allow-all --no-ask-user
+      ;;
+  esac
+}
+
+# run_duck <prompt_file> <model>
+# Cross-engine adversarial "rubber duck" review.
+# Always uses the OPPOSITE engine from REVIEW_ENGINE. Output to stdout.
+run_duck() {
+  local prompt_file="$1"
+  local model="$2"
+  case "$DUCK_ENGINE" in
+    claude)
+      claude --print \
+        --model "$model" \
+        --permission-mode acceptEdits \
+        --allowed-tools "Bash,Read,Grep,Glob" \
+        --max-turns 25 \
         < "$prompt_file"
       ;;
     copilot)

--- a/scripts/review-one-pr.sh
+++ b/scripts/review-one-pr.sh
@@ -159,12 +159,30 @@ if [ "$TRIAGE_ESCALATE" = "false" ]; then
   exit 0
 fi
 
-# --- Tier 2: Deep review ---
-echo "    [tier2] deep review ($ENGINE_DEEP_MODEL)"
+# --- Tier 2: Deep review + Rubber duck (parallel, cross-engine) ---
+echo "    [tier2] deep review ($ENGINE_DEEP_MODEL) + rubber duck ($DUCK_MODEL via $DUCK_ENGINE)"
+
+# Launch both reviewers in parallel — different model families for diversity.
 OUTPUT_FILE="/tmp/cascade/deep.json"
 export OUTPUT_FILE
 run_agentic prompts/deep-review.md "$ENGINE_DEEP_MODEL" \
-  > /tmp/cascade/deep.log 2>&1 || true
+  > /tmp/cascade/deep.log 2>&1 &
+DEEP_PID=$!
+
+DUCK_OUTPUT="/tmp/cascade/rubber-duck.json"
+(
+  export OUTPUT_FILE="$DUCK_OUTPUT"
+  run_duck prompts/rubber-duck.md "$DUCK_MODEL" \
+    > /tmp/cascade/duck.log 2>&1
+) &
+DUCK_PID=$!
+
+# Wait for both to finish
+wait $DEEP_PID || true
+wait $DUCK_PID || true
+
+# Validate primary deep review (required)
+OUTPUT_FILE="/tmp/cascade/deep.json"
 if [ ! -s "$OUTPUT_FILE" ] || ! jq empty "$OUTPUT_FILE" 2>/dev/null; then
   echo "::warning::deep review did not produce valid JSON at $OUTPUT_FILE"
   cat /tmp/cascade/deep.log || true
@@ -172,17 +190,59 @@ if [ ! -s "$OUTPUT_FILE" ] || ! jq empty "$OUTPUT_FILE" 2>/dev/null; then
   exit 1
 fi
 
-DEEP_ESCALATE=$(jq -r '.escalate_to_opus' "$OUTPUT_FILE")
 DEEP_DECISION=$(jq -r '.decision' "$OUTPUT_FILE")
 DEEP_RISK=$(jq -r '.risk' "$OUTPUT_FILE")
-echo "    [tier2] escalate_to_opus=$DEEP_ESCALATE decision=$DEEP_DECISION risk=$DEEP_RISK"
+echo "    [tier2] deep: decision=$DEEP_DECISION risk=$DEEP_RISK"
 
-# If deep review resolves without needing security audit → go straight to action
-if [ "$DEEP_ESCALATE" != "true" ]; then
-  echo "    [action] deep review resolved — posting review"
+# Validate rubber duck (optional — graceful degradation if it fails)
+DUCK_VALID=false
+if [ -s "$DUCK_OUTPUT" ] && jq empty "$DUCK_OUTPUT" 2>/dev/null; then
+  DUCK_DECISION=$(jq -r '.decision' "$DUCK_OUTPUT")
+  DUCK_RISK=$(jq -r '.risk' "$DUCK_OUTPUT")
+  DUCK_VALID=true
+  echo "    [tier2] duck: decision=$DUCK_DECISION risk=$DUCK_RISK"
+else
+  echo "    [tier2] rubber duck did not produce valid JSON — continuing with deep review only"
+  cat /tmp/cascade/duck.log 2>/dev/null || true
+fi
+
+# --- Tier 2b: Synthesize deep + duck verdicts ---
+if [ "$DUCK_VALID" = "true" ]; then
+  echo "    [tier2b] synthesizing deep + duck verdicts ($ENGINE_ACTION_MODEL)"
+  DEEP_RESULT="/tmp/cascade/deep.json"
+  DUCK_RESULT="$DUCK_OUTPUT"
+  OUTPUT_FILE="/tmp/cascade/combined.json"
+  export DEEP_RESULT DUCK_RESULT OUTPUT_FILE
+  run_agentic prompts/synthesize-duck.md "$ENGINE_ACTION_MODEL" \
+    > /tmp/cascade/synth.log 2>&1 || true
+
+  if [ -s "$OUTPUT_FILE" ] && jq empty "$OUTPUT_FILE" 2>/dev/null; then
+    COMBINED_DECISION=$(jq -r '.decision' "$OUTPUT_FILE")
+    COMBINED_RISK=$(jq -r '.risk' "$OUTPUT_FILE")
+    COMBINED_AGREEMENT=$(jq -r '.agreement' "$OUTPUT_FILE")
+    COMBINED_ESCALATE=$(jq -r '.escalate_to_opus' "$OUTPUT_FILE")
+    echo "    [tier2b] combined: decision=$COMBINED_DECISION risk=$COMBINED_RISK agreement=$COMBINED_AGREEMENT escalate_to_opus=$COMBINED_ESCALATE"
+  else
+    echo "    [tier2b] synthesis failed — falling back to deep review only"
+    cat /tmp/cascade/synth.log 2>/dev/null || true
+    OUTPUT_FILE="/tmp/cascade/deep.json"
+    COMBINED_ESCALATE=$(jq -r '.escalate_to_opus' "$OUTPUT_FILE")
+  fi
+else
+  OUTPUT_FILE="/tmp/cascade/deep.json"
+  COMBINED_ESCALATE=$(jq -r '.escalate_to_opus' "$OUTPUT_FILE")
+fi
+
+# If tier 2 resolves without needing security audit → go straight to action
+if [ "$COMBINED_ESCALATE" != "true" ]; then
+  echo "    [action] tier 2 resolved — posting review"
   FINAL_RESULT="$OUTPUT_FILE"
   export FINAL_RESULT
-  export FINAL_TIER="deep"
+  if [ "$DUCK_VALID" = "true" ]; then
+    export FINAL_TIER="deep+duck"
+  else
+    export FINAL_TIER="deep"
+  fi
   run_agentic prompts/cascade-action.md "$ENGINE_ACTION_MODEL"
   echo "    [done]  $PR_URL"
   exit 0

--- a/scripts/review-one-pr.sh
+++ b/scripts/review-one-pr.sh
@@ -177,18 +177,22 @@ DUCK_OUTPUT="/tmp/cascade/rubber-duck.json"
 ) &
 DUCK_PID=$!
 
-# Wait for both to finish
+# Wait for deep review first — if it fails, kill the duck and exit early.
 wait $DEEP_PID || true
-wait $DUCK_PID || true
 
 # Validate primary deep review (required)
 OUTPUT_FILE="/tmp/cascade/deep.json"
 if [ ! -s "$OUTPUT_FILE" ] || ! jq empty "$OUTPUT_FILE" 2>/dev/null; then
   echo "::warning::deep review did not produce valid JSON at $OUTPUT_FILE"
   cat /tmp/cascade/deep.log || true
+  kill $DUCK_PID 2>/dev/null || true
+  wait $DUCK_PID 2>/dev/null || true
   echo "::error::cascade failed at tier 2 for $PR_URL"
   exit 1
 fi
+
+# Wait for duck to finish (deep succeeded)
+wait $DUCK_PID || true
 
 DEEP_DECISION=$(jq -r '.decision' "$OUTPUT_FILE")
 DEEP_RISK=$(jq -r '.risk' "$OUTPUT_FILE")
@@ -226,6 +230,7 @@ if [ "$DUCK_VALID" = "true" ]; then
     echo "    [tier2b] synthesis failed — falling back to deep review only"
     cat /tmp/cascade/synth.log 2>/dev/null || true
     OUTPUT_FILE="/tmp/cascade/deep.json"
+    DUCK_VALID=false
     COMBINED_ESCALATE=$(jq -r '.escalate_to_opus' "$OUTPUT_FILE")
   fi
 else
@@ -250,7 +255,11 @@ fi
 
 # --- Tier 3: Security audit ---
 echo "    [tier3] security audit ($ENGINE_AUDIT_MODEL)"
-DEEP_RESULT="$OUTPUT_FILE"
+# TIER2_RESULT may point to combined.json (deep+duck) or deep.json (duck failed).
+TIER2_RESULT="$OUTPUT_FILE"
+export TIER2_RESULT
+# Backward compat: security-audit.md reads $DEEP_RESULT
+DEEP_RESULT="$TIER2_RESULT"
 export DEEP_RESULT
 OUTPUT_FILE="/tmp/cascade/audit.json"
 export OUTPUT_FILE


### PR DESCRIPTION
## Summary
- Adds a parallel cross-engine "rubber duck" adversarial reviewer at tier 2 of the PR review cascade
- If the primary engine is Claude, the rubber duck is Copilot (GPT-5.4), and vice versa — always a different model family
- A new synthesis step merges both verdicts (max risk, union findings, cross-engine agreement tracking) before deciding to approve or escalate

## Architecture

```
Triage (primary engine)
  └─ clean → single confirm → approve
  └─ concerns ↓
Deep review (primary) ──┐
Rubber duck (opposite) ─┤ parallel
                        ↓
Synthesize (merge verdicts)
  └─ clean → approve + auto-merge
  └─ HIGH risk ↓
Security audit → final decision
```

## Key design decisions
- **Always cross-engine**: maximizes model diversity for catching blind spots (inspired by [Copilot's rubber duck](https://github.blog/ai-and-ml/github-copilot/github-copilot-cli-combines-model-families-for-a-second-opinion/))
- **Graceful degradation**: if the rubber duck fails (missing creds, CLI unavailable), cascade continues with primary review only
- **Both CLIs installed**: workflow now installs both Claude and Copilot CLIs regardless of `REVIEW_ENGINE`
- **Cost impact**: adds 2 LLM calls (duck + synthesis) only for escalated PRs (~20% of total)

## Files changed
| File | Change |
|---|---|
| `scripts/engine.sh` | `DUCK_ENGINE`, `DUCK_MODEL`, `run_duck()` |
| `scripts/review-one-pr.sh` | Parallel tier 2, synthesis, graceful fallback |
| `prompts/rubber-duck.md` | New adversarial prompt |
| `prompts/synthesize-duck.md` | New verdict merger prompt |
| `prompts/cascade-action.md` | Cross-engine agreement in review body |
| `.github/workflows/pr-review.yml` | Install both engine CLIs |
| `AGENT.md` | Document rubber duck review |

## Test plan
- [ ] Dry-run with `REVIEW_ENGINE=claude` — verify deep + duck run in parallel, synthesis merges
- [ ] Dry-run with `REVIEW_ENGINE=copilot` — verify duck uses Claude as opposite engine
- [ ] Test graceful degradation — unset `COPILOT_GITHUB_TOKEN`, verify cascade proceeds with deep only
- [ ] Verify triage-approved path skips rubber duck entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)