### PR TITLE
fix: per-PR isolation and single-review retry (closes #132)

### DIFF
--- a/scripts/review-batch.sh
+++ b/scripts/review-batch.sh
@@ -103,13 +103,10 @@ while IFS= read -r pr_url; do
       abort_reason="rate-limit on fallback engine"
       ;;
     *)
-      # Other failure — session-fatal. A systemic problem (model degraded,
-      # prompt regression, malformed verdicts) shouldn't burn the queue.
+      # Per-PR failure — log and continue. Remaining candidates still run.
+      # Accumulated failures surface in the session summary.
       failed=$((failed + 1))
       echo "::error::Review failed for $pr_url (exit code $rc)"
-      session_aborted=1
-      abort_pr="$pr_url"
-      abort_reason="exit code $rc"
       ;;
   esac
 

--- a/scripts/review-one-pr.sh
+++ b/scripts/review-one-pr.sh
@@ -325,14 +325,30 @@ if [ "$TRIAGE_ESCALATE" = "false" ]; then
     rm -f "$VERDICT_JSON" "$VERDICT_JSON.raw"
     OUTPUT_FILE="$VERDICT_JSON"
     export OUTPUT_FILE
-    if run_agentic prompts/single-review.md "$ENGINE_SINGLE_MODEL" \
-         > "$VERDICT_JSON.raw" 2>"/tmp/cascade/single-review.log" \
-       && extract_verdict_json "$VERDICT_JSON.raw" "$VERDICT_JSON"; then
+    SINGLE_LOG="/tmp/cascade/single-review-attempt-${single_attempt}.log"
+
+    single_rc=0
+    run_agentic prompts/single-review.md "$ENGINE_SINGLE_MODEL" \
+      > "$VERDICT_JSON.raw" 2>"$SINGLE_LOG" || single_rc=$?
+
+    # Check for rate limit before retrying — exit code 2 lets review-batch.sh
+    # trigger engine fallback rather than burning retries on the same engine.
+    SINGLE_STDOUT=$(cat "$VERDICT_JSON.raw" 2>/dev/null || true)
+    SINGLE_STDERR=$(cat "$SINGLE_LOG" 2>/dev/null || true)
+    if is_rate_limited "$SINGLE_STDOUT" || is_rate_limited "$SINGLE_STDERR"; then
+      echo "    [approve] rate limit detected — exiting with code 2 for engine fallback"
+      [ -n "$SINGLE_STDERR" ] && echo "    limit stderr: $SINGLE_STDERR"
+      exit 2
+    fi
+
+    if [ "$single_rc" -eq 0 ] && extract_verdict_json "$VERDICT_JSON.raw" "$VERDICT_JSON"; then
       single_ok=true
       break
     fi
-    echo "    [approve] single-review attempt $single_attempt/$SINGLE_REVIEW_MAX_RETRIES produced no valid JSON"
+
+    echo "    [approve] single-review attempt $single_attempt/$SINGLE_REVIEW_MAX_RETRIES produced no valid JSON (exit $single_rc)"
     head -20 "$VERDICT_JSON.raw" 2>/dev/null || true
+    [ -n "$SINGLE_STDERR" ] && echo "    stderr: $SINGLE_STDERR"
     if [ "$single_attempt" -lt "$SINGLE_REVIEW_MAX_RETRIES" ]; then
       echo "    [approve] retrying in ${SINGLE_REVIEW_RETRY_DELAY_SEC}s"
       sleep "$SINGLE_REVIEW_RETRY_DELAY_SEC"
@@ -342,7 +358,10 @@ if [ "$TRIAGE_ESCALATE" = "false" ]; then
 
   if [ "$single_ok" = "false" ]; then
     echo "::warning::single-review failed after $SINGLE_REVIEW_MAX_RETRIES attempts — flagging for manual review"
-    [ -s "/tmp/cascade/single-review.log" ] && cat "/tmp/cascade/single-review.log"
+    for i in $(seq 1 "$SINGLE_REVIEW_MAX_RETRIES"); do
+      log="/tmp/cascade/single-review-attempt-${i}.log"
+      [ -s "$log" ] && { echo "    attempt $i stderr:"; cat "$log"; }
+    done
     if [ "${DRY_RUN:-false}" = "false" ]; then
       gh pr edit "$PR_URL" --add-label needs-human-review 2>/dev/null || true
     fi

--- a/scripts/review-one-pr.sh
+++ b/scripts/review-one-pr.sh
@@ -316,10 +316,38 @@ if [ "$TRIAGE_ESCALATE" = "false" ]; then
   echo "    [approve] triage cleared — running single confirmation ($ENGINE_SINGLE_MODEL)"
   export REVIEW_MODE="triage-approved"
   VERDICT_JSON="/tmp/cascade/single-review-verdict.json"
