### PR TITLE
fix: auto-fallback to Copilot on Claude rate limit, fix E2BIG on large diffs

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -106,6 +106,7 @@ jobs:
           actual=0
           skipped_noops=0
           failed=0
+          engine_fallbacks=0
           processed=0
           while IFS= read -r pr_url; do
             [ -z "$pr_url" ] && continue
@@ -126,6 +127,18 @@ jobs:
             echo "::group::Reviewing $pr_url"
             rc=0
             bash scripts/review-one-pr.sh "$pr_url" || rc=$?
+
+            # Exit code 2 = engine rate-limited.
+            # If primary engine is Claude, switch to Copilot and retry this PR.
+            # All subsequent PRs in this batch will also use Copilot.
+            if [ "$rc" -eq 2 ] && [ "${REVIEW_ENGINE:-claude}" = "claude" ]; then
+              echo "::warning::Claude rate limit hit — switching to Copilot engine for remaining PRs"
+              export REVIEW_ENGINE=copilot
+              engine_fallbacks=$((engine_fallbacks + 1))
+              rc=0
+              bash scripts/review-one-pr.sh "$pr_url" || rc=$?
+            fi
+
             if [ "$rc" -eq 100 ]; then
               # Exit code 100 = no-op (already reviewed), don't count toward budget
               skipped_noops=$((skipped_noops + 1))
@@ -134,6 +147,10 @@ jobs:
               # Successful review
               actual=$((actual + 1))
               echo "::notice::Review posted ($actual/$MAX_PRS)"
+            elif [ "$rc" -eq 2 ]; then
+              # Rate-limited on fallback engine too — no further fallback available
+              failed=$((failed + 1))
+              echo "::warning::Rate limit hit on $REVIEW_ENGINE engine, no fallback available for $pr_url"
             else
               # Other failure
               failed=$((failed + 1))
@@ -141,4 +158,8 @@ jobs:
             fi
             echo "::endgroup::"
           done < prs.txt
-          echo "Summary: $actual reviews posted, $skipped_noops no-ops skipped, $failed failures (processed $processed/$CANDIDATE_LIMIT candidates)"
+          if [ "$engine_fallbacks" -gt 0 ]; then
+            echo "Summary: $actual reviews posted, $skipped_noops no-ops skipped, $failed failures, $engine_fallbacks engine fallback(s) to copilot (processed $processed/$CANDIDATE_LIMIT candidates)"
+          else
+            echo "Summary: $actual reviews posted, $skipped_noops no-ops skipped, $failed failures (processed $processed/$CANDIDATE_LIMIT candidates)"
+          fi

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -55,7 +55,7 @@ echo "    engine: $REVIEW_ENGINE ($ENGINE_LABEL)"
 # review-one-pr.sh exits with code 2 when this fires so the caller can switch engines.
 is_rate_limited() {
   local text="$1"
-  echo "$text" | grep -qiE "(hit your limit|rate.?limit|resets [0-9]+(am|pm)|usage limit|quota exceeded|too many requests|exceeded.*quota)"
+  echo "$text" | grep -qiE "(hit your limit|rate[ -]?limit|resets [0-9]+(am|pm)|usage limit|quota exceeded|too many requests|exceeded.*quota)"
 }
 
 # run_triage <prompt_file>

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -50,6 +50,14 @@ export DUCK_ENGINE DUCK_MODEL
 
 echo "    engine: $REVIEW_ENGINE ($ENGINE_LABEL)"
 
+# is_rate_limited <text>
+# Returns 0 (true) if the text looks like a Claude or Copilot rate-limit message.
+# review-one-pr.sh exits with code 2 when this fires so the caller can switch engines.
+is_rate_limited() {
+  local text="$1"
+  echo "$text" | grep -qiE "(hit your limit|rate.?limit|resets [0-9]+(am|pm)|usage limit|quota exceeded|too many requests|exceeded.*quota)"
+}
+
 # run_triage <prompt_file>
 # No-tool mode: reads pre-fetched context from env vars only.
 # Captures stdout (the model's JSON response).

