### PR TITLE
Harden triage tier against prompt regressions and timeouts

### DIFF
--- a/prompts/triage.md
+++ b/prompts/triage.md
@@ -4,9 +4,15 @@ You are a fast PR triage agent. Your ONLY job is to read the pre-fetched PR
 context provided below and decide: does this PR need a deeper review, or is
 it safe to approve?
 
-You have NO tools. The complete context for the single PR you are triaging
-is inlined below under "## Pre-fetched PR context". Do not look anywhere
-else; the only PR you are triaging is the one whose context appears there.
+You have NO tools. You CANNOT read files, run commands, or fetch data. Do
+NOT ask clarifying questions. Do NOT propose plans. Do NOT explain your
+intent. The complete context for the single PR you are triaging is inlined
+below under "## Pre-fetched PR context". Do not look anywhere else; the
+only PR you are triaging is the one whose context appears there.
+
+If the inlined context appears incomplete, still emit the JSON output below
+with `"escalate": true` and a signal explaining what was missing — never
+respond with prose.
 
 ## Decision criteria
 

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -15,7 +15,7 @@ export REVIEW_ENGINE
 # Per-tier timeouts (seconds). The job-level 60min cap is a backstop — without
 # per-tier timeouts a single hung model invocation burns the whole hour and
 # blocks every subsequent PR in the session.
-TRIAGE_TIMEOUT_SEC="${TRIAGE_TIMEOUT_SEC:-180}"
+TRIAGE_TIMEOUT_SEC="${TRIAGE_TIMEOUT_SEC:-300}"
 DEEP_TIMEOUT_SEC="${DEEP_TIMEOUT_SEC:-600}"
 AUDIT_TIMEOUT_SEC="${AUDIT_TIMEOUT_SEC:-600}"
 ACTION_TIMEOUT_SEC="${ACTION_TIMEOUT_SEC:-300}"


### PR DESCRIPTION
## Summary

Two recent failures in the PR Review Agent workflow each aborted the hourly batch session-fatally — see the [investigation report](https://github.com/don-petry/pr-review-agent/runs) for full analysis.

- **Run #461**: triage model returned conversational text asking *"Should I triage each PR... Should I design the agent system... Something else?"* instead of the required JSON, breaking the contract.
- **Run #470**: triage process exited 1 on a single PR (likely a timeout or subprocess issue with no diagnostic output captured).

This PR addresses both root causes with minimal, low-risk changes.

## Changes

- **Bump `TRIAGE_TIMEOUT_SEC` default 180s → 300s** ([scripts/engine.sh](scripts/engine.sh)). The 180s cap was tight for large PRs and offered no headroom; 300s matches `ACTION_TIMEOUT_SEC` and reduces the chance of a kill being misclassified as a deterministic failure (kills at 124 are retried; exit 1 is not).
- **Tighten the triage prompt** ([prompts/triage.md](prompts/triage.md)): explicitly forbid clarifying questions, plan proposals, and prose. Add a fallback rule so even on incomplete context the model must still emit JSON (with `escalate=true` and a signal explaining what was missing) rather than respond conversationally.

## Test plan

- [ ] Hourly cron run completes without aborting on the same PR set
- [ ] Verify `TRIAGE_TIMEOUT_SEC=300` shows in the workflow env block
- [ ] Spot-check a triage log to confirm prompt update was picked up
- [ ] Watch the next 24h of runs for any non-JSON failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)