### PR TITLE
fix: replace individual owners with @petry-projects/org-leads in CODEOWNERS

### DIFF
--- a/frameworks/gsd/.github/CODEOWNERS
+++ b/frameworks/gsd/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # All changes require review from project owner
-* @glittercowboy
+* @petry-projects/org-leads

--- a/frameworks/spec-kit/.github/CODEOWNERS
+++ b/frameworks/spec-kit/.github/CODEOWNERS
@@ -1,8 +1,7 @@
 # Global code owner
-* @mnriem
+* @petry-projects/org-leads
 
 # Community catalog files — explicit ownership for when global ownership expands
-/extensions/catalog.community.json @mnriem
-/integrations/catalog.community.json @mnriem
-/presets/catalog.community.json @mnriem
-
+/extensions/catalog.community.json @petry-projects/org-leads
+/integrations/catalog.community.json @petry-projects/org-leads
+/presets/catalog.community.json @petry-projects/org-leads


### PR DESCRIPTION
## Summary

- Replaces individual user `@glittercowboy` in `frameworks/gsd/.github/CODEOWNERS` with `@petry-projects/org-leads`
- Replaces individual user `@mnriem` in `frameworks/spec-kit/.github/CODEOWNERS` with `@petry-projects/org-leads` on all owner lines

Per the [CODEOWNERS standard](https://github.com/petry-projects/.github/blob/main/standards/codeowners-standard.md):
- `@petry-projects/org-leads` must be the **first** owner on every owner line
- Individual named users are **forbidden** as owners

Closes #61

Generated with [Claude Code](https://claude.ai/code)