### PR TITLE
Add daily PR review health check workflow

### DIFF
--- a/.github/workflows/daily-pr-review-health.yml
+++ b/.github/workflows/daily-pr-review-health.yml
@@ -19,6 +19,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: daily-pr-review-health

--- a/.github/workflows/daily-pr-review-health.yml
+++ b/.github/workflows/daily-pr-review-health.yml
@@ -4,9 +4,7 @@ on:
   schedule:
     # Daily at 10:00 UTC — covers same-day run history before US work hours
     - cron: '0 10 * * *'
-  push:
-    branches: [claude/confident-gates-cf9485]  # TEMP: remove before merge
-  workflow_dispatch:
+workflow_dispatch:
     inputs:
       lookback_days:
         description: "Days of run history to inspect"

--- a/.github/workflows/daily-pr-review-health.yml
+++ b/.github/workflows/daily-pr-review-health.yml
@@ -1,0 +1,99 @@
+name: Daily PR Review Health Check
+
+on:
+  schedule:
+    # Daily at 10:00 UTC — covers same-day run history before US work hours
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+    inputs:
+      lookback_days:
+        description: "Days of run history to inspect"
+        required: false
+        default: "7"
+        type: string
+      run_limit:
+        description: "Max recent runs to inspect"
+        required: false
+        default: "10"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: daily-pr-review-health
+  cancel-in-progress: true
+
+jobs:
+  health-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      LOOKBACK_DAYS: ${{ inputs.lookback_days || '7' }}
+      RUN_LIMIT: ${{ inputs.run_limit || '10' }}
+
+    steps:
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: petry-projects
+
+      - name: Checkout agent repo
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: '20'
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Run health check
+        env:
+          # App token covers petry-projects scope. If it lacks access to
+          # don-petry/pr-review-agent, set GH_PAT_WORKFLOWS as fallback.
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_PAT_FALLBACK: ${{ secrets.GH_PAT_WORKFLOWS }}
+        run: bash scripts/pr_review_health.sh
+
+      - name: Truncate report if needed
+        run: |
+          if [ -f pr_review_health_report.md ]; then
+            if [ "$(wc -c < pr_review_health_report.md)" -gt 60000 ]; then
+              head -c 60000 pr_review_health_report.md > pr_review_health_report.md.tmp
+              mv pr_review_health_report.md.tmp pr_review_health_report.md
+              printf '\n\n---\n_Report truncated at 60 000 bytes._\n' >> pr_review_health_report.md
+            fi
+          fi
+
+      - name: Create issue with findings
+        if: env.HAS_FAILURES == 'true' && hashFiles('pr_review_health_report.md') != ''
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const fs = require('fs');
+            const report = fs.readFileSync('pr_review_health_report.md', 'utf8');
+            if (!report.trim()) {
+              core.setFailed('Report file is empty');
+              return;
+            }
+            const today = new Date().toISOString().split('T')[0];
+            const issue = await github.rest.issues.create({
+              owner: 'don-petry',
+              repo: 'pr-review-agent',
+              title: `PR Review Agent — failures detected ${today}`,
+              body: report,
+              labels: ['health-check', 'automated-report'],
+            });
+            core.notice(`Issue created: ${issue.data.html_url}`);
+
+      - name: Annotate clean run
+        if: env.HAS_FAILURES != 'true'
+        run: |
+          echo "::notice::Health check passed — no failures in the last ${LOOKBACK_DAYS} days (up to ${RUN_LIMIT} runs inspected)."

--- a/.github/workflows/daily-pr-review-health.yml
+++ b/.github/workflows/daily-pr-review-health.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     # Daily at 10:00 UTC — covers same-day run history before US work hours
     - cron: '0 10 * * *'
+  push:
+    branches: [claude/confident-gates-cf9485]  # TEMP: remove before merge
   workflow_dispatch:
     inputs:
       lookback_days:

