### PR TITLE
fix: triage inlines PR context into prompt; drops plan mode

### DIFF
--- a/prompts/triage.md
+++ b/prompts/triage.md
@@ -1,25 +1,14 @@
 # Tier 1: Triage
 
 You are a fast PR triage agent. Your ONLY job is to read the pre-fetched PR
-context below and decide: does this PR need a deeper review, or is it safe
-to approve?
+context provided below and decide: does this PR need a deeper review, or is
+it safe to approve?
 
-You have NO tools. All context is provided in the environment variables below.
-Do not attempt to run commands. Just read and decide.
+You have NO tools. The complete context for the single PR you are triaging
+is inlined below under "## Pre-fetched PR context". Do not look anywhere
+else; the only PR you are triaging is the one whose context appears there.
 
-## Inputs (environment variables, pre-fetched by the orchestrator)
-
-- `$PR_URL` — the PR URL.
-- `$PR_HEAD_SHA` — the head commit SHA.
-- `$PR_METADATA` — JSON from `gh pr view` (title, body, author, files, checks,
-  linked issues, reviews, comments, additions, deletions, etc.).
-- `$PR_DIFF` — the full diff (may be truncated for very large PRs).
-- `$DRY_RUN` — `true` or `false` (for your awareness, you never post anything).
-- `$REVIEW_MODE` — `triage` (always, for you).
-- `$PRIOR_REVIEW_BODY` — if this is a re-review, the body of the prior review.
-  Empty string if first review.
-
-## Your decision criteria
+## Decision criteria
 
 Output `"escalate": false` (approve) if ALL of these are true:
 1. The diff touches NONE of these high-risk areas:
@@ -34,7 +23,7 @@ Output `"escalate": false` (approve) if ALL of these are true:
      broad `except:` swallowing, `dangerouslySetInnerHTML`, etc.
 4. If there's a linked issue, the diff appears to address it (use your judgment).
 5. The PR is well-structured (clear title, reasonable scope).
-6. If `$PRIOR_REVIEW_BODY` is non-empty: the new commits appear to resolve
+6. If a prior review body is included: the new commits appear to resolve
    the findings from the prior review.
 
 Output `"escalate": true` if ANY of those checks fail. When in doubt, escalate.
@@ -42,19 +31,17 @@ False positives are fine (the next tier will sort it out). False negatives are n
 
 ## Output format
 
-Output EXACTLY one JSON object, nothing else. No markdown, no explanation,
-no preamble. Just the JSON:
+Output EXACTLY one JSON object, nothing else. No markdown fences, no
+explanation, no preamble. Just the raw JSON object on its own:
 
-```json
 {
   "escalate": true|false,
   "risk": "LOW|MEDIUM|HIGH",
   "signals": ["<short reason 1>", "<short reason 2>"],
   "summary": "<one sentence describing the PR>"
 }
-```
 
 If `escalate` is `false`, `signals` should be empty or contain only positive
 notes. If `escalate` is `true`, `signals` must list every reason for escalation.
 
-IMPORTANT: Output ONLY the JSON object. No other text.
+IMPORTANT: Output ONLY the JSON object. No code fences. No other text.

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -59,15 +59,22 @@ is_rate_limited() {
 }
 
 # run_triage <prompt_file>
-# No-tool mode: reads pre-fetched context from env vars only.
-# Captures stdout (the model's JSON response).
+# No-tool mode. The prompt file already has all PR context inlined by the
+# caller (review-one-pr.sh builds it). Every tool is denied so the model
+# can't wander into the working directory and discover prs.txt or other
+# state.
+#
+# Note: --permission-mode plan was previously used here but it makes the
+# model propose a plan and ask for approval, which surfaces as conversational
+# text under --print and breaks the JSON contract. With no tools allowed,
+# permission mode is moot — leave it unset so the model just answers.
 run_triage() {
   local prompt_file="$1"
   case "$REVIEW_ENGINE" in
     claude)
       claude --print \
         --model "$ENGINE_TRIAGE_MODEL" \
-        --permission-mode plan \
+        --disallowed-tools "Bash,Read,Write,Edit,Grep,Glob,WebFetch,WebSearch,Task,TodoWrite,NotebookEdit" \
         < "$prompt_file"
       ;;
     copilot)

--- a/scripts/review-one-pr.sh
+++ b/scripts/review-one-pr.sh
@@ -164,23 +164,40 @@ mkdir -p /tmp/cascade
 # --- Tier 1: Triage (fast, no tools, pre-fetched context) ---
 echo "    [tier1] triage ($ENGINE_TRIAGE_MODEL)"
 
-# Pre-fetch all context so the triage tier needs no tool access.
+# Pre-fetch all context. The triage model has NO tools, so we inline every
+# field it needs into the prompt itself. (Earlier versions exported these as
+# env vars and expected the prompt to reference $PR_METADATA / $PR_DIFF —
+# but `claude --print` does not interpolate shell variables into the prompt,
+# so the model only ever saw the literal text "$PR_METADATA" and reported
+# the data as missing. Inlining the values is the fix.)
 PR_METADATA=$(gh pr view "$PR_URL" --json number,title,body,author,isDraft,baseRefName,headRefName,headRefOid,url,headRepository,headRepositoryOwner,labels,reviewDecision,mergeable,mergeStateStatus,statusCheckRollup,reviewRequests,reviews,comments,commits,closingIssuesReferences,additions,deletions,changedFiles,files 2>/dev/null || echo '{}')
-export PR_METADATA
-
 PR_DIFF=$(gh pr diff "$PR_URL" 2>/dev/null | head -3000 || echo "")
-export PR_DIFF
 
