### PR TITLE
ci: add cron entries at :22, :37, :52 to ensure hourly runs

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -2,8 +2,14 @@ name: PR Review Agent
 
 on:
   schedule:
-    # Every 15 min to ensure at least one fires per hour
-    # (GitHub Actions scheduled runs can be delayed/skipped under load)
+    # Strategy: four staggered offsets per hour to improve the reliability of
+    # getting at least one scheduled run per clock-hour. GitHub Actions scheduled
+    # workflows are frequently delayed or skipped under load. The shared concurrency
+    # group (pr-review-scheduled) serializes runs so at most one executes at a time;
+    # additional triggers queue rather than overlap. Queued runs are cheap to no-op:
+    # the per-PR idempotency check (head-SHA comparison) skips any PR already
+    # reviewed since the last push, so back-to-back queued runs won't produce
+    # duplicate reviews.
     - cron: "7 * * * *"
     - cron: "22 * * * *"
     - cron: "37 * * * *"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -2,8 +2,12 @@ name: PR Review Agent
 
 on:
   schedule:
-    # Hourly at :07 to avoid the top-of-hour cron stampede
+    # Every 15 min to ensure at least one fires per hour
+    # (GitHub Actions scheduled runs can be delayed/skipped under load)
     - cron: "7 * * * *"
+    - cron: "22 * * * *"
+    - cron: "37 * * * *"
+    - cron: "52 * * * *"
   workflow_dispatch:
     inputs:
       pr_url:


### PR DESCRIPTION
## Problem

GitHub Actions scheduled workflows are frequently delayed or skipped under load on the shared runner fleet. The single cron entry (`7 * * * *`) is configured to run hourly but in practice fires every 2–5 hours.

## Strategy

Add three additional staggered cron offsets so the scheduler has four chances per clock-hour to fire at least one run:

```yaml
- cron: "7 * * * *"
- cron: "22 * * * *"
- cron: "37 * * * *"
- cron: "52 * * * *"
```

Two existing guards ensure this doesn’t cause duplicate work or runaway resource usage:

| Guard | Effect |
|---|---|
| **Shared concurrency group** (`pr-review-scheduled`, `cancel-in-progress: false`) | Serializes runs — at most one executes at a time; extra triggers queue rather than run in parallel |
| **Per-PR idempotency check** (head-SHA comparison in `review-batch.sh`) | Any PR already reviewed at its current head SHA is skipped in O(1); back-to-back queued runs no-op cheaply without producing duplicate reviews |

The net effect: if GitHub skips one or two triggers under load, the next offset within the same hour will pick it up. If all four fire, only one run does real work; the rest drain the queue quickly via idempotency short-circuits.