### PR TITLE
ci: pin auto-rebase-reusable.yml to SHA (closes #115)

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -38,5 +38,5 @@ jobs:
     permissions:
       contents: write      # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write # post comments on PRs
-    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@0cb4bba11d7563bf197ad805f12fb8639e4879e4 # v1
     secrets: inherit


### PR DESCRIPTION
## Summary

- Pins `petry-projects/.github/.github/workflows/auto-rebase-reusable.yml` from `@v1` to commit SHA `0cb4bba11d7563bf197ad805f12fb8639e4879e4` in `.github/workflows/auto-rebase.yml`
- Brings this repository into compliance with the [org action-pinning policy](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#action-pinning-policy)

Closes #115

Generated with [Claude Code](https://claude.ai/code)