### PR TITLE
fix(pr-review): detect provider usage-cap and fall back to next engine

### DIFF
--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -86,7 +86,7 @@ echo "    engine: $REVIEW_ENGINE ($ENGINE_LABEL)"
 is_rate_limited() {
   local text="$1"
   echo "$text" | grep -qiE \
-    "(hit your limit|rate[ -]?limit|resets [0-9]+(am|pm)|usage limit|quota exceeded|too many requests|exceeded.*quota|([^0-9]|^)429([^0-9]|$)|exhausted|out of.*token|token.*exhaust|plan.*limit|subscription.*limit|billing.*limit|([^0-9]|^)402([^0-9]|$)|([^0-9]|^)529([^0-9]|$))"
+    "(hit your limit|rate[ -]?limit|resets [0-9]+(am|pm)|usage limit|quota exceeded|too many requests|exceeded.*quota|([^0-9]|^)429([^0-9]|$)|exhausted|out of.*token|token.*exhaust|claude.*usage|usage.*claude|plan.*limit|subscription.*limit|billing.*limit|daily.*limit|monthly.*limit|([^0-9]|^)402([^0-9]|$)|([^0-9]|^)529([^0-9]|$))"
 }
 
 # is_transient_failure <exit_code>

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -79,17 +79,14 @@ export DUCK_ENGINE DUCK_MODEL
 echo "    engine: $REVIEW_ENGINE ($ENGINE_LABEL)"
 
 # is_rate_limited <text>
-# Returns 0 (true) if the text looks like a provider usage/rate-limit block.
-# Covers three distinct failure modes that all warrant an engine fallback:
-#   1. API-level rate limits (429, "too many requests", per-minute quotas)
-#   2. Subscription/billing caps ("usage limit", "out of tokens", plan limits,
-#      Claude Code's "you've exceeded your Claude AI usage" messages, HTTP 402)
-#   3. Service overload that acts like a hard block (529)
+# Returns 0 (true) if the text looks like a provider usage/rate-limit block —
+# API-level (429), subscription/billing caps (plan limit, out of tokens, HTTP 402),
+# or service overload acting as a hard block (529).
 # review-one-pr.sh exits with code 2 when this fires so the caller can switch engines.
 is_rate_limited() {
   local text="$1"
   echo "$text" | grep -qiE \
-    "(hit your limit|rate[ -]?limit|resets [0-9]+(am|pm)|usage limit|quota exceeded|too many requests|exceeded.*quota|([^0-9]|^)429([^0-9]|$)|exhausted|out of.*token|token.*exhaust|claude.*usage|usage.*claude|plan.*limit|subscription.*limit|billing.*limit|daily.*limit|monthly.*limit|([^0-9]|^)402([^0-9]|$)|([^0-9]|^)529([^0-9]|$))"
+    "(hit your limit|rate[ -]?limit|resets [0-9]+(am|pm)|usage limit|quota exceeded|too many requests|exceeded.*quota|([^0-9]|^)429([^0-9]|$)|exhausted|out of.*token|token.*exhaust|plan.*limit|subscription.*limit|billing.*limit|([^0-9]|^)402([^0-9]|$)|([^0-9]|^)529([^0-9]|$))"
 }
 
 # is_transient_failure <exit_code>

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -79,11 +79,17 @@ export DUCK_ENGINE DUCK_MODEL
 echo "    engine: $REVIEW_ENGINE ($ENGINE_LABEL)"
 
 # is_rate_limited <text>
-# Returns 0 (true) if the text looks like a Claude, Gemini, or Copilot rate-limit message.
+# Returns 0 (true) if the text looks like a provider usage/rate-limit block.
+# Covers three distinct failure modes that all warrant an engine fallback:
+#   1. API-level rate limits (429, "too many requests", per-minute quotas)
+#   2. Subscription/billing caps ("usage limit", "out of tokens", plan limits,
+#      Claude Code's "you've exceeded your Claude AI usage" messages, HTTP 402)
+#   3. Service overload that acts like a hard block (529)
 # review-one-pr.sh exits with code 2 when this fires so the caller can switch engines.
 is_rate_limited() {
   local text="$1"
-  echo "$text" | grep -qiE "(hit your limit|rate[ -]?limit|resets [0-9]+(am|pm)|usage limit|quota exceeded|too many requests|exceeded.*quota|([^0-9]|^)429([^0-9]|$)|exhausted)"
+  echo "$text" | grep -qiE \
+    "(hit your limit|rate[ -]?limit|resets [0-9]+(am|pm)|usage limit|quota exceeded|too many requests|exceeded.*quota|([^0-9]|^)429([^0-9]|$)|exhausted|out of.*token|token.*exhaust|claude.*usage|usage.*claude|plan.*limit|subscription.*limit|billing.*limit|daily.*limit|monthly.*limit|([^0-9]|^)402([^0-9]|$)|([^0-9]|^)529([^0-9]|$))"
 }
 
 # is_transient_failure <exit_code>

--- a/scripts/post-pr-review.sh
+++ b/scripts/post-pr-review.sh
@@ -165,6 +165,11 @@ if [ "$DRY_RUN" = "true" ]; then
   exit 0
 fi
 
+if [ "$DECISION" = "skip" ]; then
+  REASON=$(jq -r '.reason // "unspecified"' "$VERDICT_JSON")
+  echo "    reviewer returned skip ($REASON) — treating as no-op"
+  exit 100
+fi
 if [ "$DECISION" != "approve" ] && [ "$DECISION" != "escalate" ]; then
   echo "ERROR: invalid decision '$DECISION'"
   exit 1


### PR DESCRIPTION
## Problem

Closes #106

When Claude hits its subscription/token usage cap, `claude --print` exits with code 1 and writes a usage-cap message to **stdout**. The `is_rate_limited` function only matched API-level rate-limit phrasing (429, `too many requests`, etc.) — it missed Claude Code's billing/plan-cap messages entirely.

Result: the cascade hard-failed (exit 1) and aborted the session, instead of exiting 2 and triggering the existing gemini → copilot fallback chain in `review-batch.sh`.

**Observed failure:** https://github.com/petry-projects/.github-private/actions/runs/25648497571/job/75282153268

---

## Changes

### `scripts/engine.sh` — extend `is_rate_limited` regex

Added three new failure-mode categories to the pattern:

| Category | New patterns |
|---|---|
| Subscription/billing cap | `out of.*token`, `token.*exhaust`, `claude.*usage`, `usage.*claude`, `plan.*limit`, `subscription.*limit`, `billing.*limit`, `daily.*limit`, `monthly.*limit` |
| HTTP payment-required | `402` |
| Service overload (hard block) | `529` |

### `scripts/review-one-pr.sh` — dual-channel rate-limit detection + diagnostics

1. **Check stderr too**: `$TRIAGE_LOG` (stderr) is now read into `$TRIAGE_STDERR` and passed through `is_rate_limited` alongside `$TRIAGE_RESULT` (stdout). Some providers write their limit message to stderr.

2. **Surface the error on hard-fail**: the previous failure path only printed stderr via `cat $TRIAGE_LOG`, silently discarding stdout — where Claude Code actually writes its error. Both channels are now printed so the failure reason is always visible in CI logs.

---

## Behaviour after this fix

| Scenario | Before | After |
|---|---|---|
| Claude usage-cap hit at triage | Hard-fail, session aborted | exit 2 → retry with Gemini or Copilot |
| Triage fails for other reason | Opaque log | stdout + stderr both printed |
| API-level rate limit (already worked) | exit 2 → fallback | unchanged ✓ |