-export REVIEW_MODE="triage"
+# Build the triage prompt: static template + inlined PR context.
+TRIAGE_PROMPT_FILE="/tmp/cascade/triage-prompt.md"
+{
+  cat prompts/triage.md
+  printf '\n\n## Pre-fetched PR context\n\n'
+  printf 'PR_URL: %s\n' "$PR_URL"
+  printf 'PR_HEAD_SHA: %s\n' "$PR_HEAD_SHA"
+  printf 'DRY_RUN: %s\n' "${DRY_RUN:-false}"
+  printf 'REVIEW_MODE: triage\n'
+  if [ -n "$PRIOR_REVIEW_BODY" ]; then
+    printf '\nPRIOR_REVIEW_BODY:\n%s\n' "$PRIOR_REVIEW_BODY"
+  else
+    printf 'PRIOR_REVIEW_BODY: (empty — first review)\n'
+  fi
+  printf '\nPR_METADATA (JSON from `gh pr view`):\n%s\n' "$PR_METADATA"
+  printf '\nPR_DIFF (truncated to 3000 lines if larger):\n%s\n' "$PR_DIFF"
+} > "$TRIAGE_PROMPT_FILE"
 
 TRIAGE_LOG="/tmp/cascade/triage.log"
 TRIAGE_RESULT=$(
-  run_triage prompts/triage.md 2>"$TRIAGE_LOG"
+  run_triage "$TRIAGE_PROMPT_FILE" 2>"$TRIAGE_LOG"
 ) || true
 
-# Unset large pre-fetched env vars now that triage has consumed them.
-# PR_DIFF and PR_METADATA can be hundreds of KB; keeping them exported causes
-# E2BIG (Argument list too long) when later subprocesses (jq, claude) are forked.
+# Drop the bulky locals now that the prompt file is on disk. Keeps later
+# subprocess forks (jq, claude) from hitting E2BIG on hundreds-of-KB diffs.
 unset PR_DIFF PR_METADATA
 
 # Detect rate limit before JSON validation — exit 2 so the caller can fall back
@@ -190,6 +207,10 @@ if is_rate_limited "$TRIAGE_RESULT"; then
   echo "    rate limit message: $TRIAGE_RESULT"
   exit 2
 fi
+
+# Strip ```json ... ``` markdown fences if the model wrapped its JSON in
+# them. Haiku tends to add fences despite explicit instructions not to.
+TRIAGE_RESULT=$(printf '%s' "$TRIAGE_RESULT" | sed -E '/^```[a-zA-Z]*$/d; /^```$/d')
 
 # Validate triage output is JSON
 if ! echo "$TRIAGE_RESULT" | jq empty 2>/dev/null; then


### PR DESCRIPTION
## Summary

The triage tier has been silently broken since the cascade landed (`fbec114`): the prompt expected `$PR_METADATA` / `$PR_DIFF` to be interpolated into the prompt body, but `claude --print` does no shell-variable substitution, so Haiku always saw the raw `$PR_METADATA` text and reported the data as missing. A `silent-escalate` fallback in `review-one-pr.sh` synthesized a fake `escalate=MEDIUM` verdict, which kicked every PR up to the deep-review tier — burning Sonnet/Opus tokens on every single PR while the workflow looked healthy.

The session circuit breaker / triage hard-fail in commit `4d2aee3` (on `claude/practical-cannon-f1a4d4`) correctly removed that fallback and finally surfaced the underlying bug, with Tier 1 returning conversational text on https://github.com/petry-projects/ContentTwin/pull/100 instead of JSON.

This PR fixes three things:

- **No env-var substitution**: `scripts/review-one-pr.sh` now builds a self-contained triage prompt at `/tmp/cascade/triage-prompt.md` by concatenating the static template with the actual PR context (URL, SHA, metadata JSON, truncated diff, prior review body). The model gets the data inline, not via env-var interpolation that never happened.
- **`--permission-mode plan` was wrong**: under `--print` with no human, plan mode makes the model propose a plan and ask for approval — that's exactly the "Before I proceed with the plan, I need to understand your intent…" output we saw. Removed; explicit `--disallowed-tools` covers every standard tool so the model has no choice but to answer.
- **`prs.txt` context contamination**: with Read/Glob available in plan mode, Haiku wandered the cwd, found the 31-line candidate pool, and assumed the task was about all of them. Disabling tools eliminates the contamination at the source.

Belt-and-braces: a `sed` step strips ` ```json ... ``` ` fences before `jq empty`, since Haiku still tends to fence its JSON despite the instruction.

## Verification

- Reproduced both symptoms locally: empty env vars produced "PR metadata not provided", and adding `prs.txt` to cwd produced the "31 PRs" output verbatim.
- Ran the patched `scripts/review-one-pr.sh` against PR #100 in `dry_run=true` mode. Triage now returns `escalate=false risk=LOW` and the cascade proceeds to the single-reviewer Opus confirmation as designed. The Opus body even self-diagnosed: *"The recurring re-reviews are caused by a `triage-output-invalid` infrastructure failure in the triage tier"* — exactly the bug this PR fixes.

## Out of scope

Per the bug report, this PR does **not** touch the session circuit breaker / per-tier timeouts / triage hard-fail logic that just landed in `4d2aee3`. That code is correct — it caught this bug. This is a fix on `main` and merges independently of the practical-cannon branch.

## Test plan

- [x] `claude --print --model claude-haiku-4-5-20251001 --disallowed-tools "..." < /tmp/cascade/triage-prompt.md` returns valid JSON
- [x] Markdown-fence-stripped JSON parses with `jq empty`
- [x] Full `scripts/review-one-pr.sh` dry run on https://github.com/petry-projects/ContentTwin/pull/100 completes through Tier 1 → single confirmation → would-post
- [ ] Workflow dispatch on real PR after merge (delegated to maintainer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)