### PR TITLE
fix: use --admin bypass merge instead of --auto on approval

### DIFF
--- a/prompts/cascade-action.md
+++ b/prompts/cascade-action.md
@@ -58,14 +58,21 @@ array, note which engine(s) flagged each finding.>
 _Reviewed by the don-petry PR-review cascade ($ENGINE_LABEL). Reply with `@don-petry` if you need a human._
 ```
 
-5. **Act** (same logic as synthesize.md):
+5. **Act**:
    - If `$DRY_RUN` is `true`: print `--- WOULD POST ---`, the body, and
      planned actions. Exit.
    - If `decision` is `approve`:
      1. `gh pr review "$PR_URL" --approve --body "$BODY"`
      2. Rebase if `mergeStateStatus` is `BEHIND`:
         `gh api -X PUT "repos/<owner>/<repo>/pulls/<num>/update-branch" -f expected_head_sha="$PR_HEAD_SHA"` (swallow errors)
-        Then sleep 5 seconds to allow GitHub to process the branch update before merging.
+        Then poll until the branch is no longer `BEHIND` (up to 30 s, 5 s interval):
+        ```
+        for i in 1 2 3 4 5 6; do
+          STATUS=$(gh pr view "$PR_URL" --json mergeStateStatus --jq '.mergeStateStatus')
+          [ "$STATUS" != "BEHIND" ] && break
+          sleep 5
+        done
+        ```
      3. Bypass merge: `gh pr merge "$PR_URL" --squash --admin` (swallow errors)
         Use `--admin` to bypass branch protection rules (don-petry has bypass permissions).
         Do NOT use `--auto` — bypass merge is immediate, not gated on further approvals.

--- a/prompts/cascade-action.md
+++ b/prompts/cascade-action.md
@@ -65,7 +65,10 @@ _Reviewed by the don-petry PR-review cascade ($ENGINE_LABEL). Reply with `@don-p
      1. `gh pr review "$PR_URL" --approve --body "$BODY"`
      2. Rebase if `mergeStateStatus` is `BEHIND`:
         `gh api -X PUT "repos/<owner>/<repo>/pulls/<num>/update-branch" -f expected_head_sha="$PR_HEAD_SHA"` (swallow errors)
-     3. Auto-merge: `gh pr merge "$PR_URL" --auto --squash` (swallow errors)
+        Then sleep 5 seconds to allow GitHub to process the branch update before merging.
+     3. Bypass merge: `gh pr merge "$PR_URL" --squash --admin` (swallow errors)
+        Use `--admin` to bypass branch protection rules (don-petry has bypass permissions).
+        Do NOT use `--auto` — bypass merge is immediate, not gated on further approvals.
      4. Remove `needs-human-review` label if present (swallow errors)
    - If `decision` is `escalate`:
      - If `$AI_DELEGATION_ENABLED` is `true` AND `$REVIEW_CYCLE` < `$MAX_REVIEW_CYCLES`

--- a/prompts/single-review.md
+++ b/prompts/single-review.md
@@ -133,7 +133,10 @@ Then act:
   1. `gh pr review "$PR_URL" --approve --body "$BODY"`
   2. Rebase if `mergeStateStatus` is `BEHIND`:
      `gh api -X PUT "repos/<owner>/<repo>/pulls/<num>/update-branch" -f expected_head_sha="$PR_HEAD_SHA"` (swallow errors)
-  3. Enable auto-merge: `gh pr merge "$PR_URL" --auto --squash` (swallow errors)
+     Then sleep 5 seconds to allow GitHub to process the branch update before merging.
+  3. Bypass merge: `gh pr merge "$PR_URL" --squash --admin` (swallow errors)
+     Use `--admin` to bypass branch protection rules (don-petry has bypass permissions).
+     Do NOT use `--auto` — bypass merge is immediate, not gated on further approvals.
   4. Remove `needs-human-review` label if present (swallow errors)
 - If escalating:
   - If `$AI_DELEGATION_ENABLED` is `true` AND `$REVIEW_CYCLE` < `$MAX_REVIEW_CYCLES`

