### PR TITLE
fix(health-check): use github.token for issue creation instead of bot PAT

### DIFF
--- a/.github/workflows/daily-pr-review-health.yml
+++ b/.github/workflows/daily-pr-review-health.yml
@@ -62,7 +62,7 @@ jobs:
         if: env.HAS_FAILURES == 'true' && hashFiles('pr_review_health_report.md') != ''
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
-          github-token: ${{ secrets.DON_PETRY_BOT_PETRY_PROJECT_PAT }}
+          github-token: ${{ github.token }}
           script: |
             const fs = require('fs');
             const report = fs.readFileSync('pr_review_health_report.md', 'utf8');

--- a/scripts/pr_review_health.sh
+++ b/scripts/pr_review_health.sh
@@ -142,7 +142,7 @@ You are analyzing GitHub Actions workflow run logs for the PR Review Agent.
 
 ## Context
 - Workflow: \`${WORKFLOW_FILE}\` in repo \`${WORKFLOW_REPO}\`
-- Analysis window: last ${LOOKBACK_DAYS} days, up to ${RUN_LIMIT} most recent runs
+- Analysis window: last ${LOOKBACK_DAYS} days, up to 100 most recent runs
 - Report date: ${TODAY}
 - Total runs fetched: ${total_runs} | Successful: ${success_runs} | Failed: ${failed_runs} | Cancelled: ${cancelled_runs}
 


### PR DESCRIPTION
## Summary
- The "Create issue with findings" step used `DON_PETRY_BOT_PETRY_PROJECT_PAT`, which doesn't have `issues:write` on `don-petry/pr-review-agent`, causing a 403 on every run that detects failures
- The workflow already declares `issues: write` in its top-level permissions block, so `github.token` is the correct and sufficient token for this step

## Test plan
- [ ] Trigger a manual run of the Daily PR Review Health Check workflow with failures present; confirm the issue is created without a 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)