### PR TITLE
fix: replace gh copilot suggest with GitHub Models REST API

### DIFF
--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -64,6 +64,7 @@ case "$REVIEW_ENGINE" in
     # https://models.github.ai (see GitHub Models marketplace).
     # Override via COPILOT_API_MODEL env var if the default is unavailable.
     COPILOT_API_MODEL="${COPILOT_API_MODEL:-openai/o4-mini}"
+    export COPILOT_API_MODEL
     ENGINE_LABEL="triage: o4-mini → deep: o4-mini + duck: sonnet 4.6 → audit: o4-mini (GitHub Models API)"
     ENGINE_SINGLE_LABEL="single-reviewer mode: o4-mini (GitHub Models API)"
     # Cross-engine rubber duck: always the opposite engine
@@ -80,7 +81,7 @@ export ENGINE_TRIAGE_MODEL ENGINE_DEEP_MODEL ENGINE_AUDIT_MODEL
 export ENGINE_ACTION_MODEL ENGINE_SINGLE_MODEL
 export ENGINE_LABEL ENGINE_SINGLE_LABEL
 export DUCK_ENGINE DUCK_MODEL
-export COPILOT_API_MODEL
+# COPILOT_API_MODEL is exported inside the copilot) case above (only set then).
 
 echo "    engine: $REVIEW_ENGINE ($ENGINE_LABEL)"
 

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -60,8 +60,12 @@ case "$REVIEW_ENGINE" in
     ENGINE_AUDIT_MODEL="o4-mini"
     ENGINE_ACTION_MODEL="o4-mini"
     ENGINE_SINGLE_MODEL="o4-mini"
-    ENGINE_LABEL="triage: o4-mini → deep: o4-mini + duck: sonnet 4.6 → audit: o4-mini"
-    ENGINE_SINGLE_LABEL="single-reviewer mode: o4-mini"
+    # GitHub Models API model identifier — must match a model available at
+    # https://models.github.ai (see GitHub Models marketplace).
+    # Override via COPILOT_API_MODEL env var if the default is unavailable.
+    COPILOT_API_MODEL="${COPILOT_API_MODEL:-openai/o4-mini}"
+    ENGINE_LABEL="triage: o4-mini → deep: o4-mini + duck: sonnet 4.6 → audit: o4-mini (GitHub Models API)"
+    ENGINE_SINGLE_LABEL="single-reviewer mode: o4-mini (GitHub Models API)"
     # Cross-engine rubber duck: always the opposite engine
     DUCK_ENGINE="claude"
     DUCK_MODEL="claude-sonnet-4-6"
@@ -76,6 +80,7 @@ export ENGINE_TRIAGE_MODEL ENGINE_DEEP_MODEL ENGINE_AUDIT_MODEL
 export ENGINE_ACTION_MODEL ENGINE_SINGLE_MODEL
 export ENGINE_LABEL ENGINE_SINGLE_LABEL
 export DUCK_ENGINE DUCK_MODEL
+export COPILOT_API_MODEL
 
 echo "    engine: $REVIEW_ENGINE ($ENGINE_LABEL)"
 
@@ -100,6 +105,106 @@ is_transient_failure() {
     124|137|143) return 0 ;;
     *)           return 1 ;;
   esac
