### PR TITLE
fix: add CODEOWNERS with catch-all pattern

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for all files
+* @petry-projects/org-leads


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` with `* @petry-projects/org-leads` as the default catch-all owner
- Ensures all files have an owner so `require_code_owner_review` applies repo-wide
- Follows the [codeowners-standard.md](https://github.com/petry-projects/.github/blob/main/standards/codeowners-standard.md): `@petry-projects/org-leads` is the first (and only) owner on the catch-all line, using a team slug (no individual users)

## Test plan

- [ ] Verify compliance audit no longer raises `codeowners-no-catchall` for this repo
- [ ] Confirm `require_code_owner_review` is satisfied by members of `@petry-projects/org-leads`

Closes #62

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration for code ownership management.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/petry-projects/.github-private/pull/83)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->