--- a/prompts/single-review.md
+++ b/prompts/single-review.md
@@ -96,7 +96,7 @@ carefully. For each finding in the prior review:
 
 If all prior findings are resolved AND no new issues → approve.
 
-## Actions (same as synthesizer)
+## Actions
 
 Compose a review body with the same template:
 
@@ -133,7 +133,14 @@ Then act:
   1. `gh pr review "$PR_URL" --approve --body "$BODY"`
   2. Rebase if `mergeStateStatus` is `BEHIND`:
      `gh api -X PUT "repos/<owner>/<repo>/pulls/<num>/update-branch" -f expected_head_sha="$PR_HEAD_SHA"` (swallow errors)
-     Then sleep 5 seconds to allow GitHub to process the branch update before merging.
+     Then poll until the branch is no longer `BEHIND` (up to 30 s, 5 s interval):
+     ```
+     for i in 1 2 3 4 5 6; do
+       STATUS=$(gh pr view "$PR_URL" --json mergeStateStatus --jq '.mergeStateStatus')
+       [ "$STATUS" != "BEHIND" ] && break
+       sleep 5
+     done
+     ```
   3. Bypass merge: `gh pr merge "$PR_URL" --squash --admin` (swallow errors)
      Use `--admin` to bypass branch protection rules (don-petry has bypass permissions).
      Do NOT use `--auto` — bypass merge is immediate, not gated on further approvals.

--- a/prompts/synthesize.md
+++ b/prompts/synthesize.md
@@ -66,9 +66,18 @@ and (if `$DRY_RUN` is `false`) post a PR review.
       is `BEHIND` (base branch has advanced), update the PR branch:
       `gh api -X PUT "repos/<owner>/<repo>/pulls/<num>/update-branch" -f expected_head_sha="$PR_HEAD_SHA"`
       Swallow errors (conflicts will be caught on next cycle).
-   2. **Enable auto-merge**: `gh pr merge "$PR_URL" --auto --squash`
-      This tells GitHub to merge the PR once all required checks pass.
-      Swallow errors if auto-merge is already enabled or not allowed.
+      Then poll until the branch is no longer `BEHIND` (up to 30 s, 5 s interval):
+      ```
+      for i in 1 2 3 4 5 6; do
+        STATUS=$(gh pr view "$PR_URL" --json mergeStateStatus --jq '.mergeStateStatus')
+        [ "$STATUS" != "BEHIND" ] && break
+        sleep 5
+      done
+      ```
+   2. **Bypass merge**: `gh pr merge "$PR_URL" --squash --admin`
+      Use `--admin` to bypass branch protection rules (don-petry has bypass permissions).
+      Do NOT use `--auto` — bypass merge is immediate, not gated on further approvals.
+      Swallow errors.
    3. Remove the `needs-human-review` label if present:
       `gh pr edit "$PR_URL" --remove-label needs-human-review` (swallow errors).
 9. **Delegation** (only when escalating, `$DRY_RUN` is `false`):

--- a/prompts/triage.md
+++ b/prompts/triage.md
@@ -27,15 +27,14 @@ Output `"escalate": false` (approve) if ALL of these are true:
    - Database migrations or schema (`migrations/`, `schema.*`, `*.sql`, Prisma, Alembic)
    - GitHub Actions workflows that handle secrets or use `pull_request_target`
    - Files matching: `**/auth/**`, `**/*secret*`, `**/*credential*`, `**/*crypto*`
-2. No CI checks are failing (look at `statusCheckRollup` in metadata).
-3. No unresolved review threads requesting changes.
-4. The diff does not contain obvious security anti-patterns:
+2. No unresolved review threads requesting changes.
+3. The diff does not contain obvious security anti-patterns:
    - SQL string concatenation, `eval`/`exec` on dynamic input, `shell=True`
      with user input, hardcoded secrets/passwords, disabled TLS verification,
      broad `except:` swallowing, `dangerouslySetInnerHTML`, etc.
