### PR TITLE
ci: add auto-rebase.yml canonical thin-caller stub

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -1,0 +1,42 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/auto-rebase.yml
+# Standard:        petry-projects/.github/standards/ci-standards.md
+# Reusable:        petry-projects/.github/.github/workflows/auto-rebase-reusable.yml
+#
+# AGENTS — READ BEFORE EDITING:
+#   • This file is a THIN CALLER STUB. All branch-update logic lives in the
+#     reusable workflow above.
+#   • You MAY change: the SHA in the `uses:` line when upgrading the reusable
+#     workflow version (bump SHA to latest main of petry-projects/.github).
+#   • You MUST NOT change: trigger event, the concurrency group name,
+#     or the job-level `permissions:` block — reusable workflows can be
+#     granted no more permissions than the calling job has, so removing
+#     the stanza breaks the reusable's gh API calls.
+#   • If you need different behaviour, open a PR against the reusable in the
+#     central repo.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Auto-rebase non-Dependabot PRs — thin caller for the org-level reusable.
+# To adopt: copy this file to .github/workflows/auto-rebase.yml in your repo.
+# No secrets required — uses GITHUB_TOKEN only.
+name: Auto-rebase non-Dependabot PRs
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: auto-rebase
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  auto-rebase:
+    permissions:
+      contents: write      # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
+      pull-requests: write # post comments on PRs
+    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@v1
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Adds the missing `auto-rebase.yml` thin-caller stub, copied verbatim from [`standards/workflows/auto-rebase.yml`](https://github.com/petry-projects/.github/blob/main/standards/workflows/auto-rebase.yml)
- Fixes the compliance gap identified during review of issue [petry-projects/.github#215](https://github.com/petry-projects/.github/issues/215): `.github-private` was missing this Tier-1 standard workflow
- Root cause of the gap: `auto-rebase.yml` was absent from `REQUIRED_WORKFLOWS` in `scripts/compliance-audit.sh`, so the audit never flagged it

## What this does

After every push to `main`, the reusable workflow finds all open non-Dependabot same-repo PRs that have fallen behind their base branch and brings them up to date via the merge method. This is especially relevant for `.github-private` which currently has ~10 open compliance-fix PRs that can fall behind rapidly as others merge.

## Test plan

- [ ] CI passes on this PR
- [ ] Workflow visible in Actions tab after merge
- [ ] On next push to main, confirm the workflow triggers and updates any behind PRs

🤖 Generated with [Claude Code](https://claude.ai/claude-code)