### PR TITLE
fix(claude): sync inlined workflow with org standard

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -8,12 +8,16 @@ on:
   pull_request:
     branches: [main]
     types: [opened, reopened, synchronize]
+    paths-ignore:
+      - '.github/workflows/claude.yml'  # OIDC invariant — changing this file breaks token exchange
   issue_comment:
     types: [created]
   pull_request_review_comment:
     types: [created]
   issues:
     types: [labeled]
+  check_run:
+    types: [completed]
 
 permissions: {}
 
@@ -29,7 +33,8 @@ jobs:
         contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review_comment' &&
         github.event.comment.user.login != 'claude[bot]' &&
-        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+        (contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) ||
+          contains(fromJson('["coderabbitai[bot]","Copilot","copilot-pull-request-reviewer[bot]","gemini-code-assist[bot]"]'), github.event.comment.user.login)))
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -46,12 +51,78 @@ jobs:
           fetch-depth: 1
           token: ${{ secrets.DON_PETRY_BOT_GH_PAT || github.token }}
       - name: Run Claude Code
-        uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de # v1.0.89
+        uses: anthropics/claude-code-action@476e359e6203e73dad705c8b322e333fabbd7416 # v1.0.119
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
             actions: read
             checks: read
+
+  # Automation mode: CI failure response — diagnose and fix failing checks on PRs
+  claude-ci-fix:
+    if: >-
+      github.event_name == 'check_run' &&
+      github.event.check_run.conclusion == 'failure' &&
+      !startsWith(github.event.check_run.name, 'Claude Code')
+    concurrency:
+      group: claude-ci-fix-${{ github.event.check_run.head_sha }}
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
+      issues: write
+      actions: read
+      checks: read
+    steps:
+      - name: Resolve PR number
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.DON_PETRY_BOT_GH_PAT || github.token }}
+        run: |
+          PR="${{ github.event.check_run.pull_requests[0].number }}"
+          if [ -z "$PR" ]; then
+            PR=$(gh api \
+              "repos/${{ github.repository }}/commits/${{ github.event.check_run.head_sha }}/pulls" \
+              --jq '[.[] | select(.state == "open")] | first | .number // empty')
+          fi
+          echo "number=$PR" >> "$GITHUB_OUTPUT"
+      - name: Checkout repository
+        if: steps.pr.outputs.number != ''
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          token: ${{ secrets.DON_PETRY_BOT_GH_PAT || github.token }}
+      - name: Run Claude Code
+        if: steps.pr.outputs.number != ''
+        uses: anthropics/claude-code-action@476e359e6203e73dad705c8b322e333fabbd7416 # v1.0.119
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.DON_PETRY_BOT_GH_PAT || github.token }}
+          # yamllint disable rule:line-length
+          claude_args: |
+            --allowedTools "Bash(gh pr checkout:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh run view:*),Bash(gh run list:*),Bash(gh run watch:*),Bash(gh api:*),Edit,Write"
+          # yamllint enable rule:line-length
+          # yamllint disable rule:line-length
+          prompt: |
+            CI check "${{ github.event.check_run.name }}" has failed on PR #${{ steps.pr.outputs.number }}.
+
+            Check details:
+            - Check: ${{ github.event.check_run.name }}
+            - Conclusion: ${{ github.event.check_run.conclusion }}
+            - Head SHA: ${{ github.event.check_run.head_sha }}
+            - Details URL: ${{ github.event.check_run.details_url }}
+
+            Please diagnose and fix the failure:
+            1. Check out the PR branch: gh pr checkout ${{ steps.pr.outputs.number }}
+            2. Read the failure details — visit the details URL or use `gh run list --commit ${{ github.event.check_run.head_sha }}` and `gh run view` to read the logs. For SonarCloud or external check services, inspect the PR annotations via `gh api repos/${{ github.repository }}/check-runs/${{ github.event.check_run.id }}/annotations?per_page=100`.
+            3. Read the relevant source files and understand the root cause.
+            4. Apply the minimal fix needed to address the reported issues.
+            5. Commit and push the fix to the PR branch.
+            6. Leave a concise comment on PR #${{ steps.pr.outputs.number }} explaining what you found and what you changed.
+          # yamllint enable rule:line-length
 
   # Automation mode: issue-triggered work — implement, open PR, review, and notify
   claude-issue:
@@ -111,7 +182,7 @@ jobs:
           fi
       - name: Run Claude Code
         if: steps.dedup.outputs.existing_pr_url == ''
-        uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de # v1.0.89
+        uses: anthropics/claude-code-action@476e359e6203e73dad705c8b322e333fabbd7416 # v1.0.119
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.DON_PETRY_BOT_GH_PAT }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,8 @@ jobs:
       (github.event_name == 'pull_request_review_comment' &&
         github.event.comment.user.login != 'claude[bot]' &&
         (contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) ||
-          contains(fromJson('["coderabbitai[bot]","Copilot","copilot-pull-request-reviewer[bot]","gemini-code-assist[bot]"]'), github.event.comment.user.login)))
+          (github.event.pull_request.head.repo.full_name == github.repository &&
+            contains(fromJson('["coderabbitai[bot]","Copilot","copilot-pull-request-reviewer[bot]","gemini-code-assist[bot]"]'), github.event.comment.user.login))))
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -64,7 +64,7 @@ jobs:
     if: >-
       github.event_name == 'check_run' &&
       github.event.check_run.conclusion == 'failure' &&
-      !startsWith(github.event.check_run.name, 'Claude Code')
+      !contains(fromJson('["claude","claude-ci-fix","claude-issue"]'), github.event.check_run.name)
     concurrency:
       group: claude-ci-fix-${{ github.event.check_run.head_sha }}
       cancel-in-progress: true
@@ -88,6 +88,15 @@ jobs:
             PR=$(gh api \
               "repos/${{ github.repository }}/commits/${{ github.event.check_run.head_sha }}/pulls" \
               --jq '[.[] | select(.state == "open")] | first | .number // empty')
+          fi
+          # Trust gate: skip fork PRs — this job has write/secret access
+          if [ -n "$PR" ]; then
+            HEAD_REPO=$(gh api "repos/${{ github.repository }}/pulls/$PR" \
+              --jq '.head.repo.full_name // empty')
+            if [ "$HEAD_REPO" != "${{ github.repository }}" ]; then
+              echo "Skipping: fork PR (head=$HEAD_REPO)"
+              PR=""
+            fi
           fi
           echo "number=$PR" >> "$GITHUB_OUTPUT"
       - name: Checkout repository


### PR DESCRIPTION
## Problem

The inlined `claude.yml` in this repo was diverged from [`claude-code-reusable.yml`](https://github.com/petry-projects/.github/blob/main/.github/workflows/claude-code-reusable.yml) in 4 ways, causing missing functionality and the bot-comment trigger bug reported in issue context.

## Changes

### 1. 🐛 Bot allow list for `pull_request_review_comment` (bug fix)
Bots have `author_association: "NONE"` so they were silently skipped. Added the same allow list the reusable already has:
```
coderabbitai[bot], Copilot, copilot-pull-request-reviewer[bot], gemini-code-assist[bot]
```

### 2. ✨ `check_run` trigger + `claude-ci-fix` job (new feature)
Ports the CI auto-fix feature: when any non-Claude check fails on a PR, Claude diagnoses and fixes it. Uses `DON_PETRY_BOT_GH_PAT` (this repo's secret name, adapted from `GH_PAT_WORKFLOWS` in the reusable).

### 3. ⬆️ `claude-code-action` SHA bump
| Job | Before | After |
|---|---|---|
| `claude` | `6e2bd52` (v1.0.89) | `476e359` (v1.0.119) |
| `claude-issue` | `6e2bd52` (v1.0.89) | `476e359` (v1.0.119) |

### 4. 🛡️ `paths-ignore` on `pull_request` trigger
Prevents Claude from running on PRs that only change `claude.yml` itself, avoiding the Anthropic OIDC validation failure (the workflow file must be byte-for-byte identical to the default branch at token exchange time).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD automation to improve pull request processing and expedite feedback on continuous integration failures.
  * Optimized workflow configuration to prevent redundant triggers and improve overall automation efficiency.
  * Updated automated tooling integrations for more reliable development workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/petry-projects/.github-private/pull/109)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->