-5. If there's a linked issue, the diff appears to address it (use your judgment).
-6. The PR is well-structured (clear title, reasonable scope).
-7. If `$PRIOR_REVIEW_BODY` is non-empty: the new commits appear to resolve
+4. If there's a linked issue, the diff appears to address it (use your judgment).
+5. The PR is well-structured (clear title, reasonable scope).
+6. If `$PRIOR_REVIEW_BODY` is non-empty: the new commits appear to resolve
    the findings from the prior review.
 
 Output `"escalate": true` if ANY of those checks fail. When in doubt, escalate.

--- a/scripts/review-one-pr.sh
+++ b/scripts/review-one-pr.sh
@@ -35,6 +35,38 @@ PR_HEAD_SHA=$(gh pr view "$PR_URL" --json headRefOid --jq '.headRefOid')
 export PR_HEAD_SHA
 echo "    head SHA: $PR_HEAD_SHA"
 
+# 1b. CI gate: skip PRs with failing or still-running checks.
+#     We only spend review tokens on PRs where all checks are conclusive and green.
+#     No checks at all (empty statusCheckRollup) is treated as passing.
+CI_STATUS=$(gh pr view "$PR_URL" --json statusCheckRollup --jq '
+  if (.statusCheckRollup | length) == 0 then "passing"
+  elif ([.statusCheckRollup[] | select(
+         .conclusion == "FAILURE" or
+         .conclusion == "ACTION_REQUIRED" or
+         .conclusion == "TIMED_OUT" or
+         .conclusion == "CANCELLED"
+       )] | length) > 0 then "failing"
+  elif ([.statusCheckRollup[] | select(
+         .status == "IN_PROGRESS" or
+         .status == "QUEUED" or
+         .status == "WAITING" or
+         (.status == "COMPLETED" and (.conclusion == null or .conclusion == ""))
+       )] | length) > 0 then "pending"
+  else "passing"
+  end
+')
+echo "    CI status: $CI_STATUS"
+if [ "$CI_STATUS" = "failing" ]; then
+  echo "    skip: CI checks are failing — will re-evaluate after fixes are pushed"
+  echo "{\"pr\":\"$PR_URL\",\"sha\":\"$PR_HEAD_SHA\",\"decision\":\"skip\",\"reason\":\"ci-failing\"}"
+  exit 100
+fi
+if [ "$CI_STATUS" = "pending" ]; then
+  echo "    skip: CI checks still in progress — will re-evaluate when checks complete"
+  echo "{\"pr\":\"$PR_URL\",\"sha\":\"$PR_HEAD_SHA\",\"decision\":\"skip\",\"reason\":\"ci-pending\"}"
+  exit 100
+fi
+
 # 2. Idempotency: look for our marker at this SHA in existing reviews+comments
 # Extract the most recent SHA from our review marker in existing PR comments/reviews.
 # Uses (array + array) to concatenate safely when either is empty, then iterates


### PR DESCRIPTION
## Summary

- Replaces `gh pr merge --auto --squash` with `gh pr merge --squash --admin` in both `cascade-action.md` and `single-review.md`
- Adds a 5-second sleep after the `update-branch` rebase call to let GitHub process the branch update before merging
- Non-approval (escalate) paths are unchanged — `--admin` is only invoked when the agent's decision is `approve`

## Why

`--auto` queues a merge gated on further required approvals, which the bot account couldn't satisfy. `--admin` bypasses branch protection rules immediately — `don-petry` has bypass permissions configured on these repos.

## Test plan

- [ ] Trigger a manual `workflow_dispatch` run against a known-approvable PR with `dry_run=false`
- [ ] Verify the PR shows an **Approved** review event followed by a merged state
- [ ] Trigger against a PR the agent would escalate — confirm no merge occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)