--- a/scripts/review-one-pr.sh
+++ b/scripts/review-one-pr.sh
@@ -178,10 +178,13 @@ fi
 echo "    [tier2] deep review ($ENGINE_DEEP_MODEL) + rubber duck ($DUCK_MODEL via $DUCK_ENGINE)"
 
 # Launch both reviewers in parallel — different model families for diversity.
+# Stdout (model text output) and stderr (process errors) are kept separate so
+# the rate-limit check below inspects only the model's own words, not PR content
+# or tool-execution noise that could cause false positives.
 OUTPUT_FILE="/tmp/cascade/deep.json"
 export OUTPUT_FILE
 run_agentic prompts/deep-review.md "$ENGINE_DEEP_MODEL" \
-  > /tmp/cascade/deep.log 2>&1 &
+  > /tmp/cascade/deep-stdout.txt 2>/tmp/cascade/deep.log &
 DEEP_PID=$!
 
 DUCK_OUTPUT="/tmp/cascade/rubber-duck.json"
@@ -198,17 +201,20 @@ wait $DEEP_PID || true
 # Validate primary deep review (required)
 OUTPUT_FILE="/tmp/cascade/deep.json"
 if [ ! -s "$OUTPUT_FILE" ] || ! jq empty "$OUTPUT_FILE" 2>/dev/null; then
-  DEEP_LOG_CONTENT=$(cat /tmp/cascade/deep.log 2>/dev/null || true)
+  # Check the model's stdout for a rate-limit message.  We intentionally do NOT
+  # check deep.log (stderr/process noise) to avoid false positives from PR diff
+  # content that happens to mention rate-limiting in code or comments.
+  DEEP_STDOUT_CONTENT=$(cat /tmp/cascade/deep-stdout.txt 2>/dev/null || true)
   kill $DUCK_PID 2>/dev/null || true
   wait $DUCK_PID 2>/dev/null || true
-  # Detect rate limit in the deep review output — exit 2 for engine fallback.
-  if is_rate_limited "$DEEP_LOG_CONTENT"; then
+  if is_rate_limited "$DEEP_STDOUT_CONTENT"; then
     echo "    [tier2] rate limit detected — exiting with code 2 for engine fallback"
-    echo "$DEEP_LOG_CONTENT"
+    echo "$DEEP_STDOUT_CONTENT"
     exit 2
   fi
   echo "::warning::deep review did not produce valid JSON at $OUTPUT_FILE"
-  echo "$DEEP_LOG_CONTENT"
+  cat /tmp/cascade/deep-stdout.txt 2>/dev/null || true
+  cat /tmp/cascade/deep.log 2>/dev/null || true
   echo "::error::cascade failed at tier 2 for $PR_URL"
   exit 1
 fi

--- a/scripts/review-one-pr.sh
+++ b/scripts/review-one-pr.sh
@@ -139,6 +139,19 @@ TRIAGE_RESULT=$(
   run_triage prompts/triage.md 2>"$TRIAGE_LOG"
 ) || true
 
+# Unset large pre-fetched env vars now that triage has consumed them.
+# PR_DIFF and PR_METADATA can be hundreds of KB; keeping them exported causes
+# E2BIG (Argument list too long) when later subprocesses (jq, claude) are forked.
+unset PR_DIFF PR_METADATA
+
+# Detect rate limit before JSON validation — exit 2 so the caller can fall back
+# to a different engine rather than burning through the remaining PR queue.
+if is_rate_limited "$TRIAGE_RESULT"; then
+  echo "    [tier1] rate limit detected — exiting with code 2 for engine fallback"
+  echo "    rate limit message: $TRIAGE_RESULT"
+  exit 2
+fi
+
 # Validate triage output is JSON
 if ! echo "$TRIAGE_RESULT" | jq empty 2>/dev/null; then
   echo "    [tier1] triage returned non-JSON, escalating by default"
