### PR TITLE
fix: upgrade actions/cache from v4 to v5

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -90,7 +90,7 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Cache claude-code CLI
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.npm-global
           key: claude-code-${{ env.CLAUDE_CODE_VERSION }}-${{ runner.os }}


### PR DESCRIPTION
## Summary

- Upgrades `actions/cache@v4` → `actions/cache@v5` in `pr-review.yml`
- `actions/cache@v4` runs on Node.js 20, which GitHub Actions is deprecating (forced to Node.js 24 on **June 2, 2026**; Node.js 20 removed September 16, 2026)

## Why wasn't this caught by Dependabot?

This repo has no `dependabot.yml` configured. With a `github-actions` ecosystem entry, Dependabot would have flagged `actions/cache@v4` automatically when v5 shipped. Worth adding.

## Test plan

- [ ] Verify the `Cache claude-code CLI` step succeeds after merge (cache hit/miss both work with v5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)