### PR TITLE
Enforce MAX_REVIEW_CYCLES cap before running the cascade

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -75,9 +75,14 @@ and **Copilot**.
      approve + auto-merge when clean. This creates an autonomous fix loop.
    - **If escalated + no delegation (or max cycles reached):** labels
      `needs-human-review` and re-requests don-petry as reviewer.
-   - **Cycle guard:** after `MAX_REVIEW_CYCLES` (default 3) rounds of AI
-     delegation without resolution, the agent stops delegating and escalates
-     to human to prevent infinite loops.
+   - **Cycle guard:** before running the cascade, `scripts/review-one-pr.sh`
+     counts existing review markers on the PR. If the count is
+     `>= MAX_REVIEW_CYCLES` (default 3), the cascade is skipped entirely;
+     the script posts a single human-escalation comment marked
+     `<!-- pr-review-agent escalation -->`, adds `needs-human-review`, and
+     re-requests don-petry. Subsequent runs detect the escalation marker and
+     no-op without spamming. This prevents infinite review loops on PRs
+     that aren't converging.
 
 5. **Idempotency + iterative review cycles** — every posted review starts with
    an HTML marker on line 1:

--- a/scripts/review-one-pr.sh
+++ b/scripts/review-one-pr.sh
@@ -99,7 +99,7 @@ if [ -n "${EXISTING_MARKER_SHA:-}" ]; then
 fi
 
 # Count how many review cycles we've already done on this PR (number of distinct markers).
