### PR TITLE
fix: remove temperature from copilot_chat payload (o4-mini incompatible)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,14 @@
+name: Unit Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run copilot_chat unit tests
+        run: bash tests/test_copilot_chat.sh

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -145,7 +145,6 @@ model  = sys.argv[2]
 sys.stdout.write(json.dumps({
     'model': model,
     'messages': [{'role': 'user', 'content': prompt}],
-    'temperature': 0,
 }))
 " "$prompt_file" "${COPILOT_API_MODEL:-openai/o4-mini}" > "$_body_file" || {
     rm -f "$_body_file"

--- a/tests/test_copilot_chat.sh
+++ b/tests/test_copilot_chat.sh
@@ -45,7 +45,6 @@ model  = sys.argv[2]
 sys.stdout.write(json.dumps({
     'model': model,
     'messages': [{'role': 'user', 'content': prompt}],
-    'temperature': 0,
 }))
 " "$prompt_file" "$model"
 }
@@ -180,11 +179,13 @@ if [ "$MSG_ROLE" = "user" ]; then
 else
   fail "messages[0].role is 'user'" "got '$MSG_ROLE'"
 fi
-TEMPERATURE=$(echo "$PAYLOAD" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['temperature'])" 2>/dev/null || echo "ERROR")
-if [ "$TEMPERATURE" = "0" ]; then
-  ok "temperature is 0"
+# temperature must be absent from the payload — o4-mini (and other reasoning
+# models) only support the default value and reject temperature=0 with HTTP 400.
+TEMPERATURE=$(echo "$PAYLOAD" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('temperature', 'ABSENT'))" 2>/dev/null || echo "ERROR")
+if [ "$TEMPERATURE" = "ABSENT" ]; then
+  ok "temperature is absent from payload (required for o4-mini compatibility)"
 else
-  fail "temperature is 0" "got '$TEMPERATURE'"
+  fail "temperature is absent from payload" "got '$TEMPERATURE' — o4-mini rejects temperature != default"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Run job/75690347409 showed the rubber duck silently failing on every review:

```
[tier2] rubber duck did not produce valid JSON — continuing with deep review only
copilot_chat: HTTP 400 from GitHub Models API
{ "error": { "message": "Unsupported value: 'temperature' does not support 0 with this model. Only the default (1) value is supported." } }
```

### Root cause

`copilot_chat()` sends `"temperature": 0`. OpenAI reasoning models (o4-mini, o1, o3) only support the default temperature of 1 and reject anything else with HTTP 400. The code degrades gracefully so the run shows green, but the duck was never actually running.

### Changes

| File | Change |
|------|--------|
| `scripts/engine.sh` | Remove `'temperature': 0` from `copilot_chat` payload builder |
| `tests/test_copilot_chat.sh` | Sync `build_payload` copy; flip Test 9 to assert temperature is **absent** |
| `.github/workflows/test.yml` | **New**: run unit tests on every PR + push to main |

### Testing

```
$ bash tests/test_copilot_chat.sh
Results: 13 passed, 0 failed
```