@@ -185,10 +198,17 @@ wait $DEEP_PID || true
 # Validate primary deep review (required)
 OUTPUT_FILE="/tmp/cascade/deep.json"
 if [ ! -s "$OUTPUT_FILE" ] || ! jq empty "$OUTPUT_FILE" 2>/dev/null; then
-  echo "::warning::deep review did not produce valid JSON at $OUTPUT_FILE"
-  cat /tmp/cascade/deep.log || true
+  DEEP_LOG_CONTENT=$(cat /tmp/cascade/deep.log 2>/dev/null || true)
   kill $DUCK_PID 2>/dev/null || true
   wait $DUCK_PID 2>/dev/null || true
+  # Detect rate limit in the deep review output — exit 2 for engine fallback.
+  if is_rate_limited "$DEEP_LOG_CONTENT"; then
+    echo "    [tier2] rate limit detected — exiting with code 2 for engine fallback"
+    echo "$DEEP_LOG_CONTENT"
+    exit 2
+  fi
+  echo "::warning::deep review did not produce valid JSON at $OUTPUT_FILE"
+  echo "$DEEP_LOG_CONTENT"
   echo "::error::cascade failed at tier 2 for $PR_URL"
   exit 1
 fi


### PR DESCRIPTION
## Problem

Workflow run [24519713661](https://github.com/don-petry/self/actions/runs/24519713661) had **53 failures** — all caused by hitting the Claude API daily usage limit at 15:45 UTC. The run burned through all 53 remaining candidates before stopping, posting 0 reviews. One additional failure (`broodly/pull/38`) crashed with `jq: Argument list too long` due to an oversized PR diff filling the shell environment.

## Changes

### `scripts/engine.sh` — rate-limit detector

Adds `is_rate_limited()`, a shared helper that matches known rate-limit message patterns from both Claude and Copilot:
```
"hit your limit" | "rate limit" | "resets 4pm" | "quota exceeded" | "too many requests"
```

### `scripts/review-one-pr.sh` — exit 2 + E2BIG fix

**Exit code 2 (new sentinel: rate-limited)**
- After tier 1 (triage): if `TRIAGE_RESULT` matches `is_rate_limited`, exit 2 immediately instead of escalating to tier 2 (which would also fail).
- After tier 2 (deep review): if the deep review log matches `is_rate_limited`, exit 2 instead of logging a generic cascade failure.

**Fix `jq: Argument list too long`**
- `PR_DIFF` and `PR_METADATA` are unset immediately after the triage call. They can be hundreds of KB combined; keeping them exported caused `E2BIG` when forking subprocesses (jq, claude) later in the script.

### `.github/workflows/pr-review.yml` — Copilot fallback

In the review loop, on exit code 2:
1. If `REVIEW_ENGINE=claude`, switch to `REVIEW_ENGINE=copilot` and **retry the same PR** with Copilot.
2. The engine stays on Copilot for all remaining PRs in the batch (persistent switch, not per-PR overhead).
3. If the fallback engine also returns exit 2, count as a regular failure with a clear warning — no infinite loop.
4. Summary line reports `N engine fallback(s) to copilot` when the switch occurred.

## Behavior change

| Before | After |
|---|---|
| Hit Claude rate limit → log warning, count as failure, continue burning queue | Hit Claude rate limit → switch to Copilot, retry same PR, continue batch on Copilot |
| Oversized diff → `jq: Argument list too long` at line 150 | Oversized diff → large vars unset before jq calls, no crash |
| Generic `cascade failed at tier 2` on rate limit | `[tier2] rate limit detected — exiting with code 2 for engine fallback` |

## Test

Re-run of the same PR batch after a rate-limit hit (as seen in the 16:43 UTC run) would now produce reviews via Copilot instead of 53 failures.