-  OUTPUT_FILE="$VERDICT_JSON"
-  export OUTPUT_FILE
-  run_agentic prompts/single-review.md "$ENGINE_SINGLE_MODEL" > "$VERDICT_JSON.raw"
-  extract_verdict_json "$VERDICT_JSON.raw" "$VERDICT_JSON" || { echo "::error::single-review did not produce valid JSON"; exit 1; }
+  SINGLE_REVIEW_MAX_RETRIES="${SINGLE_REVIEW_MAX_RETRIES:-2}"
+  SINGLE_REVIEW_RETRY_DELAY_SEC="${SINGLE_REVIEW_RETRY_DELAY_SEC:-15}"
+
+  single_attempt=1
+  single_ok=false
+  while [ "$single_attempt" -le "$SINGLE_REVIEW_MAX_RETRIES" ]; do
+    rm -f "$VERDICT_JSON" "$VERDICT_JSON.raw"
+    OUTPUT_FILE="$VERDICT_JSON"
+    export OUTPUT_FILE
+    if run_agentic prompts/single-review.md "$ENGINE_SINGLE_MODEL" \
+         > "$VERDICT_JSON.raw" 2>"/tmp/cascade/single-review.log" \
+       && extract_verdict_json "$VERDICT_JSON.raw" "$VERDICT_JSON"; then
+      single_ok=true
+      break
+    fi
+    echo "    [approve] single-review attempt $single_attempt/$SINGLE_REVIEW_MAX_RETRIES produced no valid JSON"
+    head -20 "$VERDICT_JSON.raw" 2>/dev/null || true
+    if [ "$single_attempt" -lt "$SINGLE_REVIEW_MAX_RETRIES" ]; then
+      echo "    [approve] retrying in ${SINGLE_REVIEW_RETRY_DELAY_SEC}s"
+      sleep "$SINGLE_REVIEW_RETRY_DELAY_SEC"
+    fi
+    single_attempt=$((single_attempt + 1))
+  done
+
+  if [ "$single_ok" = "false" ]; then
+    echo "::warning::single-review failed after $SINGLE_REVIEW_MAX_RETRIES attempts — flagging for manual review"
+    [ -s "/tmp/cascade/single-review.log" ] && cat "/tmp/cascade/single-review.log"
+    if [ "${DRY_RUN:-false}" = "false" ]; then
+      gh pr edit "$PR_URL" --add-label needs-human-review 2>/dev/null || true
+    fi
+    exit 1
+  fi
   rm -f "$VERDICT_JSON.raw"
 
   # Post the review using the verdict


### PR DESCRIPTION
## Summary

- **Per-PR isolation**: `review-batch.sh` no longer treats exit code 1 as session-fatal. Only the rate-limit-on-fallback-engine case (exit code 2 with no remaining engine) still aborts the session. All other per-PR failures are counted and logged; the remaining candidates continue processing. `SESSION ABORTED EARLY` is now scoped to the rate-limit scenario only.

- **Retry + fallback for `single-review`**: `review-one-pr.sh` wraps the `single-review` step in a retry loop (default 2 total attempts, 15 s delay). On each failed attempt, the raw model output and stderr are printed for post-mortem visibility. After exhausting retries, the PR gets a `needs-human-review` label and the script exits with code 1 — which the updated batch now treats as a non-fatal per-PR failure.

**Root cause of run [#25707852006](https://github.com/petry-projects/.github-private/actions/runs/25707852006):** `claude-opus-4-7` returned a verbose non-JSON response for PR #129 on the first (and only) attempt. The old code treated that as session-fatal and skipped 35 remaining candidates.

## Acceptance criteria coverage

- [x] Resilient JSON parsing — non-JSON caught, logged, treated as per-PR failure
- [x] Per-PR isolation — one failure no longer aborts the session
- [x] Retry logic — single-review retries at least once before marking failed
- [x] Fallback behavior — exhausted retries → `needs-human-review` label, skip
- [x] Accurate summary — `SESSION ABORTED EARLY` only on rate-limit abort; per-PR failures appear in the failure count
- [x] No regression — rate-limit session abort and all existing cascade paths unchanged

## Test plan

- [ ] Manually trigger `workflow_dispatch` with a PR URL that produces a non-JSON response; confirm remaining candidates are processed and summary shows `1 failures (processed N/N candidates)` with no `SESSION ABORTED EARLY`
- [ ] Confirm retry delay is visible in CI logs (`[approve] retrying in 15s`)
- [ ] Confirm `needs-human-review` label is applied to the PR after exhausted retries
- [ ] Confirm a normal triage-cleared single-review still approves correctly (no regression)
- [ ] Confirm rate-limit abort (exit code 2 on all engines) still produces `SESSION ABORTED EARLY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in batch PR review processing to continue with remaining candidates when individual reviews encounter failures.

* **Chores**
  * Enhanced retry logic for review operations with configurable timeout and retry limits for better reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/petry-projects/.github-private/pull/133)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->