+}
+
+# copilot_chat <prompt_file> [timeout_sec]
+# Calls the GitHub Models REST API (OpenAI-compatible) for text completion.
+#
+# Replaces the broken `gh copilot suggest -p "$(cat <file>)"` invocation:
+#   • The -p flag is not valid syntax in modern gh CLI versions (produces
+#     "Invalid command format" and causes a non-zero exit that the session
+#     circuit-breaker misclassifies as a rate-limit).
+#   • gh copilot suggest is a shell-command suggestion tool; it does NOT
+#     support arbitrary prompt text or return structured JSON.
+#   • $(cat <file>) as a shell argument fails for large PR prompts (ARG_MAX).
+#
+# This function uses curl + the GitHub Models REST API instead:
+#   https://models.github.ai/inference/chat/completions
+# The endpoint is versioned (X-GitHub-Api-Version header) and stable against
+# gh CLI version changes. Auth uses COPILOT_GITHUB_TOKEN (user PAT with a
+# Copilot subscription). Model is COPILOT_API_MODEL (default: openai/o4-mini).
+#
+# Rate-limit responses (HTTP 429) are echoed to stdout so the caller's
+# is_rate_limited() check can detect them and exit 2 for engine fallback.
+copilot_chat() {
+  local prompt_file="$1"
+  local timeout_sec="${2:-300}"
+
+  # Build JSON payload via python3 — safely encodes arbitrary prompt text
+  # (special chars, newlines, quotes, Unicode, large files) without the
+  # ARG_MAX and shell-quoting issues of the old $(cat "$file") approach.
+  local body rc=0
+  body=$(python3 -c "
+import json, sys
+prompt = open(sys.argv[1]).read()
+model  = sys.argv[2]
+sys.stdout.write(json.dumps({
+    'model': model,
+    'messages': [{'role': 'user', 'content': prompt}],
+    'temperature': 0,
+}))
+" "$prompt_file" "${COPILOT_API_MODEL:-openai/o4-mini}") || {
+    echo "copilot_chat: failed to build JSON payload from $prompt_file" >&2
+    return 1
+  }
+
+  # Call GitHub Models REST API. -w '\n%{http_code}' appends the HTTP status
+  # on its own line so we can split body from code in pure shell.
+  local raw
+  raw=$(
+    timeout "$timeout_sec" curl -sSL \
+      -H "Authorization: Bearer ${COPILOT_GITHUB_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      https://models.github.ai/inference/chat/completions \
+      --data-binary "$body" \
+      -w '\n%{http_code}'
+  ) || rc=$?
+
+  if [ "$rc" -ne 0 ]; then
+    echo "copilot_chat: curl exited $rc (timeout=${timeout_sec}s)" >&2
+    return "$rc"
+  fi
+
+  # Split the appended HTTP code from the response body.
+  local http_code response_body
+  http_code=$(printf '%s' "$raw" | tail -n 1)
+  response_body=$(printf '%s' "$raw" | head -n -1)
+
+  # Rate-limit: echo to stdout so is_rate_limited() in review-one-pr.sh fires.
+  if [ "$http_code" -eq 429 ]; then
+    echo "error: GitHub Models API rate limit (HTTP 429 — quota exceeded)"
+    printf '%s\n' "$response_body"
+    return 1
+  fi
+
+  # Other HTTP errors: log to stderr and fail.
+  if [ "$http_code" -ge 400 ]; then
+    echo "copilot_chat: HTTP $http_code from GitHub Models API" >&2
+    printf '%s\n' "$response_body" >&2
+    return 1
+  fi
+
+  # Extract the assistant message from the JSON response.
+  printf '%s' "$response_body" | python3 -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError as e:
+    print('copilot_chat: invalid JSON response: ' + str(e), file=sys.stderr)
+    sys.exit(1)
+if 'error' in data:
+    err = data['error']
+    msg = err.get('message', str(err)) if isinstance(err, dict) else str(err)
+    print('copilot_chat: API error: ' + str(msg), file=sys.stderr)
+    sys.exit(1)
+choices = data.get('choices', [])
+if not choices:
+    print('copilot_chat: empty choices in response', file=sys.stderr)
+    sys.exit(1)
+content = choices[0].get('message', {}).get('content', '')
+print(content, end='')
+" || return 1
 }
 
 # run_triage <prompt_file>
@@ -136,11 +241,7 @@ run_triage() {
           < "$prompt_file" || rc=$?
         ;;
       copilot)
-        # gh copilot is now a built-in; auth via GH_PAT (user token with Copilot subscription).
-        # Model selection is not supported by gh copilot suggest — uses Copilot's default.
-        ( export GH_TOKEN="$COPILOT_GITHUB_TOKEN"
-          timeout "$TRIAGE_TIMEOUT_SEC" gh copilot suggest -p "$(cat "$prompt_file")"
-        ) || rc=$?
+        copilot_chat "$prompt_file" "$TRIAGE_TIMEOUT_SEC" || rc=$?
         ;;
     esac
     if [ "$rc" -eq 0 ]; then