-# This prevents infinite AI delegation loops.
+# This prevents infinite review loops (AI-delegation OR cascade-only).
 PR_BODIES=$(
   gh pr view "$PR_URL" --json reviews,comments \
     --jq '((.reviews // []) + (.comments // [])) | .[].body | select(. != null)' 2>/dev/null || true
@@ -137,7 +137,7 @@ Please take a look manually, or close this PR if it's no longer needed. Once a h
 
 _Posted by the don-petry PR-review cascade._
 ESCALATION_END
-    gh pr comment "$PR_URL" --body-file "$ESCALATION_BODY" 2>/dev/null || true
+    gh pr comment "$PR_URL" --body-file "$ESCALATION_BODY" || echo "    warn: gh pr comment failed — escalation marker not posted; will retry next cycle"
     gh pr edit "$PR_URL" --add-label needs-human-review 2>/dev/null || true
     gh pr request-review "$PR_URL" --user don-petry 2>/dev/null || true
     rm -f "$ESCALATION_BODY"
@@ -145,7 +145,6 @@ ESCALATION_END
   echo "{\"pr\":\"$PR_URL\",\"sha\":\"$PR_HEAD_SHA\",\"decision\":\"escalate\",\"reason\":\"max-cycles-reached\"}"
   exit 100
 fi
-unset PR_BODIES
 
 # Detect if the PR's repo org supports AI delegation for automated fix requests.
 # Reads DELEGATION_ORGS (falls back to CLAUDE_ORGS for backward compat).

--- a/scripts/review-one-pr.sh
+++ b/scripts/review-one-pr.sh
@@ -100,13 +100,52 @@ fi
 
 # Count how many review cycles we've already done on this PR (number of distinct markers).
 # This prevents infinite AI delegation loops.
-REVIEW_CYCLE=$(
+PR_BODIES=$(
   gh pr view "$PR_URL" --json reviews,comments \
-    --jq '((.reviews // []) + (.comments // [])) | .[].body | select(. != null)' 2>/dev/null \
-  | grep -cE '<!-- pr-review-agent v1 sha=[a-f0-9]+' || echo 0
+    --jq '((.reviews // []) + (.comments // [])) | .[].body | select(. != null)' 2>/dev/null || true
 )
+REVIEW_CYCLE=$(echo "$PR_BODIES" | grep -cE '<!-- pr-review-agent v1 sha=[a-f0-9]+' || echo 0)
 export REVIEW_CYCLE
-echo "    review cycle: $REVIEW_CYCLE (max: ${MAX_REVIEW_CYCLES:-3})"
+MAX_CYCLES="${MAX_REVIEW_CYCLES:-3}"
+echo "    review cycle: $REVIEW_CYCLE (max: $MAX_CYCLES)"
+
+# Cycle cap: once we've reviewed this PR MAX_REVIEW_CYCLES times without it
+# merging, stop running the cascade and escalate to a human. We post a single
+# escalation comment marked with `<!-- pr-review-agent escalation -->` so
+# subsequent runs detect the marker and no-op without spamming.
+if echo "$PR_BODIES" | grep -qE '<!-- pr-review-agent escalation -->'; then
+  echo "    noop: human-escalation marker present — cascade already capped"
+  echo "{\"pr\":\"$PR_URL\",\"sha\":\"$PR_HEAD_SHA\",\"decision\":\"noop\",\"reason\":\"human-escalated\"}"
+  exit 100
+fi
+
+if [ "$REVIEW_CYCLE" -ge "$MAX_CYCLES" ]; then
+  echo "    cap: review cycle $REVIEW_CYCLE >= max $MAX_CYCLES — escalating to human"
+  if [ "${DRY_RUN:-false}" = "true" ]; then
+    echo "    DRY_RUN: would post escalation comment, add label, request reviewer"
+  else
+    ESCALATION_BODY="/tmp/cascade/escalation-comment.txt"
+    mkdir -p /tmp/cascade
+    cat > "$ESCALATION_BODY" <<ESCALATION_END
+<!-- pr-review-agent escalation -->
+
+## Automated review — human attention needed
+
+This PR has been through $REVIEW_CYCLE automated review cycles (cap: $MAX_CYCLES) without converging on an approval-and-merge state. Further automated review has been paused to avoid infinite loops.
+
+Please take a look manually, or close this PR if it's no longer needed. Once a human review resolves the situation, remove the \`needs-human-review\` label and the cascade can be re-engaged on the next push.
+
+_Posted by the don-petry PR-review cascade._
+ESCALATION_END
+    gh pr comment "$PR_URL" --body-file "$ESCALATION_BODY" 2>/dev/null || true
+    gh pr edit "$PR_URL" --add-label needs-human-review 2>/dev/null || true
+    gh pr request-review "$PR_URL" --user don-petry 2>/dev/null || true
+    rm -f "$ESCALATION_BODY"
+  fi
+  echo "{\"pr\":\"$PR_URL\",\"sha\":\"$PR_HEAD_SHA\",\"decision\":\"escalate\",\"reason\":\"max-cycles-reached\"}"
+  exit 100
+fi
+unset PR_BODIES
 
 # Detect if the PR's repo org supports AI delegation for automated fix requests.
 # Reads DELEGATION_ORGS (falls back to CLAUDE_ORGS for backward compat).


### PR DESCRIPTION
## Summary

- `MAX_REVIEW_CYCLES` was only consulted in `post-pr-review.sh` to switch the *escalate* branch from AI delegation to human label — the cascade itself ran on every cron tick regardless of how many cycles had accumulated. Observed real-world impact: ContentTwin#100 logged `review cycle: 9 (max: 3)` and still ran a full cascade.
- Add a pre-cascade check in [scripts/review-one-pr.sh](scripts/review-one-pr.sh) that, once the count of existing `<!-- pr-review-agent v1 sha=... -->` markers reaches `MAX_REVIEW_CYCLES`, posts one human-attention comment marked `<!-- pr-review-agent escalation -->`, labels `needs-human-review`, requests don-petry, and exits with the skip sentinel (100). The escalation marker doubles as the no-spam guard — later runs see it and exit immediately.
- Reuses a single `gh pr view` call for both the cycle count and the escalation-marker probe.
- Updates [AGENT.md](AGENT.md) so the documented cycle-guard behavior matches the new short-circuit.

Out of scope: the session circuit breaker / triage hard-fail / per-tier timeouts on `claude/practical-cannon-f1a4d4` (commit 4d2aee3) — untouched here.

## Test plan

- [ ] Run a workflow dry-run on a PR with `>= 3` existing review markers and confirm the log shows `cap: review cycle N >= max 3 — escalating to human` and the cascade does not run.
- [ ] Confirm a follow-up dry-run on the same PR sees the escalation marker and prints `noop: human-escalation marker present`.
- [ ] Live-mode run (when ready): verify exactly one escalation comment is posted, `needs-human-review` label is added, and don-petry is re-requested as reviewer.
- [ ] Bump `MAX_REVIEW_CYCLES` to 5 via repo variable on a test repo and confirm the cap moves with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)