### PR TITLE
chore: rename GH_PAT_WORKFLOWS secret to DON_PETRY_BOT_GH_PAT

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
-          token: ${{ secrets.GH_PAT_WORKFLOWS || github.token }}
+          token: ${{ secrets.DON_PETRY_BOT_GH_PAT || github.token }}
       - name: Run Claude Code
         uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de # v1.0.89
         with:
@@ -75,11 +75,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
-          token: ${{ secrets.GH_PAT_WORKFLOWS || github.token }}
+          token: ${{ secrets.DON_PETRY_BOT_GH_PAT || github.token }}
       - name: Check for existing open PR
         id: dedup
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS || github.token }}
+          GH_TOKEN: ${{ secrets.DON_PETRY_BOT_GH_PAT || github.token }}
           ISSUE: ${{ github.event.issue.number }}
         run: |
           # Search by branch prefix (claude/issue-NNN-*)
@@ -114,7 +114,7 @@ jobs:
         uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de # v1.0.89
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GH_PAT_WORKFLOWS }}
+          github_token: ${{ secrets.DON_PETRY_BOT_GH_PAT }}
           label_trigger: "claude"
           track_progress: "true"
           additional_permissions: |

--- a/.github/workflows/daily-pr-review-health.yml
+++ b/.github/workflows/daily-pr-review-health.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Run health check
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
+          GH_TOKEN: ${{ secrets.DON_PETRY_BOT_GH_PAT }}
         run: bash scripts/pr_review_health.sh
 
       - name: Truncate report if needed

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -44,8 +44,8 @@ jobs:
     timeout-minutes: 60
     env:
       # Auth for every gh / script call in this job. The PAT must belong to BOT_USER.
-      GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
-      # Single bot identity. GH_PAT_WORKFLOWS authenticates as BOT_USER; that
+      GH_TOKEN: ${{ secrets.DON_PETRY_BOT_GH_PAT }}
+      # Single bot identity. DON_PETRY_BOT_GH_PAT authenticates as BOT_USER; that
       # account owns/has-access-to the personal repos scanned by list-prs.sh,
       # signs the cascade's escalation comments, and is filtered out of the
       # candidate queue (it can't approve its own PRs). Human reviewers are

--- a/.github/workflows/repair-pr-approvals.yml
+++ b/.github/workflows/repair-pr-approvals.yml
@@ -22,5 +22,5 @@ jobs:
 
       - name: Repair PR approvals
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
+          GH_TOKEN: ${{ secrets.DON_PETRY_BOT_GH_PAT }}
         run: bash scripts/repair-pr-approvals.sh "${{ inputs.dry_run }}"

--- a/scripts/pr_review_health.sh
+++ b/scripts/pr_review_health.sh
@@ -39,7 +39,7 @@ if ! gh api "repos/${WORKFLOW_REPO}/actions/workflows/${WORKFLOW_FILE}/runs?per_
     export GH_TOKEN="$GH_PAT_FALLBACK"
   else
     echo "::error::App token cannot access ${WORKFLOW_REPO} run logs and GH_PAT_FALLBACK is not set."
-    echo "::error::Grant the GitHub App access to ${WORKFLOW_REPO} or set the GH_PAT_WORKFLOWS secret."
+    echo "::error::Grant the GitHub App access to ${WORKFLOW_REPO} or set the DON_PETRY_BOT_GH_PAT secret."
     exit 1
   fi
 fi


### PR DESCRIPTION
## Why

`GH_PAT_WORKFLOWS` is a generic name that doesn't tell you which account owns the PAT. Renaming to `DON_PETRY_BOT_GH_PAT` makes the identity-credential binding explicit and matches the `BOT_USER=don-petry-bot` model introduced in #97.

## Required operator action **before** merging

1. In repo settings → Secrets and variables → Actions, add a new secret named `DON_PETRY_BOT_GH_PAT` with the value of `don-petry-bot`'s PAT (scopes: `repo`, `workflow`, `read:org`).
2. Merge this PR.
3. Delete the old `GH_PAT_WORKFLOWS` secret once nothing else references it.

If the new secret is missing at merge time, the PR-review workflow will run with an empty `GH_TOKEN` and every `gh` call will fail. (The `claude.yml` workflow falls back to `github.token`, so it'll still execute, just with reduced scope.)

## Affected files

- `.github/workflows/pr-review.yml` (1 reference + 1 comment)
- `.github/workflows/claude.yml` (4 references, all keep `|| github.token` fallback)
- `.github/workflows/daily-pr-review-health.yml` (1 reference)
- `.github/workflows/repair-pr-approvals.yml` (1 reference)
- `scripts/pr_review_health.sh` (error-message string)

No behavior change beyond the secret-name lookup.

https://claude.ai/code/session_01EacTxiHSUhR6kxppXpmxig

---
_Generated by [Claude Code](https://claude.ai/code/session_01EacTxiHSUhR6kxppXpmxig)_