### PR TITLE
ci: add dependabot-automerge.yml workflow

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,39 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/dependabot-automerge.yml
+# Standard:        petry-projects/.github/standards/dependabot-policy.md
+# Reusable:        petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml
+#
+# AGENTS — READ BEFORE EDITING:
+#   • This file is a THIN CALLER STUB. All eligibility logic and the GitHub
+#     App token dance live in the reusable workflow above.
+#   • You MAY change: nothing in this file in normal use. Adopt verbatim.
+#   • You MUST NOT change: trigger event (must be `pull_request_target`),
+#     the `uses:` line, `secrets: inherit`, or the job-level `permissions:`
+#     block — reusable workflows can be granted no more permissions than the
+#     calling job has, so removing the stanza breaks the reusable's gh API
+#     calls.
+#   • If you need different behaviour, open a PR against the reusable in the
+#     central repo.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Dependabot auto-merge — thin caller for the org-level reusable.
+# To adopt: copy this file to .github/workflows/dependabot-automerge.yml in your repo.
+# Required org/repo secrets (inherited):
+#   APP_ID         — GitHub App ID with contents:write and pull-requests:write
+#   APP_PRIVATE_KEY — GitHub App private key
+name: Dependabot auto-merge
+
+on:
+  pull_request_target:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  dependabot-automerge:
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@v1
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Adds the required `dependabot-automerge.yml` workflow file copied verbatim from the org standard template at `petry-projects/.github/standards/workflows/dependabot-automerge.yml`
- This is a thin caller stub that delegates all eligibility logic to the org-level reusable workflow `petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@v1`
- No customization needed — the file is adopted exactly as specified by the standard

## Closes

Closes #48

---
Generated with [Claude Code](https://claude.ai/code)