### PR TITLE
ci: add sonarcloud.yml and sonar-project.properties

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,26 @@
+name: SonarCloud Analysis
+
+permissions: {}
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: SonarCloud Scan
+        if: ${{ env.SONAR_TOKEN != '' }}
+        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,5 @@
+sonar.projectKey=petry-projects_.github-private
+sonar.organization=petry-projects
+sonar.projectName=.github-private
+sonar.sources=.
+sonar.exclusions=_bmad/**,_bmad-output/**,.claude/**


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/sonarcloud.yml` following the Tier 2 per-repo pattern from [ci-standards.md §3](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#3-sonarcloud-analysis-sonarcloudyml)
- Copies the exact standard configuration (SHA-pinned actions, correct permissions, `SONAR_TOKEN` guard)
- Adds `sonar-project.properties` with project key `petry-projects_.github-private`, org `petry-projects`, modeled on the `broodly` repo pattern

## Test plan

- [ ] Confirm SonarCloud scan triggers on push to `main` after merge
- [ ] Confirm `SONAR_TOKEN` org secret is inherited (no additional config needed)
- [ ] Confirm compliance audit clears the `missing-sonarcloud.yml` finding on next run

Closes #47

Generated with [Claude Code](https://claude.ai/code)