### PR TITLE
feat: enable allow_auto_merge and add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,39 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/dependabot-automerge.yml
+# Standard:        petry-projects/.github/standards/dependabot-policy.md
+# Reusable:        petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml
+#
+# AGENTS — READ BEFORE EDITING:
+#   • This file is a THIN CALLER STUB. All eligibility logic and the GitHub
+#     App token dance live in the reusable workflow above.
+#   • You MAY change: nothing in this file in normal use. Adopt verbatim.
+#   • You MUST NOT change: trigger event (must be `pull_request_target`),
+#     the `uses:` line, `secrets: inherit`, or the job-level `permissions:`
+#     block — reusable workflows can be granted no more permissions than the
+#     calling job has, so removing the stanza breaks the reusable's gh API
+#     calls.
+#   • If you need different behaviour, open a PR against the reusable in the
+#     central repo.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Dependabot auto-merge — thin caller for the org-level reusable.
+# To adopt: copy this file to .github/workflows/dependabot-automerge.yml in your repo.
+# Required org/repo secrets (inherited):
+#   APP_ID         — GitHub App ID with contents:write and pull-requests:write
+#   APP_PRIVATE_KEY — GitHub App private key
+name: Dependabot auto-merge
+
+on:
+  pull_request_target:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  dependabot-automerge:
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@v1
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/dependabot-automerge.yml` verbatim from the org standard template (`petry-projects/.github/standards/workflows/dependabot-automerge.yml`)
- The `allow_auto_merge` repository setting was flipped to `true` out-of-band via the GitHub API (see note below). This PR does **not** include a settings-as-code change because this codebase has no settings-as-code mechanism (no `settings.yml` / Probot Settings App, no Terraform/Pulumi config) — repository settings are managed manually per the org standard.

## Why

The weekly compliance audit flagged this repository as non-compliant because `allow_auto_merge` was `false`. Per the [standards](https://github.com/petry-projects/.github/blob/main/standards/github-settings.md#repository-settings--standard-defaults), this setting must be `true` to support the Dependabot auto-merge workflow.

The `dependabot-automerge.yml` workflow is a thin caller stub that delegates to the org-level reusable workflow (`dependabot-automerge-reusable.yml@v1`). All eligibility logic and the GitHub App token dance live in that reusable workflow.

## Note on `allow_auto_merge` (addresses Copilot review feedback)

The reviewer correctly pointed out that the original PR description implied a code change that does not exist in the diff. To clarify:

- **What this PR contains:** the workflow file only.
- **What was changed out-of-band:** `allow_auto_merge=true`, applied directly via `PATCH /repos/petry-projects/.github-private` because there is no settings-as-code surface in this repo.
- **Audit follow-up:** if a settings-as-code mechanism is later adopted org-wide, this repo's `allow_auto_merge: true` value should be captured there to keep future audits green without manual intervention.

Closes #56

Generated with [Claude Code](https://claude.ai/code)