### PR TITLE
ci: pin dependabot-automerge reusable workflow to SHA

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -35,5 +35,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@0cb4bba11d7563bf197ad805f12fb8639e4879e4 # v1
     secrets: inherit


### PR DESCRIPTION
Pins the `petry-projects/.github` reusable workflow reference in `.github/workflows/dependabot-automerge.yml` from `@v1` to commit SHA `0cb4bba11d7563bf197ad805f12fb8639e4879e4` (with a `# v1` comment for readability), satisfying the action-pinning compliance policy.

## Changes

- `.github/workflows/dependabot-automerge.yml`: pin `uses:` reference to SHA

## Verification

SHA looked up via:
```
gh api repos/petry-projects/.github/git/refs/tags/v1 --jq '.object.sha'
# → 0cb4bba11d7563bf197ad805f12fb8639e4879e4
```

Closes #116

Generated with [Claude Code](https://claude.ai/code)