--- a/scripts/pr_review_health.sh
+++ b/scripts/pr_review_health.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
-# Daily health check for the PR Review Agent workflow (don-petry/self).
+# Daily health check for the PR Review Agent workflow (don-petry/pr-review-agent).
 #
 # Fetches recent pr-review.yml run logs, feeds them to Claude for pattern
 # analysis, and writes a markdown report to pr_review_health_report.md.
 # Sets HAS_FAILURES=true in $GITHUB_ENV when failed runs are detected.
 #
 # Env vars consumed:
-#   GH_TOKEN              — primary (GitHub App; must have actions:read on don-petry/self)
-#   GH_PAT_FALLBACK       — fallback PAT if App token can't access personal repo
+#   GH_TOKEN              — primary (GitHub App; must have actions:read on this repo)
+#   GH_PAT_FALLBACK       — fallback PAT if App token lacks access
 #   CLAUDE_CODE_OAUTH_TOKEN — passed through to claude CLI
 #   LOOKBACK_DAYS         — days of history to consider (default: 7)
 #   RUN_LIMIT             — max runs to inspect (default: 10)
@@ -35,7 +35,7 @@ echo ""
 # 0. Token selection — App token preferred; PAT fallback for don-petry/self
 # ---------------------------------------------------------------------------
 if ! gh api "repos/${WORKFLOW_REPO}/actions/workflows/${WORKFLOW_FILE}/runs?per_page=1" \
-     --silent >/dev/null 2>&1; then
+     >/dev/null 2>&1; then
   if [ -n "${GH_PAT_FALLBACK:-}" ]; then
     echo "::warning::App token cannot access ${WORKFLOW_REPO} run logs — using GH_PAT_FALLBACK"
     export GH_TOKEN="$GH_PAT_FALLBACK"
@@ -65,10 +65,13 @@ runs_json=$(gh api \
     run_number: .run_number
   })' 2>/dev/null || echo '[]')
 
