### PR TITLE
fix(health-check): remove undefined RUN_LIMIT variable

### DIFF
--- a/scripts/pr_review_health.sh
+++ b/scripts/pr_review_health.sh
@@ -142,7 +142,7 @@ You are analyzing GitHub Actions workflow run logs for the PR Review Agent.
 
 ## Context
 - Workflow: \`${WORKFLOW_FILE}\` in repo \`${WORKFLOW_REPO}\`
-- Analysis window: last ${LOOKBACK_DAYS} days, up to ${RUN_LIMIT} most recent runs
+- Analysis window: last ${LOOKBACK_DAYS} days, up to 100 most recent runs
 - Report date: ${TODAY}
 - Total runs fetched: ${total_runs} | Successful: ${success_runs} | Failed: ${failed_runs} | Cancelled: ${cancelled_runs}
 


### PR DESCRIPTION
## Summary
- `scripts/pr_review_health.sh` referenced `${RUN_LIMIT}` inside a heredoc, but the variable was never defined anywhere in the script
- With `set -euo pipefail` active, bash exits with "unbound variable" on line 140 every time the script reaches the Claude invocation
- Fixed by replacing `${RUN_LIMIT}` with the literal `100`, which matches the `per_page=100` used in the GitHub API call on line 58

## Test plan
- [ ] Confirm the next scheduled health-check run completes successfully (no more "unbound variable" error at line 140)
- [ ] Verify the Claude prompt still renders correctly with `100` hardcoded

🤖 Generated with [Claude Code](https://claude.com/claude-code)