### PR TITLE
ci: pin agent-shield reusable workflow to SHA

### DIFF
--- a/.github/workflows/agent-shield.yml
+++ b/.github/workflows/agent-shield.yml
@@ -30,6 +30,6 @@ permissions:
 
 jobs:
   agent-shield:
-    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@0cb4bba11d7563bf197ad805f12fb8639e4879e4 # v1
     with:
       required-files: AGENTS.md


### PR DESCRIPTION
## Summary

- Pins `petry-projects/.github/.github/workflows/agent-shield-reusable.yml` from `@v1` to exact commit SHA (`0cb4bba11d7563bf197ad805f12fb8639e4879e4`) per the org [action-pinning policy](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#action-pinning-policy).
- The `# v1` comment is retained for human readability.
- Repo-specific `with: required-files: AGENTS.md` input is preserved unchanged.

## Change

```diff
-    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@0cb4bba11d7563bf197ad805f12fb8639e4879e4 # v1
```

Closes #114

Generated with [Claude Code](https://claude.ai/code)