-total_runs=$(echo "$runs_json" | jq 'length')
-failed_runs=$(echo "$runs_json" | jq '[.[] | select(.conclusion == "failure")] | length')
-success_runs=$(echo "$runs_json" | jq '[.[] | select(.conclusion == "success")] | length')
-cancelled_runs=$(echo "$runs_json" | jq '[.[] | select(.conclusion == "cancelled")] | length')
+read -r total_runs failed_runs success_runs cancelled_runs < <(echo "$runs_json" | jq -r '
+  [
+    length,
+    ([.[] | select(.conclusion == "failure")] | length),
+    ([.[] | select(.conclusion == "success")] | length),
+    ([.[] | select(.conclusion == "cancelled")] | length)
+  ] | @tsv')
 
 echo "  Total runs:   $total_runs"
 echo "  Successful:   $success_runs"
@@ -96,15 +99,14 @@ mkdir -p "$LOG_DIR"
 failed_run_ids=$(echo "$runs_json" | jq -r '.[] | select(.conclusion == "failure") | .id')
 
 for run_id in $failed_run_ids; do
-  log_file="${LOG_DIR}/run_${run_id}.txt"
-  echo "  Downloading logs for run $run_id..."
-  gh run view "$run_id" --repo "$WORKFLOW_REPO" --log 2>/dev/null \
-    | head -c 200000 \
-    > "$log_file" || {
-      echo "  ::warning::Could not fetch logs for run $run_id — skipping"
-      echo "(log unavailable for run $run_id)" > "$log_file"
-    }
+  {
+    gh run view "$run_id" --repo "$WORKFLOW_REPO" --log 2>/dev/null \
+      | head -c 200000 \
+      > "${LOG_DIR}/run_${run_id}.txt" \
+      || echo "(log unavailable for run $run_id)" > "${LOG_DIR}/run_${run_id}.txt"
+  } &
 done
+wait
 echo ""
 
 # ---------------------------------------------------------------------------
@@ -121,21 +123,28 @@ workflow_source=$(gh api \
 RUNS_SUMMARY=$(echo "$runs_json" | jq -r \
   '.[] | "[\(.conclusion // "unknown")] run #\(.run_number) (\(.created_at)) — \(.html_url)"')
 
-all_logs=""
+logs_file=$(mktemp)
+# Pre-compute run metadata as id→label map (one jq pass)
+declare -A run_meta_map
+while IFS=$'\t' read -r rid label; do
+  run_meta_map["$rid"]="$label"
+done < <(echo "$runs_json" | jq -r \
+  '.[] | [(.id | tostring), "run #\(.run_number) (\(.conclusion)) at \(.created_at)"] | @tsv')
+
 for log_file in "$LOG_DIR"/run_*.txt; do
   [ -f "$log_file" ] || continue
   run_id=$(basename "$log_file" .txt | sed 's/run_//')
-  run_meta=$(echo "$runs_json" | jq -r --argjson id "$run_id" \
-    '.[] | select(.id == $id) | "run #\(.run_number) (\(.conclusion)) at \(.created_at)"' 2>/dev/null \
-    || echo "run $run_id")
-  all_logs="${all_logs}
-=== LOG: ${run_meta} ===
-$(cat "$log_file")
-=== END LOG ===
-"
+  run_meta="${run_meta_map[$run_id]:-run $run_id}"
+  {
+    printf '=== LOG: %s ===\n' "$run_meta"
+    cat "$log_file"
+    printf '=== END LOG ===\n\n'
+  } >> "$logs_file"
 done
 
-PROMPT="You are analyzing GitHub Actions workflow run logs for the PR Review Agent.
+echo "Invoking Claude for log analysis..."
+claude --print --model claude-sonnet-4-6 > "$REPORT_FILE" <<PROMPT
+You are analyzing GitHub Actions workflow run logs for the PR Review Agent.
 
 ## Context
 - Workflow: \`${WORKFLOW_FILE}\` in repo \`${WORKFLOW_REPO}\`
@@ -152,7 +161,7 @@ ${workflow_source}
 \`\`\`
 
 ## Failed Run Logs
-${all_logs}
+$(cat "$logs_file")
 
 ---
 
@@ -189,10 +198,9 @@ Mark CRITICAL if the issue causes 100% workflow failure.
 Single line: \`Health: X/10 — <one-sentence verdict>\`
 (10 = all runs passing; 0 = complete outage)
 
-Output ONLY the markdown report — no preamble or commentary outside the report sections."
-
-echo "Invoking Claude for log analysis..."
-claude --print --model claude-sonnet-4-6 <<< "$PROMPT" > "$REPORT_FILE"
+Output ONLY the markdown report — no preamble or commentary outside the report sections.
+PROMPT
+rm -f "$logs_file"
 
 echo ""
 echo "Report written to $REPORT_FILE ($(wc -c < "$REPORT_FILE") bytes)"

--- a/scripts/pr_review_health.sh
+++ b/scripts/pr_review_health.sh
@@ -124,23 +124,17 @@ RUNS_SUMMARY=$(echo "$runs_json" | jq -r \
   '.[] | "[\(.conclusion // "unknown")] run #\(.run_number) (\(.created_at)) — \(.html_url)"')
 
 logs_file=$(mktemp)
-# Pre-compute run metadata as id→label map (one jq pass)
-declare -A run_meta_map  # requires bash 4+ (ubuntu-latest ships bash 5)
-while IFS=$'\t' read -r rid label; do
-  run_meta_map["$rid"]="$label"
-done < <(echo "$runs_json" | jq -r \
-  '.[] | [(.id | tostring), "run #\(.run_number) (\(.conclusion)) at \(.created_at)"] | @tsv')
-
-for log_file in "$LOG_DIR"/run_*.txt; do
+# One jq pass over failed runs; append each log file in the same order
+while IFS=$'\t' read -r run_id run_meta; do
+  log_file="${LOG_DIR}/run_${run_id}.txt"
   [ -f "$log_file" ] || continue
-  run_id=$(basename "$log_file" .txt | sed 's/run_//')
-  run_meta="${run_meta_map[$run_id]:-run $run_id}"
   {
     printf '=== LOG: %s ===\n' "$run_meta"
     cat "$log_file"
     printf '=== END LOG ===\n\n'
   } >> "$logs_file"
-done
+done < <(echo "$runs_json" | jq -r \
+  '.[] | select(.conclusion == "failure") | [(.id | tostring), "run #\(.run_number) (\(.conclusion)) at \(.created_at)"] | @tsv')
 
 echo "Invoking Claude for log analysis..."
 claude --print --model claude-sonnet-4-6 > "$REPORT_FILE" <<PROMPT

--- a/scripts/pr_review_health.sh
+++ b/scripts/pr_review_health.sh
@@ -32,7 +32,7 @@ echo "  Date:         $TODAY"
 echo ""
 
 # ---------------------------------------------------------------------------
-# 0. Token selection — App token preferred; PAT fallback for don-petry/self
+# 0. Token selection — App token preferred; PAT fallback for don-petry/pr-review-agent
 # ---------------------------------------------------------------------------
 if ! gh api "repos/${WORKFLOW_REPO}/actions/workflows/${WORKFLOW_FILE}/runs?per_page=1" \
      >/dev/null 2>&1; then
@@ -125,7 +125,7 @@ RUNS_SUMMARY=$(echo "$runs_json" | jq -r \
 
 logs_file=$(mktemp)
 # Pre-compute run metadata as id→label map (one jq pass)
-declare -A run_meta_map
+declare -A run_meta_map  # requires bash 4+ (ubuntu-latest ships bash 5)
 while IFS=$'\t' read -r rid label; do
   run_meta_map["$rid"]="$label"
 done < <(echo "$runs_json" | jq -r \

--- a/scripts/pr_review_health.sh
+++ b/scripts/pr_review_health.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# Daily health check for the PR Review Agent workflow (don-petry/self).
+#
+# Fetches recent pr-review.yml run logs, feeds them to Claude for pattern
+# analysis, and writes a markdown report to pr_review_health_report.md.
+# Sets HAS_FAILURES=true in $GITHUB_ENV when failed runs are detected.
+#
+# Env vars consumed:
+#   GH_TOKEN              — primary (GitHub App; must have actions:read on don-petry/self)
+#   GH_PAT_FALLBACK       — fallback PAT if App token can't access personal repo
+#   CLAUDE_CODE_OAUTH_TOKEN — passed through to claude CLI
+#   LOOKBACK_DAYS         — days of history to consider (default: 7)
+#   RUN_LIMIT             — max runs to inspect (default: 10)
+#   GITHUB_ENV            — written by Actions runner; used to export HAS_FAILURES
+
+set -euo pipefail
+
+LOOKBACK_DAYS="${LOOKBACK_DAYS:-7}"
+RUN_LIMIT="${RUN_LIMIT:-10}"
+WORKFLOW_REPO="don-petry/pr-review-agent"
+WORKFLOW_FILE="pr-review.yml"
+REPORT_FILE="pr_review_health_report.md"
+LOG_DIR="health_run_logs"
+TODAY=$(date -u +%Y-%m-%d)
+
+echo "=== PR Review Agent — Daily Health Check ==="
+echo "  Repo:         $WORKFLOW_REPO"
+echo "  Workflow:     $WORKFLOW_FILE"
+echo "  Lookback:     ${LOOKBACK_DAYS} days"
+echo "  Max runs:     $RUN_LIMIT"
+echo "  Date:         $TODAY"
+echo ""
+
+# ---------------------------------------------------------------------------
+# 0. Token selection — App token preferred; PAT fallback for don-petry/self
+# ---------------------------------------------------------------------------
+if ! gh api "repos/${WORKFLOW_REPO}/actions/workflows/${WORKFLOW_FILE}/runs?per_page=1" \
+     --silent >/dev/null 2>&1; then
+  if [ -n "${GH_PAT_FALLBACK:-}" ]; then
+    echo "::warning::App token cannot access ${WORKFLOW_REPO} run logs — using GH_PAT_FALLBACK"
+    export GH_TOKEN="$GH_PAT_FALLBACK"
+  else
+    echo "::error::App token cannot access ${WORKFLOW_REPO} run logs and GH_PAT_FALLBACK is not set."
+    echo "::error::Grant the GitHub App access to ${WORKFLOW_REPO} or set the GH_PAT_WORKFLOWS secret."
+    exit 1
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 1. Fetch recent run metadata
+# ---------------------------------------------------------------------------
+# GNU date: date -d "N days ago"; macOS: date -v-Nd
+CUTOFF=$(date -u -d "${LOOKBACK_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+  || date -u -v-"${LOOKBACK_DAYS}"d +%Y-%m-%dT%H:%M:%SZ)
+
+echo "Fetching run list (cutoff: $CUTOFF)..."
+runs_json=$(gh api \
+  "repos/${WORKFLOW_REPO}/actions/workflows/${WORKFLOW_FILE}/runs?per_page=${RUN_LIMIT}&created=>=${CUTOFF}" \
+  --jq '.workflow_runs | map({
+    id: .id,
+    status: .status,
+    conclusion: .conclusion,
+    created_at: .created_at,
+    html_url: .html_url,
+    run_number: .run_number
+  })' 2>/dev/null || echo '[]')
+
+total_runs=$(echo "$runs_json" | jq 'length')
+failed_runs=$(echo "$runs_json" | jq '[.[] | select(.conclusion == "failure")] | length')
+success_runs=$(echo "$runs_json" | jq '[.[] | select(.conclusion == "success")] | length')
+cancelled_runs=$(echo "$runs_json" | jq '[.[] | select(.conclusion == "cancelled")] | length')
+
+echo "  Total runs:   $total_runs"
+echo "  Successful:   $success_runs"
+echo "  Failed:       $failed_runs"
+echo "  Cancelled:    $cancelled_runs"
+echo ""
+
+# ---------------------------------------------------------------------------
+# 2. Early exit when no failures
+# ---------------------------------------------------------------------------
+if [ "$failed_runs" -eq 0 ]; then
+  echo "No failed runs in the last ${LOOKBACK_DAYS} days. Health check passed."
+  printf '# PR Review Agent Health Check — %s\n\nAll %d run(s) inspected over the last %d days succeeded. No action required.\n' \
+    "$TODAY" "$total_runs" "$LOOKBACK_DAYS" > "$REPORT_FILE"
+  exit 0
+fi
+
+# Export flag for workflow step condition
+[ -n "${GITHUB_ENV:-}" ] && echo "HAS_FAILURES=true" >> "$GITHUB_ENV"
+
+# ---------------------------------------------------------------------------
+# 3. Download logs for failed runs
+# ---------------------------------------------------------------------------
+mkdir -p "$LOG_DIR"
+failed_run_ids=$(echo "$runs_json" | jq -r '.[] | select(.conclusion == "failure") | .id')
+
+for run_id in $failed_run_ids; do
+  log_file="${LOG_DIR}/run_${run_id}.txt"
+  echo "  Downloading logs for run $run_id..."
+  gh run view "$run_id" --repo "$WORKFLOW_REPO" --log 2>/dev/null \
+    | head -c 200000 \
+    > "$log_file" || {
+      echo "  ::warning::Could not fetch logs for run $run_id — skipping"
+      echo "(log unavailable for run $run_id)" > "$log_file"
+    }
+done
+echo ""
+
+# ---------------------------------------------------------------------------
+# 4. Fetch workflow source for token/permission context
+# ---------------------------------------------------------------------------
+echo "Fetching ${WORKFLOW_FILE} source..."
+workflow_source=$(gh api \
+  "repos/${WORKFLOW_REPO}/contents/.github/workflows/${WORKFLOW_FILE}" \
+  --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || echo "(workflow source unavailable)")
+
+# ---------------------------------------------------------------------------
+# 5. Build analysis prompt and invoke Claude
+# ---------------------------------------------------------------------------
+RUNS_SUMMARY=$(echo "$runs_json" | jq -r \
+  '.[] | "[\(.conclusion // "unknown")] run #\(.run_number) (\(.created_at)) — \(.html_url)"')
+
+all_logs=""
+for log_file in "$LOG_DIR"/run_*.txt; do
+  [ -f "$log_file" ] || continue
+  run_id=$(basename "$log_file" .txt | sed 's/run_//')
+  run_meta=$(echo "$runs_json" | jq -r --argjson id "$run_id" \
+    '.[] | select(.id == $id) | "run #\(.run_number) (\(.conclusion)) at \(.created_at)"' 2>/dev/null \
+    || echo "run $run_id")
+  all_logs="${all_logs}
+=== LOG: ${run_meta} ===
+$(cat "$log_file")
+=== END LOG ===
+"
+done
+
+PROMPT="You are analyzing GitHub Actions workflow run logs for the PR Review Agent.
+
+## Context
+- Workflow: \`${WORKFLOW_FILE}\` in repo \`${WORKFLOW_REPO}\`
+- Analysis window: last ${LOOKBACK_DAYS} days, up to ${RUN_LIMIT} most recent runs
+- Report date: ${TODAY}
+- Total runs fetched: ${total_runs} | Successful: ${success_runs} | Failed: ${failed_runs} | Cancelled: ${cancelled_runs}
+
+## Run Summary
+${RUNS_SUMMARY}
+
+## Workflow Source (.github/workflows/${WORKFLOW_FILE})
+\`\`\`yaml
+${workflow_source}
+\`\`\`
+
+## Failed Run Logs
+${all_logs}
+
+---
+
+Analyze these logs and produce a markdown health report with the following sections:
+
+### 1. Executive Summary
+One paragraph: how many runs failed vs succeeded, the dominant failure cause, and urgency level (BLOCKING / DEGRADED / WARNING).
+
+### 2. Failure Breakdown
+A table with columns: Failure Category | Affected Runs | Example Error Message.
+Categories to look for (not exhaustive):
+- CLI breaking change (e.g. invalid flag values)
+- Permission / auth error (403, 401, insufficient scope)
+- GitHub API rate limit
+- Missing token scope (e.g. read:org, read:packages)
+- Engine rate limit (Claude or Copilot quota)
+- Timeout / infrastructure
+- Other / unknown
+
+### 3. Error Patterns
+For each category found: quote the exact error message from the logs, identify which step and script it comes from, and explain the root cause.
+
+### 4. Token Scope Analysis
+From the workflow source and any gh auth status output in the logs, list:
+- Scopes currently present
+- Scopes that appear missing or insufficient based on the errors
+- Recommendation for each missing scope
+
+### 5. Recommendations
+Numbered list. For each issue include: what to change (file, line, command), why, expected impact after fix, and urgency: [CRITICAL | HIGH | MEDIUM | LOW].
+Mark CRITICAL if the issue causes 100% workflow failure.
+
+### 6. Health Score
+Single line: \`Health: X/10 — <one-sentence verdict>\`
+(10 = all runs passing; 0 = complete outage)
+
+Output ONLY the markdown report — no preamble or commentary outside the report sections."
+
+echo "Invoking Claude for log analysis..."
+claude --print --model claude-sonnet-4-6 <<< "$PROMPT" > "$REPORT_FILE"
+
+echo ""
+echo "Report written to $REPORT_FILE ($(wc -c < "$REPORT_FILE") bytes)"
+echo "=== Health check complete ==="


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/daily-pr-review-health.yml` — runs daily at 10:00 UTC, fetches recent `pr-review.yml` run logs, invokes Claude to analyze failure patterns, and opens an issue in this repo when failures are detected. Silent on clean runs.
- Adds `scripts/pr_review_health.sh` — fetches run metadata + full logs via `gh api`/`gh run view`, builds a structured prompt, and pipes it to `claude --print` for analysis. Produces a report with Executive Summary, Failure Breakdown table, Error Patterns, Token Scope Analysis, Recommendations (CRITICAL/HIGH/MEDIUM/LOW), and Health Score.

## Test plan
- [ ] Trigger manually: `gh workflow run daily-pr-review-health.yml`
- [ ] Verify "Run health check" step completes and produces `pr_review_health_report.md`
- [ ] With recent failures present: confirm an issue is opened with the analysis report
- [ ] With no failures: confirm the workflow exits green with no issue created

## Notes
- Uses the existing GitHub App token (`APP_ID` + `APP_PRIVATE_KEY`) with `GH_PAT_WORKFLOWS` as fallback if the App lacks access to this repo's run logs
- All action versions pinned to commit SHAs

🤖 Generated with [Claude Code](https://claude.com/claude-code)