### PR TITLE
fix: replace --checks passing with --checks success in list-prs.sh

### DIFF
--- a/scripts/list-prs.sh
+++ b/scripts/list-prs.sh
@@ -7,7 +7,7 @@
 #
 # Filters:
 #   --draft=false       — skip work-in-progress PRs
-#   --checks passing    — only include PRs where all CI checks are green;
+#   --checks success    — only include PRs where all CI checks are green;
 #                         failing or pending CI PRs are excluded here so they
 #                         never consume a review slot. review-one-pr.sh also
 #                         enforces this per-PR as a second layer of defence.
@@ -20,7 +20,7 @@ authored=$(gh search prs \
   --state open \
   --author "@me" \
   --draft=false \
-  --checks passing \
+  --checks success \
   --limit 100 \
   --json url \
   --jq '.[].url')
@@ -29,7 +29,7 @@ review_requested=$(gh search prs \
   --state open \
   --review-requested "@me" \
   --draft=false \
-  --checks passing \
+  --checks success \
   --limit 100 \
   --json url \
   --jq '.[].url')


### PR DESCRIPTION
## Summary

- GitHub CLI changed `gh search prs --checks` to only accept `{pending|success|failure}` — `passing` is no longer valid
- All PR Review Agent workflow runs have been failing since this change (5 consecutive failures today, 11:21–15:23 UTC)
- Replace `--checks passing` with `--checks success` in both search calls in `scripts/list-prs.sh`

## Root Cause

The "Enumerate candidate PRs" step fails immediately with:
```
invalid argument "passing" for "--checks" flag: valid values are {pending|success|failure}
```

Since enumeration fails, zero PRs are reviewed in any run.

## Test plan

- [ ] Trigger a manual workflow run after merge: `gh workflow run pr-review.yml --repo don-petry/self`
- [ ] Confirm "Enumerate candidate PRs" step completes without error and reports a candidate count
- [ ] Confirm subsequent review steps proceed normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)