@@ -186,11 +287,15 @@ run_agentic() {
         < "$prompt_file"
       ;;
     copilot)
-      # gh copilot is now a built-in; auth via GH_PAT (user token with Copilot subscription).
-      # Model selection is not supported by gh copilot suggest — uses Copilot's default.
-      ( export GH_TOKEN="$COPILOT_GITHUB_TOKEN"
-        timeout "$DEEP_TIMEOUT_SEC" gh copilot suggest -p "$(cat "$prompt_file")"
-      )
+      # Text-only completion via GitHub Models API (no tool use available).
+      # Output goes to stdout (captured by the caller's redirect); also written
+      # to $OUTPUT_FILE if set so callers that check that path directly find it.
+      local _cop_out
+      _cop_out=$(copilot_chat "$prompt_file" "$DEEP_TIMEOUT_SEC") || return $?
+      printf '%s\n' "$_cop_out"
+      if [ -n "${OUTPUT_FILE:-}" ]; then
+        printf '%s\n' "$_cop_out" > "$OUTPUT_FILE"
+      fi
       ;;
   esac
 }
@@ -259,10 +364,12 @@ run_duck() {
     copilot)
       unset CLAUDE_CODE_OAUTH_TOKEN 2>/dev/null || true
       unset GOOGLE_API_KEY 2>/dev/null || true
-      # gh copilot is now a built-in; auth via GH_PAT (user token with Copilot subscription).
-      ( export GH_TOKEN="$COPILOT_GITHUB_TOKEN"
-        timeout "$DUCK_TIMEOUT_SEC" gh copilot suggest -p "$(cat "$prompt_file")"
-      )
+      local _duck_out
+      _duck_out=$(copilot_chat "$prompt_file" "$DUCK_TIMEOUT_SEC") || return $?
+      printf '%s\n' "$_duck_out"
+      if [ -n "${OUTPUT_FILE:-}" ]; then
+        printf '%s\n' "$_duck_out" > "$OUTPUT_FILE"
+      fi
       ;;
     *)
       echo "::error::Unknown DUCK_ENGINE='$DUCK_ENGINE'" >&2

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -63,6 +63,8 @@ case "$REVIEW_ENGINE" in
     # GitHub Models API model identifier — must match a model available at
     # https://models.github.ai (see GitHub Models marketplace).
     # Override via COPILOT_API_MODEL env var if the default is unavailable.
+    # openai/o4-mini is the April-2025 o4-generation reasoning model; it is
+    # not a typo for o1-mini or gpt-4o-mini.
     COPILOT_API_MODEL="${COPILOT_API_MODEL:-openai/o4-mini}"
     export COPILOT_API_MODEL
     ENGINE_LABEL="triage: o4-mini → deep: o4-mini + duck: sonnet 4.6 → audit: o4-mini (GitHub Models API)"
