### PR TITLE
fix: robustly extract JSON verdict from mixed claude --print output

### DIFF
--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -101,6 +101,33 @@ run_agentic() {
   esac
 }
 
+# extract_verdict_json <raw_file> <dest_file>
+# Extracts the first valid JSON object containing a 'decision' field from
+# a file that may contain claude preamble text before/after the JSON.
+extract_verdict_json() {
+  local raw="$1" dest="$2"
+  if jq empty "$raw" 2>/dev/null; then
+    cp "$raw" "$dest"
+    return 0
+  fi
+  python3 -c "
+import sys, json
+text = open(sys.argv[1]).read()
+decoder = json.JSONDecoder()
+pos = text.find('{')
+while pos >= 0:
+    try:
+        obj, _ = decoder.raw_decode(text, pos)
+        if isinstance(obj, dict) and 'decision' in obj:
+            print(json.dumps(obj))
+            sys.exit(0)
+    except Exception:
+        pass
+    pos = text.find('{', pos + 1)
+sys.exit(1)
+" "$raw" > "$dest" 2>/dev/null
+}
+
 # run_duck <prompt_file> <model>
 # Cross-engine adversarial "rubber duck" review.
 # Always uses the OPPOSITE engine from REVIEW_ENGINE. Output to stdout.

--- a/scripts/review-one-pr.sh
+++ b/scripts/review-one-pr.sh
@@ -211,7 +211,9 @@ if [ "$TRIAGE_ESCALATE" = "false" ]; then
   VERDICT_JSON="/tmp/cascade/single-review-verdict.json"
   OUTPUT_FILE="$VERDICT_JSON"
   export OUTPUT_FILE
-  run_agentic prompts/single-review.md "$ENGINE_SINGLE_MODEL" > "$VERDICT_JSON"
+  run_agentic prompts/single-review.md "$ENGINE_SINGLE_MODEL" > "$VERDICT_JSON.raw"
+  extract_verdict_json "$VERDICT_JSON.raw" "$VERDICT_JSON" || { echo "::error::single-review did not produce valid JSON"; exit 1; }
+  rm -f "$VERDICT_JSON.raw"
 
   # Post the review using the verdict
   bash scripts/post-pr-review.sh "$PR_URL" "$VERDICT_JSON" "$DRY_RUN"
@@ -324,7 +326,9 @@ if [ "$COMBINED_ESCALATE" != "true" ]; then
   VERDICT_JSON="/tmp/cascade/cascade-action-verdict.json"
   OUTPUT_FILE="$VERDICT_JSON"
   export OUTPUT_FILE
-  run_agentic prompts/cascade-action.md "$ENGINE_ACTION_MODEL" > "$VERDICT_JSON"
+  run_agentic prompts/cascade-action.md "$ENGINE_ACTION_MODEL" > "$VERDICT_JSON.raw"
+  extract_verdict_json "$VERDICT_JSON.raw" "$VERDICT_JSON" || { echo "::error::cascade-action did not produce valid JSON"; exit 1; }
+  rm -f "$VERDICT_JSON.raw"
 
   # Post the review using the verdict
   bash scripts/post-pr-review.sh "$PR_URL" "$VERDICT_JSON" "$DRY_RUN"
@@ -364,7 +368,9 @@ export FINAL_TIER="audit"
 VERDICT_JSON="/tmp/cascade/cascade-action-verdict-audit.json"
 OUTPUT_FILE="$VERDICT_JSON"
 export OUTPUT_FILE
-run_agentic prompts/cascade-action.md "$ENGINE_ACTION_MODEL" > "$VERDICT_JSON"
+run_agentic prompts/cascade-action.md "$ENGINE_ACTION_MODEL" > "$VERDICT_JSON.raw"
+extract_verdict_json "$VERDICT_JSON.raw" "$VERDICT_JSON" || { echo "::error::cascade-action (audit) did not produce valid JSON"; exit 1; }
+rm -f "$VERDICT_JSON.raw"
 
 # Post the review using the verdict
 bash scripts/post-pr-review.sh "$PR_URL" "$VERDICT_JSON" "$DRY_RUN"


### PR DESCRIPTION
## Summary
- `claude --print` can output conversational preamble before the JSON verdict, causing `jq` parse failures (exit 5) in the review pipeline
- Added `extract_verdict_json` to `engine.sh` — uses Python to scan for the first valid JSON object with a `decision` field
- Wired all three `run_agentic` → VERDICT_JSON call sites in `review-one-pr.sh` to use the new extractor

## Test plan
- [ ] Trigger `pr-review.yml` against ContentTwin #108 — previously failed with `jq: parse error: Invalid numeric literal at line 1, column 4`
- [ ] Confirm the run completes with a posted approval rather than `exit code 5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)