@@ -131,11 +133,12 @@ copilot_chat() {
   local prompt_file="$1"
   local timeout_sec="${2:-300}"
 
-  # Build JSON payload via python3 — safely encodes arbitrary prompt text
-  # (special chars, newlines, quotes, Unicode, large files) without the
-  # ARG_MAX and shell-quoting issues of the old $(cat "$file") approach.
-  local body rc=0
-  body=$(python3 -c "
+  # Build JSON payload via python3 into a temp file — safely encodes arbitrary
+  # prompt text (special chars, newlines, quotes, Unicode, large files) and
+  # avoids ARG_MAX limits when passing large diffs to curl via --data-binary.
+  local _body_file rc=0
+  _body_file=$(mktemp) || { echo "copilot_chat: mktemp failed" >&2; return 1; }
+  python3 -c "
 import json, sys
 prompt = open(sys.argv[1]).read()
 model  = sys.argv[2]
@@ -144,7 +147,8 @@ sys.stdout.write(json.dumps({
     'messages': [{'role': 'user', 'content': prompt}],
     'temperature': 0,
 }))
-" "$prompt_file" "${COPILOT_API_MODEL:-openai/o4-mini}") || {
+" "$prompt_file" "${COPILOT_API_MODEL:-openai/o4-mini}" > "$_body_file" || {
+    rm -f "$_body_file"
     echo "copilot_chat: failed to build JSON payload from $prompt_file" >&2
     return 1
   }
@@ -154,13 +158,14 @@ sys.stdout.write(json.dumps({
   local raw
   raw=$(
     timeout "$timeout_sec" curl -sSL \
-      -H "Authorization: Bearer ${COPILOT_GITHUB_TOKEN}" \
+      -H "Authorization: Bearer ${COPILOT_GITHUB_TOKEN:?COPILOT_GITHUB_TOKEN is required for copilot engine}" \
       -H "Content-Type: application/json" \
       -H "X-GitHub-Api-Version: 2022-11-28" \
       https://models.github.ai/inference/chat/completions \
-      --data-binary "$body" \
+      --data-binary @"$_body_file" \
       -w '\n%{http_code}'
   ) || rc=$?
+  rm -f "$_body_file"
 
   if [ "$rc" -ne 0 ]; then
     echo "copilot_chat: curl exited $rc (timeout=${timeout_sec}s)" >&2
@@ -289,13 +294,12 @@ run_agentic() {
       ;;
     copilot)
       # Text-only completion via GitHub Models API (no tool use available).
-      # Output goes to stdout (captured by the caller's redirect); also written
-      # to $OUTPUT_FILE if set so callers that check that path directly find it.
-      local _cop_out
-      _cop_out=$(copilot_chat "$prompt_file" "$DEEP_TIMEOUT_SEC") || return $?
-      printf '%s\n' "$_cop_out"
+      # Stream directly to stdout; tee to OUTPUT_FILE when set.
       if [ -n "${OUTPUT_FILE:-}" ]; then
-        printf '%s\n' "$_cop_out" > "$OUTPUT_FILE"
+        copilot_chat "$prompt_file" "$DEEP_TIMEOUT_SEC" | tee "$OUTPUT_FILE"
+        return "${PIPESTATUS[0]}"
+      else
+        copilot_chat "$prompt_file" "$DEEP_TIMEOUT_SEC"
       fi
       ;;
   esac
@@ -365,11 +369,11 @@ run_duck() {
     copilot)
       unset CLAUDE_CODE_OAUTH_TOKEN 2>/dev/null || true
       unset GOOGLE_API_KEY 2>/dev/null || true
-      local _duck_out
-      _duck_out=$(copilot_chat "$prompt_file" "$DUCK_TIMEOUT_SEC") || return $?
-      printf '%s\n' "$_duck_out"
       if [ -n "${OUTPUT_FILE:-}" ]; then
-        printf '%s\n' "$_duck_out" > "$OUTPUT_FILE"
+        copilot_chat "$prompt_file" "$DUCK_TIMEOUT_SEC" | tee "$OUTPUT_FILE"
+        return "${PIPESTATUS[0]}"
+      else
+        copilot_chat "$prompt_file" "$DUCK_TIMEOUT_SEC"
       fi
       ;;
     *)

--- a/scripts/review-batch.sh
+++ b/scripts/review-batch.sh
@@ -42,9 +42,27 @@ if [ "${REVIEW_ENGINE:-claude}" = "copilot" ]; then
   if [ -z "$_smoke_model" ]; then
     # Source engine.sh to get COPILOT_API_MODEL without running any reviews.
     # Redirect stdout to discard the "    engine: ..." echo from engine.sh.
-    source "$SCRIPT_DIR_BATCH/engine.sh" > /dev/null 2>&1 || true
+    source "$SCRIPT_DIR_BATCH/engine.sh" > /dev/null || {
+      echo "::error::Copilot pre-flight: failed to source engine.sh — check REVIEW_ENGINE and file path" >&2
+      exit 1
+    }
     _smoke_model="${COPILOT_API_MODEL:-openai/o4-mini}"
   fi
+
+  _smoke_payload_file=$(mktemp) || { echo "::error::Copilot pre-flight: mktemp failed" >&2; exit 1; }
+  python3 -c "
+import json, sys
+sys.stdout.write(json.dumps({
+    'model': sys.argv[1],
+    'messages': [{'role': 'user', 'content': 'Reply with the single word: ready'}],
+    'max_tokens': 5,
+    'temperature': 0,
+}))
+" "$_smoke_model" > "$_smoke_payload_file" || {
+    rm -f "$_smoke_payload_file"
+    echo "::error::Copilot pre-flight: failed to build smoke-test JSON payload" >&2
+    exit 1
+  }
 
   _smoke_rc=0
   _smoke_raw=$(
@@ -53,9 +71,10 @@ if [ "${REVIEW_ENGINE:-claude}" = "copilot" ]; then
       -H "Content-Type: application/json" \
       -H "X-GitHub-Api-Version: 2022-11-28" \
       https://models.github.ai/inference/chat/completions \
-      --data-binary "{\"model\":\"${_smoke_model}\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with the single word: ready\"}],\"max_tokens\":5,\"temperature\":0}" \
+      --data-binary @"$_smoke_payload_file" \
       -w '\n%{http_code}'
   ) || _smoke_rc=$?
+  rm -f "$_smoke_payload_file"
 
   if [ "$_smoke_rc" -ne 0 ]; then
     echo "::error::Copilot pre-flight failed: curl exited $_smoke_rc — check COPILOT_GITHUB_TOKEN and network connectivity"
@@ -79,7 +98,7 @@ d = json.load(sys.stdin)
 print(d.get('choices', [{}])[0].get('message', {}).get('content', '(empty)'))
 " 2>/dev/null || echo "(parse failed)")
   echo "::notice::Copilot pre-flight passed — model=${_smoke_model} response='${_smoke_text}'"
-  unset _smoke_model _smoke_rc _smoke_raw _smoke_http _smoke_body _smoke_text
+  unset _smoke_model _smoke_payload_file _smoke_rc _smoke_raw _smoke_http _smoke_body _smoke_text
 fi
 
 if [ ! -s "$PRS_FILE" ]; then

--- a/scripts/review-batch.sh
+++ b/scripts/review-batch.sh
@@ -21,6 +21,67 @@ PRS_FILE="${PRS_FILE:-prs.txt}"
 MAX_PRS="${MAX_PRS:-10}"
 CANDIDATE_LIMIT="${CANDIDATE_LIMIT:-100}"
 
+# ---------------------------------------------------------------------------
+# Pre-flight smoke test for the Copilot engine.
+#
+# gh copilot suggest is a shell-command suggestion tool that does not accept
+# large prompts or the -p flag in modern gh CLI versions (see issue #147).
+# We now use the GitHub Models REST API directly. This pre-flight step verifies
+# API connectivity and auth BEFORE reviewing any PRs, so format/auth errors
+# surface as a clear setup failure rather than being mis-classified as
+# rate-limit hits mid-run (which caused session aborts skipping many PRs).
+# ---------------------------------------------------------------------------
+if [ "${REVIEW_ENGINE:-claude}" = "copilot" ]; then
+  SCRIPT_DIR_BATCH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  echo "==> Copilot engine pre-flight: testing GitHub Models API"
+
+  # Determine the configured API model (set by engine.sh; fall back to a
+  # known-available model for the connectivity check itself).
+  # shellcheck source=engine.sh
+  _smoke_model="${COPILOT_API_MODEL:-}"
+  if [ -z "$_smoke_model" ]; then
+    # Source engine.sh to get COPILOT_API_MODEL without running any reviews.
+    # Redirect stdout to discard the "    engine: ..." echo from engine.sh.
+    source "$SCRIPT_DIR_BATCH/engine.sh" > /dev/null 2>&1 || true
+    _smoke_model="${COPILOT_API_MODEL:-openai/o4-mini}"
+  fi
+
+  _smoke_rc=0
+  _smoke_raw=$(
+    timeout 30 curl -sSL \
+      -H "Authorization: Bearer ${COPILOT_GITHUB_TOKEN:?COPILOT_GITHUB_TOKEN not set for copilot engine}" \
+      -H "Content-Type: application/json" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      https://models.github.ai/inference/chat/completions \
+      --data-binary "{\"model\":\"${_smoke_model}\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with the single word: ready\"}],\"max_tokens\":5,\"temperature\":0}" \
+      -w '\n%{http_code}'
+  ) || _smoke_rc=$?
+
+  if [ "$_smoke_rc" -ne 0 ]; then
+    echo "::error::Copilot pre-flight failed: curl exited $_smoke_rc — check COPILOT_GITHUB_TOKEN and network connectivity"
+    exit 1
+  fi
+
+  _smoke_http=$(printf '%s' "$_smoke_raw" | tail -n 1)
+  _smoke_body=$(printf '%s' "$_smoke_raw" | head -n -1)
+
+  if [ "$_smoke_http" -ge 400 ]; then
+    echo "::error::Copilot pre-flight failed: GitHub Models API returned HTTP $_smoke_http for model '${_smoke_model}'"
+    echo "  Response: $_smoke_body"
+    echo "  Check COPILOT_GITHUB_TOKEN permissions and that model '${_smoke_model}' is available."
+    echo "  Override the model via the COPILOT_API_MODEL env var if needed."
+    exit 1
+  fi
+
+  _smoke_text=$(printf '%s' "$_smoke_body" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+print(d.get('choices', [{}])[0].get('message', {}).get('content', '(empty)'))
+" 2>/dev/null || echo "(parse failed)")
+  echo "::notice::Copilot pre-flight passed — model=${_smoke_model} response='${_smoke_text}'"
+  unset _smoke_model _smoke_rc _smoke_raw _smoke_http _smoke_body _smoke_text
+fi
+
 if [ ! -s "$PRS_FILE" ]; then
   echo "::notice::No candidate PRs to review."
   exit 0

--- a/tests/test_copilot_chat.sh
+++ b/tests/test_copilot_chat.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# tests/test_copilot_chat.sh
+#
+# Unit tests for the copilot_chat JSON payload builder in scripts/engine.sh.
+# Verifies that the python3 JSON-encoding logic handles edge-case prompts
+# without producing invalid JSON or triggering "Invalid command format" errors
+# from the old gh copilot suggest invocation.
+#
+# Run:  bash tests/test_copilot_chat.sh
+# Requires: python3, bash
+#
+# These tests are deliberately network-free: they test only the
+# payload-building step (not the API call itself). The smoke test in
+# review-batch.sh covers live API connectivity.
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+ERRORS=""
+
+ok() {
+  local name="$1"
+  PASS=$((PASS + 1))
+  printf 'PASS  %s\n' "$name"
+}
+
+fail() {
+  local name="$1"
+  local msg="$2"
+  FAIL=$((FAIL + 1))
+  ERRORS="${ERRORS}FAIL  ${name}: ${msg}\n"
+  printf 'FAIL  %s: %s\n' "$name" "$msg"
+}
+
+# Build a JSON payload from a prompt file using the same python3 logic as
+# copilot_chat in engine.sh.
+build_payload() {
+  local prompt_file="$1"
+  local model="${2:-openai/o4-mini}"
+  python3 -c "
+import json, sys
+prompt = open(sys.argv[1]).read()
+model  = sys.argv[2]
+sys.stdout.write(json.dumps({
+    'model': model,
+    'messages': [{'role': 'user', 'content': prompt}],
+    'temperature': 0,
+}))
+" "$prompt_file" "$model"
+}
+
+# Assert that a string is valid JSON.
+assert_valid_json() {
+  local name="$1"
+  local json_str="$2"
+  if echo "$json_str" | python3 -c "import json,sys; json.load(sys.stdin)" 2>/dev/null; then
+    ok "$name"
+  else
+    fail "$name" "produced invalid JSON"
+  fi
+}
+
+# Assert that a JSON string has a specific field value.
+assert_json_field() {
+  local name="$1"
+  local json_str="$2"
+  local field="$3"
+  local expected="$4"
+  local got
+  got=$(echo "$json_str" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d$field)" 2>/dev/null || echo "ERROR")
+  if [ "$got" = "$expected" ]; then
+    ok "$name"
+  else
+    fail "$name" "expected '$expected', got '$got'"
+  fi
+}
+
+TMPDIR_TESTS=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_TESTS"' EXIT
+
+# ---------------------------------------------------------------------------
+# Test 1: Plain ASCII prompt
+# ---------------------------------------------------------------------------
+PROMPT="$TMPDIR_TESTS/plain.txt"
+printf 'Review this PR and output JSON.' > "$PROMPT"
+PAYLOAD=$(build_payload "$PROMPT")
+assert_valid_json "plain ASCII prompt: valid JSON" "$PAYLOAD"
+assert_json_field "plain ASCII prompt: model field" "$PAYLOAD" "['model']" "openai/o4-mini"
+
+# ---------------------------------------------------------------------------
+# Test 2: Prompt with double quotes (the old `gh copilot suggest -p "..."`
+#          approach would have broken shell quoting here)
+# ---------------------------------------------------------------------------
+PROMPT="$TMPDIR_TESTS/quotes.txt"
+printf 'Say "hello world" and output {"key": "value"}.' > "$PROMPT"
+PAYLOAD=$(build_payload "$PROMPT")
+assert_valid_json "prompt with double quotes: valid JSON" "$PAYLOAD"
+
+# ---------------------------------------------------------------------------
+# Test 3: Prompt with single quotes
+# ---------------------------------------------------------------------------
+PROMPT="$TMPDIR_TESTS/single_quotes.txt"
+printf "It's a test. Don't break." > "$PROMPT"
+PAYLOAD=$(build_payload "$PROMPT")
+assert_valid_json "prompt with single quotes: valid JSON" "$PAYLOAD"
+
+# ---------------------------------------------------------------------------
+# Test 4: Prompt with markdown headings (# chars)
+# This was the trigger for "Invalid command format" in the old invocation:
+# the expanded prompt started with "# Tier 1: Triage..." which the CLI
+# misinterpreted as a flag/subcommand.
+# ---------------------------------------------------------------------------
+PROMPT="$TMPDIR_TESTS/markdown.txt"
+printf '# Tier 1: Triage\n\nReview the PR.\n\n## Output\n\n{"escalate": false}\n' > "$PROMPT"
+PAYLOAD=$(build_payload "$PROMPT")
+assert_valid_json "prompt with markdown headings (#): valid JSON" "$PAYLOAD"
+CONTENT=$(echo "$PAYLOAD" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['messages'][0]['content'])" 2>/dev/null)
+if printf '%s' "$CONTENT" | grep -q '# Tier 1: Triage'; then
+  ok "prompt with markdown headings: # preserved in content"
+else
+  fail "prompt with markdown headings: # preserved in content" "heading not found in encoded content"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: Prompt with newlines and backslashes
+# ---------------------------------------------------------------------------
+PROMPT="$TMPDIR_TESTS/newlines.txt"
+printf 'Line 1\nLine 2\nPath: C:\\Users\\test\n' > "$PROMPT"
+PAYLOAD=$(build_payload "$PROMPT")
+assert_valid_json "prompt with newlines and backslashes: valid JSON" "$PAYLOAD"
+
+# ---------------------------------------------------------------------------
+# Test 6: Large prompt (simulating a real triage-prompt.md with PR diff)
+# ---------------------------------------------------------------------------
+PROMPT="$TMPDIR_TESTS/large.txt"
+{
+  printf '# Tier 1: Triage\n\n'
+  printf 'PR_URL: https://github.com/org/repo/pull/42\n'
+  printf 'PR_HEAD_SHA: abc123def456\n\n'
+  # Simulate a 200-line diff
+  for i in $(seq 1 200); do
+    printf '+  line %d: some code change with "quotes" and $variables\n' "$i"
+  done
+} > "$PROMPT"
+PAYLOAD=$(build_payload "$PROMPT")
+assert_valid_json "large prompt (200-line diff): valid JSON" "$PAYLOAD"
+CONTENT_LEN=$(echo "$PAYLOAD" | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d['messages'][0]['content']))" 2>/dev/null || echo 0)
+if [ "$CONTENT_LEN" -gt 1000 ]; then
+  ok "large prompt: full content preserved (len=$CONTENT_LEN)"
+else
+  fail "large prompt: full content preserved" "content length $CONTENT_LEN is unexpectedly short"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7: Prompt with Unicode
+# ---------------------------------------------------------------------------
+PROMPT="$TMPDIR_TESTS/unicode.txt"
+printf 'Review: résumé → naïve → José → 中文 → 日本語\n' > "$PROMPT"
+PAYLOAD=$(build_payload "$PROMPT")
+assert_valid_json "prompt with Unicode: valid JSON" "$PAYLOAD"
+
+# ---------------------------------------------------------------------------
+# Test 8: Custom model name propagated correctly
+# ---------------------------------------------------------------------------
+PROMPT="$TMPDIR_TESTS/model.txt"
+printf 'Simple prompt.\n' > "$PROMPT"
+PAYLOAD=$(build_payload "$PROMPT" "openai/gpt-4o-mini")
+assert_json_field "custom model name: model field" "$PAYLOAD" "['model']" "openai/gpt-4o-mini"
+
+# ---------------------------------------------------------------------------
+# Test 9: Messages array has correct structure
+# ---------------------------------------------------------------------------
+PROMPT="$TMPDIR_TESTS/structure.txt"
+printf 'Check structure.\n' > "$PROMPT"
+PAYLOAD=$(build_payload "$PROMPT")
+MSG_ROLE=$(echo "$PAYLOAD" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['messages'][0]['role'])" 2>/dev/null || echo "ERROR")
+if [ "$MSG_ROLE" = "user" ]; then
+  ok "messages[0].role is 'user'"
+else
+  fail "messages[0].role is 'user'" "got '$MSG_ROLE'"
+fi
+TEMPERATURE=$(echo "$PAYLOAD" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['temperature'])" 2>/dev/null || echo "ERROR")
+if [ "$TEMPERATURE" = "0" ]; then
+  ok "temperature is 0"
+else
+  fail "temperature is 0" "got '$TEMPERATURE'"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  printf '%b' "$ERRORS"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- **Root cause**: `scripts/engine.sh` invoked `gh copilot suggest -p "$(cat <file>)"` in three places. The `-p` flag is invalid in modern `gh copilot` built-in versions, producing `error: Invalid command format`. Additionally, `gh copilot suggest` is a shell-command suggestion tool — it cannot handle multi-thousand-line PR prompts or return structured JSON. The resulting non-zero exit was misclassified by the rate-limit detector, aborting the entire review session.
- **Fix**: Replace all three copilot invocations (`run_triage`, `run_agentic`, `run_duck`) with a new `copilot_chat` helper that calls the **GitHub Models REST API** (`https://models.github.ai/inference/chat/completions`) via `curl`. The API is OpenAI-compatible, versioned via `X-GitHub-Api-Version`, and stable against `gh` CLI version changes.
- **Prompt encoding**: Uses `python3` for JSON payload building — safely handles special characters, `#` headings, newlines, quotes, and large PR diffs without ARG_MAX issues.
- **Rate-limit detection**: HTTP 429 responses are echoed to stdout so the existing `is_rate_limited()` detector fires correctly for engine fallback (exit 2).
- **Pre-flight smoke test**: Added to `review-batch.sh` — verifies GitHub Models API connectivity before processing any PRs; format/auth errors now surface as a clear setup failure rather than mid-run false-positive rate-limits.
- **Unit tests**: `tests/test_copilot_chat.sh` tests the JSON payload builder with edge-case prompts (quotes, newlines, `#` headings, large diffs, Unicode, backslashes).
- **Model config**: Added `COPILOT_API_MODEL` env var (default `openai/o4-mini`) overrideable at the job level if the default model is unavailable.

## Changes

| File | Change |
|------|--------|
| `scripts/engine.sh` | Add `copilot_chat` helper; replace 3x `gh copilot suggest` calls; add `COPILOT_API_MODEL` |
| `scripts/review-batch.sh` | Add Copilot pre-flight smoke test block |
| `tests/test_copilot_chat.sh` | New: 9 unit tests for the JSON payload builder |

## Test plan

- [x] Unit tests (`tests/test_copilot_chat.sh`): payload builder handles all edge cases
- [ ] Integration: run `bash scripts/review-batch.sh` with `REVIEW_ENGINE=copilot` against a real low-risk PR, confirm triage tier completes with exit 0

Closes #147

Generated with [Claude Code](https://claude.ai/code)