### PR TITLE
feat(dev-lead): Phase 0+1 — test infrastructure and intent stub

### DIFF
--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -68,7 +68,7 @@ jobs:
         id: intent
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          # GITHUB_EVENT_PATH is set automatically by GitHub Actions — no override needed
         run: bash scripts/dev-lead-intent.sh
 
       - name: Log intent
@@ -230,19 +230,26 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          gh api \
+          # Build a proper nested JSON payload; --field cannot encode nested objects
+          payload=$(jq -n \
+            --argjson pr_number '${{ steps.check-pr.outputs.pr_number }}' \
+            --arg head_sha '${{ github.event.check_run.head_sha }}' \
+            --arg repo '${{ github.repository }}' \
+            --arg name '${{ github.event.check_run.name }}' \
+            --arg conclusion '${{ github.event.check_run.conclusion }}' \
+            --arg details_url '${{ github.event.check_run.details_url }}' \
+            --arg app_slug '${{ github.event.check_run.app.slug }}' \
+            '{
+              event_type: "dev-lead-ci-failure",
+              client_payload: {
+                pr_number: $pr_number,
+                head_sha: $head_sha,
+                repo: $repo,
+                checks: [{name: $name, conclusion: $conclusion, details_url: $details_url, app_slug: $app_slug}]
+              }
+            }')
+          echo "$payload" | gh api \
             --method POST \
             "repos/${{ github.repository }}/dispatches" \
-            --field event_type=dev-lead-ci-failure \
-            --field client_payload="{
-              \"pr_number\": ${{ steps.check-pr.outputs.pr_number }},
-              \"head_sha\": \"${{ github.event.check_run.head_sha }}\",
-              \"repo\": \"${{ github.repository }}\",
-              \"checks\": [{
-                \"name\": \"${{ github.event.check_run.name }}\",
-                \"conclusion\": \"${{ github.event.check_run.conclusion }}\",
-                \"details_url\": \"${{ github.event.check_run.details_url }}\",
-                \"app_slug\": \"${{ github.event.check_run.app.slug }}\"
-              }]
-            }"
+            --input -
           echo "::notice::Relayed CI failure for PR ${{ steps.check-pr.outputs.pr_number }} — dispatched dev-lead-ci-failure"

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -91,6 +91,8 @@ jobs:
 
       - name: Install engine CLIs
         if: env.INTENT_TYPE != 'skip'
+        env:
+          CLAUDE_CODE_VERSION: ${{ vars.CLAUDE_CODE_VERSION || 'latest' }}
         run: |
           set -euo pipefail
           mkdir -p "$HOME/.npm-global"
@@ -98,7 +100,6 @@ jobs:
           echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
           export PATH="$HOME/.npm-global/bin:$PATH"
 
-          CLAUDE_CODE_VERSION="${{ vars.CLAUDE_CODE_VERSION || 'latest' }}"
           if ! command -v claude >/dev/null 2>&1; then
             npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
           fi

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -1,0 +1,223 @@
+name: Dev-Lead Agent
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+  issues:
+    types: [labeled]
+  check_run:
+    types: [completed]
+  repository_dispatch:
+    types: [dev-lead-ci-failure]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  checks: read
+
+concurrency:
+  # Per-PR slots for most events; ci-relay is ephemeral and runs immediately
+  group: >-
+    ${{
+      github.event_name == 'check_run' && format('dev-lead-ci-relay-{0}', github.event.check_run.head_sha) ||
+      github.event_name == 'repository_dispatch' && format('dev-lead-fix-ci-{0}', github.event.client_payload.pr_number) ||
+      github.event_name == 'issues' && format('dev-lead-issue-{0}', github.event.issue.number) ||
+      format('dev-lead-pr-{0}', github.event.pull_request.number || github.event.issue.number || '0')
+    }}
+  cancel-in-progress: false
+
+env:
+  BOT_USER: ${{ vars.BOT_USER || 'donpetry-bot' }}
+  TRUSTED_BOTS: ${{ vars.TRUSTED_BOTS || 'copilot-pull-request-reviewer[bot],gemini-code-assist[bot],sonarqubecloud[bot],coderabbitai[bot]' }}
+  TRIGGER_PHRASES: ${{ vars.TRIGGER_PHRASES || '@dev-lead' }}
+  DEV_LEAD_ENGINE: ${{ vars.DEV_LEAD_ENGINE || 'claude' }}
+  DEV_LEAD_DRY_RUN: ${{ vars.DEV_LEAD_DRY_RUN || 'false' }}
+  GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS || secrets.GITHUB_TOKEN }}
+
+jobs:
+  # ── dispatch ────────────────────────────────────────────────────────────────
+  # Handles all events except check_run (which goes to ci-relay).
+  # 1. Runs dev-lead-intent.sh to classify the event into an intent.
+  # 2. Routes to the appropriate action based on intent.
+  dispatch:
+    if: github.event_name != 'check_run'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      COPILOT_GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+
+    steps:
+      - name: Checkout agent repo
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          token: ${{ secrets.GH_PAT_WORKFLOWS || secrets.GITHUB_TOKEN }}
+
+      - name: Pre-flight checks
+        run: bash scripts/dev-lead-preflight.sh
+
+      - name: Classify event intent
+        id: intent
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+        run: bash scripts/dev-lead-intent.sh
+
+      - name: Log intent
+        run: |
+          echo "::notice::intent=${{ env.INTENT_TYPE }} reason=${{ env.INTENT_REASON }}"
+
+      - name: Skip — log reason
+        if: env.INTENT_TYPE == 'skip'
+        run: |
+          echo "::notice::Skipping event: ${{ env.INTENT_REASON }}"
+
+      # ── Install engine CLIs ───────────────────────────────────────────────
+      - name: Cache claude-code CLI
+        if: env.INTENT_TYPE != 'skip'
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.npm-global
+          key: claude-code-${{ vars.CLAUDE_CODE_VERSION || 'latest' }}-${{ runner.os }}
+
+      - name: Install engine CLIs
+        if: env.INTENT_TYPE != 'skip'
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.npm-global"
+          npm config set prefix "$HOME/.npm-global"
+          echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.npm-global/bin:$PATH"
+
+          CLAUDE_CODE_VERSION="${{ vars.CLAUDE_CODE_VERSION || 'latest' }}"
+          if ! command -v claude >/dev/null 2>&1; then
+            npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
+          fi
+
+          case "$DEV_LEAD_ENGINE" in
+            gemini)
+              npm install -g @google/gemini-cli || true ;;
+            copilot)
+              if ! gh copilot --version >/dev/null 2>&1; then
+                gh extension install github/gh-copilot || true
+              fi ;;
+          esac
+
+      # ── fix-ci ────────────────────────────────────────────────────────────
+      - name: Run fix-ci
+        if: env.INTENT_TYPE == 'fix-ci'
+        run: |
+          echo "::notice::Running fix-ci for PR ${{ env.INTENT_CONTEXT }}"
+          # TODO Phase 2: implement fix-ci runner
+
+      # ── fix-reviews ───────────────────────────────────────────────────────
+      - name: Run fix-reviews
+        if: env.INTENT_TYPE == 'fix-reviews'
+        run: |
+          echo "::notice::Running fix-reviews for PR ${{ env.INTENT_CONTEXT }}"
+          # TODO Phase 2: implement fix-reviews runner
+
+      # ── fix-bot-comment ───────────────────────────────────────────────────
+      - name: Run fix-bot-comment
+        if: env.INTENT_TYPE == 'fix-bot-comment'
+        run: |
+          echo "::notice::Running fix-bot-comment for PR ${{ env.INTENT_CONTEXT }}"
+          # TODO Phase 2: implement fix-bot-comment runner
+
+      # ── human ─────────────────────────────────────────────────────────────
+      - name: Run human
+        if: env.INTENT_TYPE == 'human'
+        run: |
+          echo "::notice::Running human task for PR ${{ env.INTENT_CONTEXT }}"
+          # TODO Phase 2: implement human runner
+
+      # ── human-pr ──────────────────────────────────────────────────────────
+      - name: Run human-pr
+        if: env.INTENT_TYPE == 'human-pr'
+        run: |
+          echo "::notice::Running human-pr for PR ${{ env.INTENT_CONTEXT }}"
+          # TODO Phase 2: implement human-pr runner
+
+      # ── issue ─────────────────────────────────────────────────────────────
+      - name: Run issue
+        if: env.INTENT_TYPE == 'issue'
+        run: |
+          echo "::notice::Running issue for #${{ env.INTENT_CONTEXT }}"
+          # TODO Phase 2: implement issue runner
+
+      # ── rebase ────────────────────────────────────────────────────────────
+      - name: Run rebase
+        if: env.INTENT_TYPE == 'rebase'
+        run: |
+          echo "::notice::Running rebase for PR ${{ env.INTENT_CONTEXT }}"
+          # TODO Phase 2: implement rebase runner
+
+  # ── ci-relay ────────────────────────────────────────────────────────────────
+  # Handles check_run completed events only.
+  # No LLM involved — resolves the PR number from the check and fires
+  # a repository_dispatch so the dispatch job can handle it asynchronously.
+  ci-relay:
+    if: >-
+      github.event_name == 'check_run' &&
+      github.event.action == 'completed' &&
+      github.event.check_run.conclusion == 'failure' &&
+      !startsWith(github.event.check_run.name, 'dev-lead / ')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check for associated non-fork PR
+        id: check-pr
+        env:
+          CHECK_RUN_PRS: ${{ toJson(github.event.check_run.pull_requests) }}
+          REPO_FULL_NAME: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Require at least one PR in the check_run.pull_requests array
+          pr_count=$(echo "$CHECK_RUN_PRS" | jq 'length')
+          if [ "$pr_count" -eq 0 ]; then
+            echo "::notice::check_run has no associated PRs — skipping relay"
+            echo "should_relay=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Require PR head repo matches this repo (not a fork)
+          head_repo=$(echo "$CHECK_RUN_PRS" | jq -r '.[0].head.repo.full_name')
+          if [ "$head_repo" != "$REPO_FULL_NAME" ]; then
+            echo "::notice::check_run PR is from fork ($head_repo) — skipping relay"
+            echo "should_relay=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          pr_number=$(echo "$CHECK_RUN_PRS" | jq -r '.[0].number')
+          echo "should_relay=true" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+
+      - name: Emit repository_dispatch dev-lead-ci-failure
+        if: steps.check-pr.outputs.should_relay == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh api \
+            --method POST \
+            "repos/${{ github.repository }}/dispatches" \
+            --field event_type=dev-lead-ci-failure \
+            --field client_payload="{
+              \"pr_number\": ${{ steps.check-pr.outputs.pr_number }},
+              \"head_sha\": \"${{ github.event.check_run.head_sha }}\",
+              \"repo\": \"${{ github.repository }}\",
+              \"checks\": [{
+                \"name\": \"${{ github.event.check_run.name }}\",
+                \"conclusion\": \"${{ github.event.check_run.conclusion }}\",
+                \"details_url\": \"${{ github.event.check_run.details_url }}\",
+                \"app_slug\": \"${{ github.event.check_run.app.slug }}\"
+              }]
+            }"
+          echo "::notice::Relayed CI failure for PR ${{ steps.check-pr.outputs.pr_number }} — dispatched dev-lead-ci-failure"

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -61,9 +61,6 @@ jobs:
         with:
           token: ${{ secrets.GH_PAT_WORKFLOWS || secrets.GITHUB_TOKEN }}
 
-      - name: Pre-flight checks
-        run: bash scripts/dev-lead-preflight.sh
-
       - name: Classify event intent
         id: intent
         env:
@@ -79,6 +76,10 @@ jobs:
         if: env.INTENT_TYPE == 'skip'
         run: |
           echo "::notice::Skipping event: ${{ env.INTENT_REASON }}"
+
+      - name: Pre-flight checks
+        if: env.INTENT_TYPE != 'skip'
+        run: bash scripts/dev-lead-preflight.sh
 
       # ── Install engine CLIs ───────────────────────────────────────────────
       - name: Cache claude-code CLI
@@ -213,10 +214,12 @@ jobs:
             echo "should_relay=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # Require PR head repo matches this repo (not a fork)
-          head_repo=$(echo "$CHECK_RUN_PRS" | jq -r '.[0].head.repo.full_name')
-          if [ "$head_repo" != "$REPO_FULL_NAME" ]; then
-            echo "::notice::check_run PR is from fork ($head_repo) — skipping relay"
+          # Fork check: check_run.pull_requests[*].head.repo only contains id/url/name
+          # (not full_name), so compare the API URL pattern against the expected repo URL.
+          head_repo_url=$(echo "$CHECK_RUN_PRS" | jq -r '.[0].head.repo.url // empty')
+          expected_url="https://api.github.com/repos/${REPO_FULL_NAME}"
+          if [ -n "$head_repo_url" ] && [ "$head_repo_url" != "$expected_url" ]; then
+            echo "::notice::check_run PR head repo URL ($head_repo_url) does not match expected ($expected_url) — fork, skipping relay"
             echo "should_relay=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -114,51 +114,76 @@ jobs:
       # ── fix-ci ────────────────────────────────────────────────────────────
       - name: Run fix-ci
         if: env.INTENT_TYPE == 'fix-ci'
-        run: |
-          echo "::notice::Running fix-ci for PR ${{ env.INTENT_CONTEXT }}"
-          # TODO Phase 2: implement fix-ci runner
+        env:
+          PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
+          HEAD_SHA: ${{ fromJson(env.INTENT_CONTEXT).head_sha }}
+          CHECKS_JSON: ${{ toJson(fromJson(env.INTENT_CONTEXT).checks) }}
+          REPO: ${{ github.repository }}
+          REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
+        run: bash scripts/dev-lead-fix-ci.sh
 
       # ── fix-reviews ───────────────────────────────────────────────────────
       - name: Run fix-reviews
         if: env.INTENT_TYPE == 'fix-reviews'
-        run: |
-          echo "::notice::Running fix-reviews for PR ${{ env.INTENT_CONTEXT }}"
-          # TODO Phase 2: implement fix-reviews runner
+        env:
+          INTENT_TYPE: fix-reviews
+          PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
+          HEAD_SHA: ${{ fromJson(env.INTENT_CONTEXT).head_sha }}
+          REPO: ${{ github.repository }}
+          REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
+        run: bash scripts/dev-lead-fix-reviews.sh
 
       # ── fix-bot-comment ───────────────────────────────────────────────────
       - name: Run fix-bot-comment
         if: env.INTENT_TYPE == 'fix-bot-comment'
-        run: |
-          echo "::notice::Running fix-bot-comment for PR ${{ env.INTENT_CONTEXT }}"
-          # TODO Phase 2: implement fix-bot-comment runner
+        env:
+          INTENT_TYPE: fix-bot-comment
+          PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
+          HEAD_SHA: ${{ fromJson(env.INTENT_CONTEXT).head_sha }}
+          REPO: ${{ github.repository }}
+          REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
+        run: bash scripts/dev-lead-fix-reviews.sh
 
       # ── human ─────────────────────────────────────────────────────────────
       - name: Run human
         if: env.INTENT_TYPE == 'human'
-        run: |
-          echo "::notice::Running human task for PR ${{ env.INTENT_CONTEXT }}"
-          # TODO Phase 2: implement human runner
+        env:
+          INTENT_TYPE: human
+          PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
+          HEAD_SHA: ${{ fromJson(env.INTENT_CONTEXT).head_sha }}
+          REPO: ${{ github.repository }}
+          REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
+        run: bash scripts/dev-lead-fix-reviews.sh
 
       # ── human-pr ──────────────────────────────────────────────────────────
       - name: Run human-pr
         if: env.INTENT_TYPE == 'human-pr'
-        run: |
-          echo "::notice::Running human-pr for PR ${{ env.INTENT_CONTEXT }}"
-          # TODO Phase 2: implement human-pr runner
+        env:
+          INTENT_TYPE: human-pr
+          PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
+          HEAD_SHA: ${{ fromJson(env.INTENT_CONTEXT).head_sha }}
+          REPO: ${{ github.repository }}
+          REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
+        run: bash scripts/dev-lead-fix-reviews.sh
 
       # ── issue ─────────────────────────────────────────────────────────────
       - name: Run issue
         if: env.INTENT_TYPE == 'issue'
-        run: |
-          echo "::notice::Running issue for #${{ env.INTENT_CONTEXT }}"
-          # TODO Phase 2: implement issue runner
+        env:
+          ISSUE_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).issue_number }}
+          REPO: ${{ github.repository }}
+          REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
+        run: bash scripts/dev-lead-fix-issue.sh
 
       # ── rebase ────────────────────────────────────────────────────────────
       - name: Run rebase
         if: env.INTENT_TYPE == 'rebase'
-        run: |
-          echo "::notice::Running rebase for PR ${{ env.INTENT_CONTEXT }}"
-          # TODO Phase 2: implement rebase runner
+        env:
+          INTENT_TYPE: rebase
+          PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
+          REPO: ${{ github.repository }}
+          REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
+        run: bash scripts/dev-lead-fix-reviews.sh
 
   # ── ci-relay ────────────────────────────────────────────────────────────────
   # Handles check_run completed events only.

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -70,12 +70,12 @@ jobs:
 
       - name: Log intent
         run: |
-          echo "::notice::intent=${{ env.INTENT_TYPE }} reason=${{ env.INTENT_REASON }}"
+          echo "::notice::intent=$INTENT_TYPE reason=$INTENT_REASON"
 
       - name: Skip — log reason
         if: env.INTENT_TYPE == 'skip'
         run: |
-          echo "::notice::Skipping event: ${{ env.INTENT_REASON }}"
+          echo "::notice::Skipping event: $INTENT_REASON"
 
       - name: Pre-flight checks
         if: env.INTENT_TYPE != 'skip'
@@ -231,17 +231,25 @@ jobs:
         if: steps.check-pr.outputs.should_relay == 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS || secrets.GITHUB_TOKEN }}
+          # Move all event-sourced values to env vars to prevent script injection
+          RELAY_PR_NUMBER: ${{ steps.check-pr.outputs.pr_number }}
+          RELAY_HEAD_SHA: ${{ github.event.check_run.head_sha }}
+          RELAY_REPO: ${{ github.repository }}
+          RELAY_CHECK_NAME: ${{ github.event.check_run.name }}
+          RELAY_CONCLUSION: ${{ github.event.check_run.conclusion }}
+          RELAY_DETAILS_URL: ${{ github.event.check_run.details_url }}
+          RELAY_APP_SLUG: ${{ github.event.check_run.app.slug }}
         run: |
           set -euo pipefail
-          # Build a proper nested JSON payload; --field cannot encode nested objects
+          # Build a proper nested JSON payload via jq to avoid shell injection
           payload=$(jq -n \
-            --argjson pr_number '${{ steps.check-pr.outputs.pr_number }}' \
-            --arg head_sha '${{ github.event.check_run.head_sha }}' \
-            --arg repo '${{ github.repository }}' \
-            --arg name '${{ github.event.check_run.name }}' \
-            --arg conclusion '${{ github.event.check_run.conclusion }}' \
-            --arg details_url '${{ github.event.check_run.details_url }}' \
-            --arg app_slug '${{ github.event.check_run.app.slug }}' \
+            --argjson pr_number "$RELAY_PR_NUMBER" \
+            --arg head_sha "$RELAY_HEAD_SHA" \
+            --arg repo "$RELAY_REPO" \
+            --arg name "$RELAY_CHECK_NAME" \
+            --arg conclusion "$RELAY_CONCLUSION" \
+            --arg details_url "$RELAY_DETAILS_URL" \
+            --arg app_slug "$RELAY_APP_SLUG" \
             '{
               event_type: "dev-lead-ci-failure",
               client_payload: {
@@ -253,6 +261,6 @@ jobs:
             }')
           echo "$payload" | gh api \
             --method POST \
-            "repos/${{ github.repository }}/dispatches" \
+            "repos/$RELAY_REPO/dispatches" \
             --input -
-          echo "::notice::Relayed CI failure for PR ${{ steps.check-pr.outputs.pr_number }} — dispatched dev-lead-ci-failure"
+          echo "::notice::Relayed CI failure for PR $RELAY_PR_NUMBER — dispatched dev-lead-ci-failure"

--- a/.github/workflows/test-dev-lead.yml
+++ b/.github/workflows/test-dev-lead.yml
@@ -1,0 +1,53 @@
+name: Test Dev-Lead Agent
+on:
+  pull_request:
+    paths:
+      - 'scripts/dev-lead*'
+      - 'scripts/engine.sh'
+      - '.github/workflows/dev-lead*.yml'
+      - '.github/workflows/test-dev-lead.yml'
+      - 'tests/dev-lead/**'
+      - 'prompts/dev-lead/**'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/dev-lead*'
+      - 'scripts/engine.sh'
+      - 'tests/dev-lead/**'
+      - 'prompts/dev-lead/**'
+  workflow_dispatch: {}
+
+jobs:
+  validate-fixtures:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Validate event fixtures
+        run: find tests/dev-lead/fixtures/events -name '*.json' -exec jq empty {} \;
+
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Install bats
+        run: |
+          npm install -g bats bats-support bats-assert
+      - name: Run unit tests (if exist)
+        run: |
+          if ls tests/dev-lead/unit/*.bats 2>/dev/null; then
+            bats tests/dev-lead/unit/ --formatter tap
+          else
+            echo "No unit tests yet - harness verified"
+          fi
+
+  prompt-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Verify prompt variable coverage
+        run: |
+          if [ -f tests/dev-lead/integration/test_prompt_coverage.sh ]; then
+            bash tests/dev-lead/integration/test_prompt_coverage.sh
+          else
+            echo "Prompt coverage test not yet implemented"
+          fi

--- a/.github/workflows/test-dev-lead.yml
+++ b/.github/workflows/test-dev-lead.yml
@@ -35,7 +35,11 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install bats
         run: |
-          npm install -g bats bats-support bats-assert
+          # Install bats-core to user-local prefix to avoid root requirement
+          mkdir -p "$HOME/.local/bin" "$HOME/.local/lib"
+          git clone --depth 1 https://github.com/bats-core/bats-core.git /tmp/bats-core
+          bash /tmp/bats-core/install.sh "$HOME/.local"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Run unit tests (if exist)
         run: |
           if ls tests/dev-lead/unit/*.bats 2>/dev/null; then

--- a/.github/workflows/test-dev-lead.yml
+++ b/.github/workflows/test-dev-lead.yml
@@ -20,6 +20,8 @@ on:
 jobs:
   validate-fixtures:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Validate event fixtures
@@ -27,6 +29,8 @@ jobs:
 
   unit:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install bats
@@ -42,6 +46,8 @@ jobs:
 
   prompt-coverage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Verify prompt variable coverage

--- a/prompts/dev-lead/fix-bot-comment.md
+++ b/prompts/dev-lead/fix-bot-comment.md
@@ -1,0 +1,46 @@
+<!-- VARIABLES: PR_NUMBER, PR_URL, REPO, ACTOR, COMMENT_BODY, HEAD_SHA -->
+# Dev-Lead Agent: Fix Bot Comment Issues
+You are the dev-lead agent for the `${REPO}` repository. Your task is to address issues raised by an automated code analysis bot on a pull request.
+
+## Context
+
+- **Repository:** `${REPO}`
+- **Pull Request:** [#${PR_NUMBER}](${PR_URL})
+- **Head SHA:** `${HEAD_SHA}`
+- **Bot:** `${ACTOR}`
+
+## Bot Comment
+
+```
+${COMMENT_BODY}
+```
+
+## Task
+
+Analyze the bot's findings and address each actionable issue:
+
+1. Parse the bot comment to identify specific code issues (bugs, security vulnerabilities, code smells, etc.)
+2. Locate the referenced files and line numbers using Read/Grep/Glob tools
+3. Apply targeted fixes using Edit/Write tools
+4. Verify that the fixes are complete and do not introduce regressions
+5. Commit changes with a message: `fix(bot): address ${ACTOR} findings on PR #${PR_NUMBER}`
+
+## Constraints
+
+- Only fix issues that are clearly actionable from the bot's output
+- Do not fix issues marked as "informational" or "suggestion" unless they indicate a real bug
+- Do not suppress bot rules without a documented reason
+- Do not modify the bot's configuration files
+- Stay within the scope of the pull request's changed files where possible
+- Do not push to remote — the CI workflow will handle that
+
+## Output Format
+
+After applying fixes, output a summary:
+```
+Bot: ${ACTOR}
+Issues addressed: N
+- <issue description>: <fix applied>
+Files changed: <list of files>
+Skipped (informational): <count>
+```

--- a/prompts/dev-lead/fix-ci.md
+++ b/prompts/dev-lead/fix-ci.md
@@ -1,0 +1,52 @@
+<!-- VARIABLES: PR_NUMBER, PR_URL, CHECK_NAME, APP_SLUG, HEAD_SHA, DETAILS_URL, FAILURE_LOGS, ANNOTATIONS, REPO -->
+# Dev-Lead Agent: Fix CI Failures
+You are the dev-lead agent for the `${REPO}` repository. Your task is to fix failing CI checks on a pull request.
+
+## Context
+
+- **Repository:** `${REPO}`
+- **Pull Request:** [#${PR_NUMBER}](${PR_URL})
+- **Head SHA:** `${HEAD_SHA}`
+- **Failed Check:** `${CHECK_NAME}` (app: `${APP_SLUG}`)
+- **Details URL:** ${DETAILS_URL}
+
+## Failure Information
+
+### Failure Logs
+
+```
+${FAILURE_LOGS}
+```
+
+### Annotations
+
+```
+${ANNOTATIONS}
+```
+
+## Task
+
+Analyze the CI failure logs and annotations above, then fix the root cause(s). You should:
+
+1. Identify the specific errors or test failures
+2. Locate the relevant source files using Read/Grep/Glob tools
+3. Apply targeted fixes using the Edit/Write tools
+4. Verify your fixes are consistent with the rest of the codebase
+5. Commit the changes with a descriptive message: `fix(ci): resolve ${CHECK_NAME} failures`
+
+## Constraints
+
+- Fix only what is broken — do not refactor unrelated code
+- Do not modify test expectations to make tests pass artificially
+- Do not suppress linting rules unless absolutely necessary (add a comment explaining why)
+- Stay within the scope of the failing check: `${CHECK_NAME}`
+- Do not push to remote — the CI workflow will handle that
+
+## Output Format
+
+After applying fixes, output a brief summary:
+```
+Fixed: <description of what was fixed>
+Files changed: <list of files>
+Commit: <commit SHA or "pending">
+```

--- a/prompts/dev-lead/fix-issue.md
+++ b/prompts/dev-lead/fix-issue.md
@@ -1,0 +1,48 @@
+<!-- VARIABLES: ISSUE_NUMBER, ISSUE_URL, REPO, ISSUE_TITLE, ISSUE_BODY, ORG_STANDARDS_HINT -->
+# Dev-Lead Agent: Implement Issue
+You are the dev-lead agent for the `${REPO}` repository. You have been assigned to implement a GitHub issue.
+
+## Context
+
+- **Repository:** `${REPO}`
+- **Issue:** [#${ISSUE_NUMBER}: ${ISSUE_TITLE}](${ISSUE_URL})
+- **Org Standards:** ${ORG_STANDARDS_HINT}
+
+## Issue Description
+
+```
+${ISSUE_BODY}
+```
+
+## Task
+
+Implement the feature or fix described in the issue:
+
+1. Analyze the issue description to understand the full scope of work
+2. Explore the codebase using Read/Grep/Glob tools to understand the relevant patterns
+3. Create a new branch (if not already on one): `git checkout -b fix/${ISSUE_NUMBER}-brief-slug` or `feat/${ISSUE_NUMBER}-brief-slug`
+4. Implement the changes using Edit/Write/Bash tools
+5. Write or update tests as needed
+6. Commit with a message referencing the issue: `feat: implement ${ISSUE_TITLE} (closes #${ISSUE_NUMBER})`
+7. Open a pull request referencing the issue
+
+## Constraints
+
+- Follow the org standards in `${ORG_STANDARDS_HINT}` — check AGENTS.md and any referenced standards docs
+- Do not implement more than what the issue requests
+- Add tests for new functionality
+- Keep commits atomic and well-described
+- Do not modify unrelated files
+- Do not push to remote without creating a PR — use `gh pr create` to open a draft PR when ready
+
+## Output Format
+
+After completing implementation, output a summary:
+```
+Issue: #${ISSUE_NUMBER} - ${ISSUE_TITLE}
+Branch: <branch name>
+Changes:
+- <file>: <description of change>
+Tests: <added/updated/none>
+PR: <PR URL or "draft opened">
+```

--- a/prompts/dev-lead/fix-reviews.md
+++ b/prompts/dev-lead/fix-reviews.md
@@ -1,0 +1,48 @@
+<!-- VARIABLES: PR_NUMBER, PR_URL, REPO, OPEN_THREADS_JSON, BASE_REF -->
+# Dev-Lead Agent: Fix Review Comments
+You are the dev-lead agent for the `${REPO}` repository. Your task is to address open review threads on a pull request.
+
+## Context
+
+- **Repository:** `${REPO}`
+- **Pull Request:** [#${PR_NUMBER}](${PR_URL})
+- **Base Branch:** `${BASE_REF}`
+
+## Open Review Threads
+
+The following review threads are unresolved and require attention:
+
+```json
+${OPEN_THREADS_JSON}
+```
+
+## Task
+
+For each open review thread, address the feedback by:
+
+1. Reading the relevant file(s) using the Read/Grep/Glob tools
+2. Understanding the reviewer's concern
+3. Applying the appropriate fix using Edit/Write tools
+4. Ensuring the fix aligns with existing code patterns and style
+
+After addressing all threads:
+- Commit all changes with a message like: `fix(reviews): address PR #${PR_NUMBER} review feedback`
+- Do not resolve the threads yourself — they will be resolved automatically when the conversation is updated
+
+## Constraints
+
+- Address each open thread individually — do not batch unrelated changes into one commit
+- Do not make changes beyond what the review threads request
+- If a review thread is ambiguous, apply the most conservative interpretation
+- Do not modify files that are not referenced in the review threads
+- Do not push to remote — the CI workflow will handle that
+
+## Output Format
+
+After applying fixes, output a summary:
+```
+Addressed N threads:
+- Thread <id>: <brief description of fix>
+- Thread <id>: <brief description of fix>
+Files changed: <list of files>
+```

--- a/prompts/dev-lead/human-pr.md
+++ b/prompts/dev-lead/human-pr.md
@@ -1,0 +1,53 @@
+<!-- VARIABLES: PR_NUMBER, PR_URL, REPO, PR_TITLE, PR_DESCRIPTION, OPEN_THREADS_JSON -->
+# Dev-Lead Agent: Human Pull Request Review Response
+You are the dev-lead agent for the `${REPO}` repository. A human reviewer has submitted a pull request review requesting changes. Your task is to address all open review threads.
+
+## Context
+
+- **Repository:** `${REPO}`
+- **Pull Request:** [#${PR_NUMBER}](${PR_URL})
+- **PR Title:** ${PR_TITLE}
+
+## Pull Request Description
+
+```
+${PR_DESCRIPTION}
+```
+
+## Open Review Threads
+
+The following threads from human reviewers require your attention:
+
+```json
+${OPEN_THREADS_JSON}
+```
+
+## Task
+
+Address every open review thread from the human reviewers:
+
+1. Read each thread carefully to understand the reviewer's intent
+2. Use Read/Grep/Glob tools to examine the referenced code and surrounding context
+3. Apply the requested changes using Edit/Write tools
+4. Ensure your changes align with the PR's overall purpose and do not break existing functionality
+5. Commit the changes with: `fix(pr): address review feedback on PR #${PR_NUMBER}`
+
+## Constraints
+
+- Treat human reviewer feedback with high priority — implement exactly what is asked
+- If multiple threads conflict, prioritize in this order: security > correctness > style
+- Do not dismiss or skip any thread without a documented reason
+- Maintain the existing code style and patterns
+- Run any available test commands to verify fixes where possible
+- Do not push to remote — the CI workflow will handle that
+
+## Output Format
+
+After applying fixes, output a summary:
+```
+PR: #${PR_NUMBER} - ${PR_TITLE}
+Human review threads addressed: N
+- Thread <author>: <brief description of change>
+Files changed: <list of files>
+Remaining (if any): <explanation>
+```

--- a/prompts/dev-lead/human.md
+++ b/prompts/dev-lead/human.md
@@ -1,0 +1,49 @@
+<!-- VARIABLES: PR_NUMBER, PR_URL, REPO, ACTOR, USER_INSTRUCTION, PR_DESCRIPTION -->
+# Dev-Lead Agent: Human-Directed Task
+You are the dev-lead agent for the `${REPO}` repository. A human contributor has given you a direct instruction to act on a pull request.
+
+## Context
+
+- **Repository:** `${REPO}`
+- **Pull Request:** [#${PR_NUMBER}](${PR_URL})
+- **Requested by:** `${ACTOR}`
+
+## Pull Request Description
+
+```
+${PR_DESCRIPTION}
+```
+
+## Instruction
+
+```
+${USER_INSTRUCTION}
+```
+
+## Task
+
+Carry out the instruction exactly as requested by `${ACTOR}`:
+
+1. Read the instruction carefully and identify the specific action required
+2. Use Read/Grep/Glob tools to understand the relevant code
+3. Apply the requested changes using Edit/Write/Bash tools as needed
+4. Commit the changes with an appropriate message that references the instruction
+5. If the instruction is ambiguous, apply the most reasonable interpretation and note it in your output
+
+## Constraints
+
+- Execute the instruction faithfully — do not substitute your own judgment for the requester's intent
+- If the instruction would break tests or CI, still apply it but note the potential issue in your output
+- Do not make unrelated improvements
+- Do not push to remote — the CI workflow will handle that
+- If the instruction is unsafe (e.g., deletes critical security checks, exposes secrets), decline and explain why
+
+## Output Format
+
+After completing the task, output a summary:
+```
+Instruction from: ${ACTOR}
+Action taken: <brief description>
+Files changed: <list of files>
+Notes: <any caveats or observations>
+```

--- a/prompts/dev-lead/rebase.md
+++ b/prompts/dev-lead/rebase.md
@@ -1,0 +1,51 @@
+<!-- VARIABLES: PR_NUMBER, PR_URL, REPO, BASE_REF, HEAD_REF, CONFLICTING_FILES -->
+# Dev-Lead Agent: Rebase Pull Request
+You are the dev-lead agent for the `${REPO}` repository. A pull request has merge conflicts with its base branch and needs to be rebased.
+
+## Context
+
+- **Repository:** `${REPO}`
+- **Pull Request:** [#${PR_NUMBER}](${PR_URL})
+- **Head Branch:** `${HEAD_REF}`
+- **Base Branch:** `${BASE_REF}`
+
+## Conflicting Files
+
+The following files have merge conflicts:
+
+```
+${CONFLICTING_FILES}
+```
+
+## Task
+
+Resolve the merge conflicts and rebase the branch onto `${BASE_REF}`:
+
+1. Check out the PR branch: `gh pr checkout ${PR_NUMBER}`
+2. Fetch the latest `${BASE_REF}`: `git fetch origin ${BASE_REF}`
+3. Start an interactive rebase: `git rebase origin/${BASE_REF}`
+4. For each conflicting file:
+   - Read both versions of the conflict using the Read tool
+   - Resolve the conflict by keeping the correct logic from each side
+   - Stage the resolved file: `git add <file>`
+5. Continue the rebase: `git rebase --continue`
+6. Force-push the rebased branch: `git push --force-with-lease origin ${HEAD_REF}`
+
+## Constraints
+
+- Prefer keeping PR changes over base branch changes when there is a semantic conflict
+- Never silently drop code from either side — if both sides add code to the same location, merge them intelligently
+- Do not squash or otherwise rewrite the PR commit history beyond rebasing
+- If a conflict cannot be resolved safely, abort the rebase and comment on the PR explaining why
+- Only modify the conflicting files listed above — do not touch other files during conflict resolution
+
+## Output Format
+
+After completing the rebase, output a summary:
+```
+PR: #${PR_NUMBER}
+Rebased onto: ${BASE_REF}
+Conflicts resolved: N files
+- <file>: <brief description of resolution>
+Push: <success/failed>
+```

--- a/scripts/dev-lead-fix-ci.sh
+++ b/scripts/dev-lead-fix-ci.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# dev-lead-fix-ci.sh — handles the fix-ci intent
+# Called when a CI check fails on a PR.
+# Env: PR_NUMBER, HEAD_SHA, CHECKS_JSON, REPO, GITHUB_REPOSITORY,
+#      DEV_LEAD_DRY_RUN, REVIEW_ENGINE, GH_TOKEN
+
+source "$(dirname "$0")/engine.sh"
+
+PR_NUMBER="${PR_NUMBER:-}"
+HEAD_SHA="${HEAD_SHA:-}"
+CHECKS_JSON="${CHECKS_JSON:-[]}"
+REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
+MAX_CI_CYCLES="${MAX_CI_CYCLES:-3}"
+LOG_MAX_LINES="${LOG_MAX_LINES:-200}"
+MARKER_PREFIX="<!-- dev-lead-fix-ci sha="
+
+check_idempotency() {
+  local existing
+  existing=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+    --jq "[.[] | select(.body | startswith(\"${MARKER_PREFIX}${HEAD_SHA}\"))] | length" 2>/dev/null || echo "0")
+  [ "$existing" -gt 0 ]
+}
+
+collect_logs() {
+  local check_name="$1" details_url="$2"
+  # Try to get run ID from details URL
+  local run_id
+  run_id=$(echo "$details_url" | grep -oP '(?<=runs/)\d+' || true)
+  if [ -n "$run_id" ]; then
+    gh run view "$run_id" --log-failed 2>/dev/null | tail -n "$LOG_MAX_LINES" || true
+  else
+    echo "# No run logs available for check: $check_name"
+  fi
+}
+
+build_prompt() {
+  local prompt_template="prompts/dev-lead/fix-ci.md"
+  local check_name app_slug details_url
+  check_name=$(echo "$CHECKS_JSON" | jq -r '.[0].name // "unknown"')
+  app_slug=$(echo "$CHECKS_JSON" | jq -r '.[0].app_slug // "github-actions"')
+  details_url=$(echo "$CHECKS_JSON" | jq -r '.[0].details_url // ""')
+
+  export PR_NUMBER PR_URL="https://github.com/${REPO}/pull/${PR_NUMBER}"
+  export CHECK_NAME="$check_name" APP_SLUG="$app_slug"
+  export HEAD_SHA DETAILS_URL="$details_url"
+  export REPO
+
+  FAILURE_LOGS=$(collect_logs "$check_name" "$details_url")
+  ANNOTATIONS=$(gh api "repos/${REPO}/check-runs/$(echo "$CHECKS_JSON" | jq -r '.[0].id // empty')/annotations?per_page=100" 2>/dev/null | jq -c '.' || echo "[]")
+  export FAILURE_LOGS ANNOTATIONS
+
+  local rendered="/tmp/dev-lead-fix-ci-prompt-$$.md"
+  envsubst < "$prompt_template" > "$rendered"
+  echo "$rendered"
+}
+
+post_summary() {
+  local status="$1" details="${2:-}"
+  local marker="${MARKER_PREFIX}${HEAD_SHA} status=${status} -->"
+  local body="${marker}
+## Dev-Lead Fix CI — ${status}
+**PR:** #${PR_NUMBER} | **SHA:** \`${HEAD_SHA}\`
+${details}"
+  if [ "${DEV_LEAD_DRY_RUN:-false}" = "true" ]; then
+    echo "[dry-run] would post PR comment:"
+    echo "$body"
+  else
+    gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$body"
+  fi
+}
+
+main() {
+  if [ -z "$PR_NUMBER" ] || [ -z "$HEAD_SHA" ]; then
+    echo "::error::PR_NUMBER and HEAD_SHA are required"
+    exit 1
+  fi
+
+  if check_idempotency; then
+    echo "::notice::Already handled CI failure at SHA $HEAD_SHA — skipping (idempotent)"
+    exit 0
+  fi
+
+  local prompt_file
+  prompt_file=$(build_prompt)
+
+  if [ "${DEV_LEAD_DRY_RUN:-false}" = "true" ]; then
+    echo "[dry-run] fix-ci: would run engine with prompt: $prompt_file"
+    post_summary "dry-run" "Would apply fix for: $(echo "$CHECKS_JSON" | jq -r '[.[].name] | join(", ")')"
+    exit 0
+  fi
+
+  # Checkout the PR branch for modification
+  gh pr checkout "$PR_NUMBER" --repo "$REPO"
+
+  local cycle=1
+  while [ "$cycle" -le "$MAX_CI_CYCLES" ]; do
+    echo "  [fix-ci] cycle $cycle/$MAX_CI_CYCLES"
+
+    if ! run_writer_with_fallback "$prompt_file"; then
+      post_summary "failed" "Engine invocation failed after all retries."
+      exit 1
+    fi
+
+    # Check if there are changes to commit
+    if git diff --quiet && git diff --cached --quiet; then
+      echo "  [fix-ci] no changes made by engine"
+      post_summary "no-changes" "Engine ran but made no changes."
+      exit 0
+    fi
+
+    git add -A
+    git commit -m "fix(ci): auto-fix for $(echo "$CHECKS_JSON" | jq -r '.[0].name // "CI failure"') [skip ci-relay]"
+    git push
+
+    post_summary "applied" "Fix committed and pushed. Waiting for CI."
+    break
+  done
+
+  rm -f "$prompt_file"
+}
+
+main "$@"

--- a/scripts/dev-lead-fix-issue.sh
+++ b/scripts/dev-lead-fix-issue.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# dev-lead-fix-issue.sh — handles the issue intent
+
+source "$(dirname "$0")/engine.sh"
+
+ISSUE_NUMBER="${ISSUE_NUMBER:-}"
+REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
+DEV_LEAD_DRY_RUN="${DEV_LEAD_DRY_RUN:-false}"
+
+check_existing_pr() {
+  local existing
+  existing=$(gh api "repos/${REPO}/pulls?state=open" \
+    --jq "[.[] | select(.head.ref | startswith(\"dev-lead/issue-${ISSUE_NUMBER}\"))] | length" 2>/dev/null || echo "0")
+  [ "$existing" -gt 0 ]
+}
+
+main() {
+  if [ -z "$ISSUE_NUMBER" ]; then
+    echo "::error::ISSUE_NUMBER is required"
+    exit 1
+  fi
+
+  if check_existing_pr; then
+    echo "::notice::Existing open PR found for issue #${ISSUE_NUMBER} — skipping (dedup)"
+    gh issue comment "$ISSUE_NUMBER" --repo "$REPO" \
+      --body "<!-- dev-lead-issue-dedup -->Already working on this: an open PR exists for issue #${ISSUE_NUMBER}." 2>/dev/null || true
+    exit 0
+  fi
+
+  # Gather issue context
+  export ISSUE_NUMBER ISSUE_URL="https://github.com/${REPO}/issues/${ISSUE_NUMBER}"
+  export REPO
+  ISSUE_TITLE=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" --jq '.title' 2>/dev/null || echo "Unknown")
+  ISSUE_BODY=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" --jq '.body // ""' 2>/dev/null || echo "")
+  ORG_STANDARDS_HINT="See AGENTS.md and docs/ for coding standards."
+  export ISSUE_TITLE ISSUE_BODY ORG_STANDARDS_HINT
+
+  local prompt_file="/tmp/dev-lead-fix-issue-prompt-$$.md"
+  envsubst < "prompts/dev-lead/fix-issue.md" > "$prompt_file"
+
+  if [ "$DEV_LEAD_DRY_RUN" = "true" ]; then
+    echo "[dry-run] fix-issue: would implement issue #${ISSUE_NUMBER} using prompt: $prompt_file"
+    rm -f "$prompt_file"
+    exit 0
+  fi
+
+  # Create feature branch
+  local branch="dev-lead/issue-${ISSUE_NUMBER}-$(date +%Y%m%d-%H%M)"
+  git checkout -b "$branch"
+
+  if ! run_writer_with_fallback "$prompt_file"; then
+    echo "::error::Engine failed to implement issue #${ISSUE_NUMBER}"
+    rm -f "$prompt_file"
+    exit 1
+  fi
+
+  if git diff --quiet && git diff --cached --quiet; then
+    echo "::notice::No changes made for issue #${ISSUE_NUMBER}"
+    rm -f "$prompt_file"
+    exit 0
+  fi
+
+  git add -A
+  git commit -m "feat: implement issue #${ISSUE_NUMBER} — ${ISSUE_TITLE}"
+  git push --set-upstream origin "$branch"
+
+  gh pr create \
+    --repo "$REPO" \
+    --title "feat: implement issue #${ISSUE_NUMBER} — ${ISSUE_TITLE}" \
+    --body "Closes #${ISSUE_NUMBER}
+
+Implemented by dev-lead agent. Please review." \
+    --head "$branch"
+
+  rm -f "$prompt_file"
+}
+
+main "$@"

--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# dev-lead-fix-reviews.sh — handles review-related intents
+
+source "$(dirname "$0")/engine.sh"
+
+INTENT_TYPE="${INTENT_TYPE:-fix-reviews}"
+PR_NUMBER="${PR_NUMBER:-}"
+REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
+HEAD_SHA="${HEAD_SHA:-}"
+DEV_LEAD_DRY_RUN="${DEV_LEAD_DRY_RUN:-false}"
+
+if [ -z "$PR_NUMBER" ] && [ "$INTENT_TYPE" != "rebase" ]; then
+  echo "::error::PR_NUMBER is required"
+  exit 1
+fi
+
+build_and_run() {
+  local template_name="$1"
+  local prompt_file="/tmp/dev-lead-${template_name}-prompt-$$.md"
+  # Export required vars then envsubst
+  envsubst < "prompts/dev-lead/${template_name}.md" > "$prompt_file"
+
+  if [ "$DEV_LEAD_DRY_RUN" = "true" ]; then
+    echo "[dry-run] would run engine with prompt: $prompt_file ($(wc -l < "$prompt_file") lines)"
+    rm -f "$prompt_file"
+    return 0
+  fi
+
+  run_writer_with_fallback "$prompt_file"
+  rm -f "$prompt_file"
+}
+
+post_comment() {
+  local body="$1"
+  if [ "$DEV_LEAD_DRY_RUN" = "true" ]; then
+    echo "[dry-run] would post comment: $body"
+  else
+    gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$body"
+  fi
+}
+
+case "$INTENT_TYPE" in
+  fix-reviews)
+    # Get open review threads
+    export PR_NUMBER PR_URL="https://github.com/${REPO}/pull/${PR_NUMBER}"
+    export REPO HEAD_SHA
+    export BASE_REF="${BASE_REF:-main}"
+    OPEN_THREADS_JSON=$(gh api graphql -f query='
+      query($owner:String!,$repo:String!,$pr:Int!) {
+        repository(owner:$owner, name:$repo) {
+          pullRequest(number:$pr) {
+            reviewThreads(first:50) {
+              nodes { isResolved line path comments(first:5) { nodes { body author { login } } } }
+            }
+          }
+        }
+      }' \
+      -F owner="${REPO%%/*}" -F repo="${REPO##*/}" -F pr="$PR_NUMBER" \
+      --jq '.data.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved == false))' 2>/dev/null || echo "[]")
+    export OPEN_THREADS_JSON
+    build_and_run "fix-reviews"
+    ;;
+  fix-bot-comment)
+    export PR_NUMBER PR_URL="https://github.com/${REPO}/pull/${PR_NUMBER}"
+    export REPO ACTOR="${ACTOR:-}" COMMENT_BODY="${COMMENT_BODY:-}" HEAD_SHA
+    build_and_run "fix-bot-comment"
+    ;;
+  human)
+    export PR_NUMBER PR_URL="https://github.com/${REPO}/pull/${PR_NUMBER}"
+    export REPO ACTOR="${ACTOR:-}" USER_INSTRUCTION="${USER_INSTRUCTION:-}" PR_DESCRIPTION="${PR_DESCRIPTION:-}"
+    build_and_run "human"
+    ;;
+  human-pr)
+    export PR_NUMBER PR_URL="https://github.com/${REPO}/pull/${PR_NUMBER}"
+    export REPO PR_TITLE="${PR_TITLE:-}" PR_DESCRIPTION="${PR_DESCRIPTION:-}"
+    OPEN_THREADS_JSON=$(gh api graphql -f query='
+      query($owner:String!,$repo:String!,$pr:Int!) {
+        repository(owner:$owner, name:$repo) {
+          pullRequest(number:$pr) {
+            reviewThreads(first:50) {
+              nodes { isResolved line path comments(first:5) { nodes { body author { login } } } }
+            }
+          }
+        }
+      }' \
+      -F owner="${REPO%%/*}" -F repo="${REPO##*/}" -F pr="$PR_NUMBER" \
+      --jq '.data.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved == false))' 2>/dev/null || echo "[]")
+    export OPEN_THREADS_JSON BASE_REF="${BASE_REF:-main}"
+    build_and_run "human-pr"
+    ;;
+  rebase)
+    export PR_NUMBER="${PR_NUMBER:-}" PR_URL="https://github.com/${REPO}/pull/${PR_NUMBER:-}"
+    export REPO BASE_REF="${BASE_REF:-main}" HEAD_REF="${HEAD_REF:-}" CONFLICTING_FILES="${CONFLICTING_FILES:-}"
+    if [ "$DEV_LEAD_DRY_RUN" = "true" ]; then
+      echo "[dry-run] would run rebase for PR $PR_NUMBER"
+      exit 0
+    fi
+    if [ -z "$PR_NUMBER" ]; then
+      echo "::error::PR_NUMBER is required for rebase"
+      exit 1
+    fi
+    gh pr checkout "$PR_NUMBER" --repo "$REPO"
+    git fetch origin "$BASE_REF"
+    CONFLICTING_FILES=$(git merge-tree "$(git merge-base HEAD "origin/${BASE_REF}")" HEAD "origin/${BASE_REF}" 2>/dev/null | grep "^changed in both" | awk '{print $NF}' || true)
+    export CONFLICTING_FILES
+    build_and_run "rebase"
+    ;;
+  *)
+    echo "::error::Unknown intent type: $INTENT_TYPE"
+    exit 1
+    ;;
+esac

--- a/scripts/dev-lead-intent.sh
+++ b/scripts/dev-lead-intent.sh
@@ -6,10 +6,7 @@ set -euo pipefail
 # an intent, and writes INTENT_TYPE / INTENT_REASON / INTENT_CONTEXT to
 # GITHUB_ENV and GITHUB_OUTPUT.
 #
-# Phase 1: STUB — only anti-loop guards are fully implemented.
-#   All other events emit skip("not-implemented").
-#
-# Intents (for future phases):
+# Intents:
 #   fix-ci          — CI failure to auto-fix
 #   fix-reviews     — Bot review comments to address
 #   fix-bot-comment — Bot issue comment to address
@@ -41,11 +38,57 @@ emit_skip() {
   emit_intent "skip" "$reason" ""
 }
 
+# is_trusted_bot <actor>
+# Returns 0 (true) if actor is in the TRUSTED_BOTS comma-delimited list.
+is_trusted_bot() {
+  local actor="$1"
+  local bots
+  bots=$(echo "${TRUSTED_BOTS:-}" | tr ',' '\n')
+  echo "$bots" | grep -qxF "$actor"
+}
+
+# is_human_trusted <author_association>
+# Returns 0 (true) for OWNER, MEMBER, or COLLABORATOR associations.
+is_human_trusted() {
+  local assoc="$1"
+  case "$assoc" in
+    OWNER|MEMBER|COLLABORATOR) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# has_trigger_phrase <body>
+# Returns 0 (true) if body contains any phrase from TRIGGER_PHRASES.
+has_trigger_phrase() {
+  local body="$1"
+  local phrases
+  phrases=$(echo "${TRIGGER_PHRASES:-@dev-lead}" | tr ',' '\n')
+  while IFS= read -r phrase; do
+    [ -z "$phrase" ] && continue
+    if echo "$body" | grep -qF "$phrase"; then
+      return 0
+    fi
+  done <<< "$phrases"
+  return 1
+}
+
+# is_fork_pr <event_path>
+# Returns 0 (true) if the PR head repo differs from GITHUB_REPOSITORY.
+is_fork_pr() {
+  local event_path="$1"
+  local head_repo base_repo
+  head_repo=$(jq -r '.pull_request.head.repo.full_name // .head.repo.full_name // empty' "$event_path" 2>/dev/null || true)
+  base_repo="${GITHUB_REPOSITORY:-}"
+  [ -n "$head_repo" ] && [ "$head_repo" != "$base_repo" ]
+}
+
 # ── read event ───────────────────────────────────────────────────────────────
 
 EVENT_NAME="${GITHUB_EVENT_NAME:-}"
 EVENT_PATH="${GITHUB_EVENT_PATH:-}"
 BOT_USER="${BOT_USER:-donpetry-bot}"
+TRUSTED_BOTS="${TRUSTED_BOTS:-copilot-pull-request-reviewer[bot],gemini-code-assist[bot],sonarqubecloud[bot],coderabbitai[bot]}"
+TRIGGER_PHRASES="${TRIGGER_PHRASES:-@dev-lead}"
 
 if [ -z "$EVENT_NAME" ]; then
   echo "::error::GITHUB_EVENT_NAME is not set"
@@ -73,16 +116,213 @@ if [ "$EVENT_NAME" = "pull_request" ] && [ -n "$EVENT_PATH" ] && [ -f "$EVENT_PA
       emit_skip "dev-lead-own-commit"
       exit 0
     fi
-    # Also skip if the commit message starts with fix(ci): or fix(dev-lead):
-    head_commit_msg=$(jq -r '.pull_request.head.sha // empty' "$EVENT_PATH" 2>/dev/null || true)
-    # Note: full commit message check would require a git fetch; check via
-    # event context only (pusher commits are not embedded in the event payload).
-    # Future phases can add a git-based check after checkout.
   fi
 fi
 
-# ── stub: everything else ─────────────────────────────────────────────────────
-# Phase 1 stub: emit skip for all unimplemented intents.
-# Future phases will implement the full routing logic.
+# ── routing ───────────────────────────────────────────────────────────────────
 
-emit_skip "not-implemented"
+case "$EVENT_NAME" in
+
+  # ── pull_request ─────────────────────────────────────────────────────────
+  pull_request)
+    if [ -z "$EVENT_PATH" ] || [ ! -f "$EVENT_PATH" ]; then
+      emit_skip "no-event-path"
+      exit 0
+    fi
+    pr_action=$(jq -r '.action // empty' "$EVENT_PATH" 2>/dev/null || true)
+    sender_login=$(jq -r '.sender.login // empty' "$EVENT_PATH" 2>/dev/null || true)
+    pr_number=$(jq -r '.pull_request.number // .number // empty' "$EVENT_PATH" 2>/dev/null || true)
+    head_sha=$(jq -r '.pull_request.head.sha // empty' "$EVENT_PATH" 2>/dev/null || true)
+
+    case "$pr_action" in
+      opened|reopened)
+        # Skip forks and bot PRs
+        if is_fork_pr "$EVENT_PATH"; then
+          emit_skip "fork-pr"
+          exit 0
+        fi
+        if [[ "$sender_login" == *"[bot]"* ]] || [[ "$sender_login" == "dependabot"* ]]; then
+          emit_skip "bot-pr"
+          exit 0
+        fi
+        context=$(printf '{"pr_number":%s,"head_sha":"%s"}' "${pr_number:-0}" "${head_sha:-}")
+        emit_intent "human-pr" "pr-${pr_action}" "$context"
+        ;;
+      synchronize)
+        # Anti-loop already handled above; now route human syncs
+        if [[ "$sender_login" == *"[bot]"* ]]; then
+          emit_skip "bot-sync"
+          exit 0
+        fi
+        # Also skip if commit message contains [skip ci-relay]
+        head_commit_msg=$(jq -r '.head_commit.message // empty' "$EVENT_PATH" 2>/dev/null || true)
+        if echo "$head_commit_msg" | grep -qF "[skip ci-relay]"; then
+          emit_skip "skip-ci-relay-commit"
+          exit 0
+        fi
+        context=$(printf '{"pr_number":%s,"head_sha":"%s"}' "${pr_number:-0}" "${head_sha:-}")
+        emit_intent "human-pr" "pr-synchronize" "$context"
+        ;;
+      *)
+        emit_skip "pr-action-not-routed"
+        ;;
+    esac
+    ;;
+
+  # ── pull_request_review ───────────────────────────────────────────────────
+  pull_request_review)
+    if [ -z "$EVENT_PATH" ] || [ ! -f "$EVENT_PATH" ]; then
+      emit_skip "no-event-path"
+      exit 0
+    fi
+    reviewer=$(jq -r '.review.user.login // empty' "$EVENT_PATH" 2>/dev/null || true)
+    review_state=$(jq -r '.review.state // empty' "$EVENT_PATH" 2>/dev/null || true)
+    pr_number=$(jq -r '.pull_request.number // empty' "$EVENT_PATH" 2>/dev/null || true)
+    head_sha=$(jq -r '.pull_request.head.sha // empty' "$EVENT_PATH" 2>/dev/null || true)
+    author_assoc=$(jq -r '.pull_request.author_association // empty' "$EVENT_PATH" 2>/dev/null || true)
+
+    # Skip if actor is BOT_USER (self-review)
+    if [ "$reviewer" = "$BOT_USER" ]; then
+      emit_skip "self-review"
+      exit 0
+    fi
+
+    # Skip fork PRs
+    if is_fork_pr "$EVENT_PATH"; then
+      emit_skip "fork-pr"
+      exit 0
+    fi
+
+    context=$(printf '{"pr_number":%s,"head_sha":"%s"}' "${pr_number:-0}" "${head_sha:-}")
+
+    if is_trusted_bot "$reviewer"; then
+      # Bot review: only route non-APPROVED states
+      if [ "$review_state" = "APPROVED" ]; then
+        emit_skip "bot-approved"
+      else
+        emit_intent "fix-reviews" "bot-review-${review_state}" "$context"
+      fi
+    elif is_human_trusted "$author_assoc"; then
+      emit_intent "human-pr" "human-review-${review_state}" "$context"
+    else
+      emit_skip "untrusted-reviewer"
+    fi
+    ;;
+
+  # ── pull_request_review_comment ───────────────────────────────────────────
+  pull_request_review_comment)
+    if [ -z "$EVENT_PATH" ] || [ ! -f "$EVENT_PATH" ]; then
+      emit_skip "no-event-path"
+      exit 0
+    fi
+    commenter=$(jq -r '.comment.user.login // empty' "$EVENT_PATH" 2>/dev/null || true)
+    comment_body=$(jq -r '.comment.body // empty' "$EVENT_PATH" 2>/dev/null || true)
+    pr_number=$(jq -r '.pull_request.number // empty' "$EVENT_PATH" 2>/dev/null || true)
+    head_sha=$(jq -r '.pull_request.head.sha // empty' "$EVENT_PATH" 2>/dev/null || true)
+    author_assoc=$(jq -r '.pull_request.author_association // empty' "$EVENT_PATH" 2>/dev/null || true)
+
+    context=$(printf '{"pr_number":%s,"head_sha":"%s"}' "${pr_number:-0}" "${head_sha:-}")
+
+    if is_trusted_bot "$commenter"; then
+      emit_intent "fix-reviews" "bot-review-comment" "$context"
+    elif is_human_trusted "$author_assoc" && has_trigger_phrase "$comment_body"; then
+      emit_intent "human" "human-review-comment-trigger" "$context"
+    else
+      emit_skip "no-trigger-or-untrusted"
+    fi
+    ;;
+
+  # ── issue_comment ─────────────────────────────────────────────────────────
+  issue_comment)
+    if [ -z "$EVENT_PATH" ] || [ ! -f "$EVENT_PATH" ]; then
+      emit_skip "no-event-path"
+      exit 0
+    fi
+    # Only handle comments on PRs (issues with pull_request field)
+    is_pr=$(jq -r '.issue.pull_request // empty' "$EVENT_PATH" 2>/dev/null || true)
+    if [ -z "$is_pr" ]; then
+      emit_skip "not-a-pr-comment"
+      exit 0
+    fi
+
+    commenter=$(jq -r '.comment.user.login // empty' "$EVENT_PATH" 2>/dev/null || true)
+    comment_body=$(jq -r '.comment.body // empty' "$EVENT_PATH" 2>/dev/null || true)
+    pr_number=$(jq -r '.issue.number // empty' "$EVENT_PATH" 2>/dev/null || true)
+    author_assoc=$(jq -r '.issue.author_association // empty' "$EVENT_PATH" 2>/dev/null || true)
+
+    # Rebase sentinel check (highest priority, before bot-skip)
+    if echo "$comment_body" | grep -qF "<!-- auto-rebase-conflict:"; then
+      context=$(printf '{"pr_number":%s}' "${pr_number:-0}")
+      emit_intent "rebase" "rebase-conflict-sentinel" "$context"
+      exit 0
+    fi
+
+    # Skip self (BOT_USER) unless it's the rebase sentinel
+    if [ "$commenter" = "$BOT_USER" ]; then
+      emit_skip "self-comment"
+      exit 0
+    fi
+
+    context=$(printf '{"pr_number":%s}' "${pr_number:-0}")
+
+    if is_trusted_bot "$commenter"; then
+      emit_intent "fix-bot-comment" "trusted-bot-comment" "$context"
+    elif is_human_trusted "$author_assoc" && has_trigger_phrase "$comment_body"; then
+      emit_intent "human" "human-comment-trigger" "$context"
+    else
+      emit_skip "no-trigger-or-untrusted"
+    fi
+    ;;
+
+  # ── issues ────────────────────────────────────────────────────────────────
+  issues)
+    if [ -z "$EVENT_PATH" ] || [ ! -f "$EVENT_PATH" ]; then
+      emit_skip "no-event-path"
+      exit 0
+    fi
+    issues_action=$(jq -r '.action // empty' "$EVENT_PATH" 2>/dev/null || true)
+    if [ "$issues_action" != "labeled" ]; then
+      emit_skip "issues-not-labeled"
+      exit 0
+    fi
+    label_name=$(jq -r '.label.name // empty' "$EVENT_PATH" 2>/dev/null || true)
+    issue_number=$(jq -r '.issue.number // empty' "$EVENT_PATH" 2>/dev/null || true)
+    case "$label_name" in
+      dev-lead|claude)
+        context=$(printf '{"issue_number":%s}' "${issue_number:-0}")
+        emit_intent "issue" "issue-labeled-${label_name}" "$context"
+        ;;
+      *)
+        emit_skip "label-not-dev-lead"
+        ;;
+    esac
+    ;;
+
+  # ── repository_dispatch ───────────────────────────────────────────────────
+  repository_dispatch)
+    if [ -z "$EVENT_PATH" ] || [ ! -f "$EVENT_PATH" ]; then
+      emit_skip "no-event-path"
+      exit 0
+    fi
+    dispatch_type=$(jq -r '.action // empty' "$EVENT_PATH" 2>/dev/null || true)
+    if [ "$dispatch_type" != "dev-lead-ci-failure" ]; then
+      emit_skip "unknown-dispatch-type"
+      exit 0
+    fi
+    pr_number=$(jq -r '.client_payload.pr_number // empty' "$EVENT_PATH" 2>/dev/null || true)
+    head_sha=$(jq -r '.client_payload.head_sha // empty' "$EVENT_PATH" 2>/dev/null || true)
+    checks=$(jq -c '.client_payload.checks // []' "$EVENT_PATH" 2>/dev/null || echo "[]")
+    if [ -z "$pr_number" ]; then
+      emit_skip "no-pr-number-in-payload"
+      exit 0
+    fi
+    context=$(printf '{"pr_number":%s,"head_sha":"%s","checks":%s}' "${pr_number}" "${head_sha:-}" "${checks}")
+    emit_intent "fix-ci" "ci-failure-dispatch" "$context"
+    ;;
+
+  # ── everything else ───────────────────────────────────────────────────────
+  *)
+    emit_skip "not-implemented"
+    ;;
+
+esac

--- a/scripts/dev-lead-intent.sh
+++ b/scripts/dev-lead-intent.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# dev-lead-intent.sh — Event classifier for the dev-lead agent.
+#
+# Reads GITHUB_EVENT_NAME and GITHUB_EVENT_PATH, classifies the event into
+# an intent, and writes INTENT_TYPE / INTENT_REASON / INTENT_CONTEXT to
+# GITHUB_ENV and GITHUB_OUTPUT.
+#
+# Phase 1: STUB — only anti-loop guards are fully implemented.
+#   All other events emit skip("not-implemented").
+#
+# Intents (for future phases):
+#   fix-ci          — CI failure to auto-fix
+#   fix-reviews     — Bot review comments to address
+#   fix-bot-comment — Bot issue comment to address
+#   human           — Human-directed @mention task
+#   human-pr        — Human review changes-requested
+#   issue           — Issue labeled dev-lead/claude
+#   rebase          — Rebase conflict sentinel
+#   ci-relay        — check_run relay (handled by ci-relay job, not this script)
+#   skip            — Event should be ignored
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+GITHUB_ENV="${GITHUB_ENV:-/dev/null}"
+GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/null}"
+
+emit_intent() {
+  local intent="$1" reason="${2:-}" context="${3:-}"
+  echo "INTENT_TYPE=${intent}" >> "$GITHUB_ENV"
+  echo "INTENT_REASON=${reason}" >> "$GITHUB_ENV"
+  echo "INTENT_CONTEXT=${context}" >> "$GITHUB_ENV"
+  echo "intent_type=${intent}" >> "$GITHUB_OUTPUT"
+  echo "intent_reason=${reason}" >> "$GITHUB_OUTPUT"
+  echo "intent_context=${context}" >> "$GITHUB_OUTPUT"
+  echo "  [intent] type=${intent} reason=${reason} context=${context}"
+}
+
+emit_skip() {
+  local reason="${1:-not-implemented}"
+  emit_intent "skip" "$reason" ""
+}
+
+# ── read event ───────────────────────────────────────────────────────────────
+
+EVENT_NAME="${GITHUB_EVENT_NAME:-}"
+EVENT_PATH="${GITHUB_EVENT_PATH:-}"
+BOT_USER="${BOT_USER:-donpetry-bot}"
+
+if [ -z "$EVENT_NAME" ]; then
+  echo "::error::GITHUB_EVENT_NAME is not set"
+  exit 1
+fi
+
+echo "dev-lead-intent: processing event=$EVENT_NAME"
+
+# ── check_run: not handled here (ci-relay job) ───────────────────────────────
+
+if [ "$EVENT_NAME" = "check_run" ]; then
+  emit_skip "check-run-handled-by-ci-relay"
+  exit 0
+fi
+
+# ── anti-loop guard: pull_request synchronize ────────────────────────────────
+# If the synchronize event was triggered by BOT_USER's own commit, skip to
+# prevent an infinite fix → push → trigger → fix loop.
+
+if [ "$EVENT_NAME" = "pull_request" ] && [ -n "$EVENT_PATH" ] && [ -f "$EVENT_PATH" ]; then
+  pr_action=$(jq -r '.action // empty' "$EVENT_PATH" 2>/dev/null || true)
+  if [ "$pr_action" = "synchronize" ]; then
+    sender_login=$(jq -r '.sender.login // empty' "$EVENT_PATH" 2>/dev/null || true)
+    if [ "$sender_login" = "$BOT_USER" ]; then
+      emit_skip "dev-lead-own-commit"
+      exit 0
+    fi
+    # Also skip if the commit message starts with fix(ci): or fix(dev-lead):
+    head_commit_msg=$(jq -r '.pull_request.head.sha // empty' "$EVENT_PATH" 2>/dev/null || true)
+    # Note: full commit message check would require a git fetch; check via
+    # event context only (pusher commits are not embedded in the event payload).
+    # Future phases can add a git-based check after checkout.
+  fi
+fi
+
+# ── stub: everything else ─────────────────────────────────────────────────────
+# Phase 1 stub: emit skip for all unimplemented intents.
+# Future phases will implement the full routing logic.
+
+emit_skip "not-implemented"

--- a/scripts/dev-lead-intent.sh
+++ b/scripts/dev-lead-intent.sh
@@ -154,12 +154,6 @@ case "$EVENT_NAME" in
           emit_skip "bot-sync"
           exit 0
         fi
-        # Also skip if commit message contains [skip ci-relay]
-        head_commit_msg=$(jq -r '.head_commit.message // empty' "$EVENT_PATH" 2>/dev/null || true)
-        if echo "$head_commit_msg" | grep -qF "[skip ci-relay]"; then
-          emit_skip "skip-ci-relay-commit"
-          exit 0
-        fi
         context=$(printf '{"pr_number":%s,"head_sha":"%s"}' "${pr_number:-0}" "${head_sha:-}")
         emit_intent "human-pr" "pr-synchronize" "$context"
         ;;

--- a/scripts/dev-lead-preflight.sh
+++ b/scripts/dev-lead-preflight.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Pre-flight checks for the dev-lead agent workflow.
+# Validates required and optional secrets/tokens before the agent runs.
+#
+# Usage: bash scripts/dev-lead-preflight.sh
+# Outputs: status messages + GITHUB_STEP_SUMMARY table (if running in Actions)
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+PASS="ok"
+FAIL="missing"
+WARN="optional"
+
+# check_required <var_name> <purpose>
+# Exits 1 if the variable is unset or empty.
+check_required() {
+  local var="$1" purpose="$2"
+  if [ -z "${!var:-}" ]; then
+    echo "::error::Required secret not set: $var ($purpose)"
+    return 1
+  fi
+  echo "  [ok] $var — $purpose"
+}
+
+# check_optional <var_name> <purpose>
+# Emits a warning if the variable is unset but does not exit.
+check_optional() {
+  local var="$1" purpose="$2"
+  if [ -z "${!var:-}" ]; then
+    echo "  [warn] $var not set — $purpose will be unavailable"
+  else
+    echo "  [ok] $var — $purpose"
+  fi
+}
+
+# ── checks ────────────────────────────────────────────────────────────────────
+
+echo "dev-lead pre-flight checks"
+echo "────────────────────────────────────────"
+
+FAILED=0
+
+check_required "CLAUDE_CODE_OAUTH_TOKEN" "Claude Code CLI authentication" || FAILED=1
+
+check_optional "GH_PAT_WORKFLOWS" "workflow file pushes and repository_dispatch"
+check_optional "GOOGLE_API_KEY" "Gemini engine fallback"
+check_optional "GH_PAT" "Copilot engine"
+
+echo "────────────────────────────────────────"
+
+# ── step summary ──────────────────────────────────────────────────────────────
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "## Dev-Lead Pre-Flight Check"
+    echo ""
+    echo "| Secret | Status | Purpose |"
+    echo "| ------ | ------ | ------- |"
+
+    _row() {
+      local var="$1" purpose="$2" required="${3:-optional}"
+      if [ -n "${!var:-}" ]; then
+        echo "| \`$var\` | $PASS | $purpose |"
+      elif [ "$required" = "required" ]; then
+        echo "| \`$var\` | $FAIL | $purpose |"
+      else
+        echo "| \`$var\` | $WARN | $purpose |"
+      fi
+    }
+
+    _row "CLAUDE_CODE_OAUTH_TOKEN" "Claude Code CLI authentication" "required"
+    _row "GH_PAT_WORKFLOWS" "Workflow file pushes and repository_dispatch"
+    _row "GOOGLE_API_KEY" "Gemini engine fallback"
+    _row "GH_PAT" "Copilot engine"
+
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+# ── exit ──────────────────────────────────────────────────────────────────────
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "Pre-flight FAILED — required secrets are missing"
+  exit 1
+fi
+
+echo "Pre-flight OK"

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -270,3 +270,83 @@ run_duck() {
       ;;
   esac
 }
+
+# run_writer <prompt_file> [model]
+# Full write-access mode for applying code fixes.
+# When DEV_LEAD_DRY_RUN=true: builds prompt but does NOT call engine; exits 0.
+# Exit codes: 0=success, 1=non-retriable failure, 2=rate-limited
+run_writer() {
+  local prompt_file="$1"
+  local model="${2:-$ENGINE_ACTION_MODEL}"
+
+  if [ "${DEV_LEAD_DRY_RUN:-false}" = "true" ]; then
+    echo "  [dry-run] run_writer: would invoke $REVIEW_ENGINE with prompt $(wc -l < "$prompt_file") lines"
+    return 0
+  fi
+
+  local rc=0
+  case "$REVIEW_ENGINE" in
+    claude)
+      timeout "$ACTION_TIMEOUT_SEC" claude --print \
+        --model "$model" \
+        --permission-mode acceptEdits \
+        --allowed-tools "Bash,Read,Write,Edit,Grep,Glob" \
+        < "$prompt_file" || rc=$?
+      ;;
+    gemini)
+      timeout "$ACTION_TIMEOUT_SEC" gemini --prompt "" \
+        --model "$model" \
+        --approval-mode auto_edit \
+        --output-format text \
+        < "$prompt_file" || rc=$?
+      ;;
+    copilot)
+      # Copilot (gh copilot suggest) is text-only — falls back to Claude for write ops
+      echo "::warning::Copilot engine is text-only; falling back to Claude for write operations" >&2
+      local saved="$REVIEW_ENGINE"
+      REVIEW_ENGINE="claude" timeout "$ACTION_TIMEOUT_SEC" claude --print \
+        --model "$model" \
+        --permission-mode acceptEdits \
+        --allowed-tools "Bash,Read,Write,Edit,Grep,Glob" \
+        < "$prompt_file" || rc=$?
+      REVIEW_ENGINE="$saved"
+      ;;
+  esac
+
+  # Map rate-limit to exit code 2 for caller to detect
+  local output_check=""
+  if [ "$rc" -ne 0 ] && output_check=$(cat /tmp/dev-lead-writer-stderr 2>/dev/null) && is_rate_limited "$output_check"; then
+    return 2
+  fi
+  return "$rc"
+}
+
+# run_writer_with_fallback <prompt_file> [model]
+# Tries primary engine, falls back through claude → gemini → copilot on rate-limit.
+# Only rate-limit (exit 2) triggers fallback; other failures propagate immediately.
+run_writer_with_fallback() {
+  local prompt_file="$1"
+  local model="${2:-$ENGINE_ACTION_MODEL}"
+  local engines=("$REVIEW_ENGINE")
+
+  for e in claude gemini copilot; do
+    [ "$e" != "$REVIEW_ENGINE" ] && engines+=("$e")
+  done
+
+  for engine in "${engines[@]}"; do
+    local saved="$REVIEW_ENGINE"
+    export REVIEW_ENGINE="$engine"
+    local rc=0
+    run_writer "$prompt_file" "$model" || rc=$?
+    export REVIEW_ENGINE="$saved"
+    [ "$rc" -eq 0 ] && return 0
+    if [ "$rc" -eq 2 ]; then
+      echo "::warning::$engine rate-limited, trying next engine" >&2
+      continue
+    fi
+    return "$rc"
+  done
+
+  echo "::error::All engines rate-limited or unavailable" >&2
+  return 2
+}

--- a/scripts/review-batch.sh
+++ b/scripts/review-batch.sh
@@ -126,3 +126,5 @@ if [ "$session_aborted" -eq 1 ]; then
 fi
 
 echo "$summary"
+[ "$failed" -gt 0 ] && exit 1
+exit 0

--- a/scripts/review-batch.sh
+++ b/scripts/review-batch.sh
@@ -103,13 +103,10 @@ while IFS= read -r pr_url; do
       abort_reason="rate-limit on fallback engine"
       ;;
     *)
-      # Other failure — session-fatal. A systemic problem (model degraded,
-      # prompt regression, malformed verdicts) shouldn't burn the queue.
+      # Per-PR failure — log and continue. Remaining candidates still run.
+      # Accumulated failures surface in the session summary.
       failed=$((failed + 1))
       echo "::error::Review failed for $pr_url (exit code $rc)"
-      session_aborted=1
-      abort_pr="$pr_url"
-      abort_reason="exit code $rc"
       ;;
   esac
 

--- a/scripts/review-one-pr.sh
+++ b/scripts/review-one-pr.sh
@@ -325,14 +325,30 @@ if [ "$TRIAGE_ESCALATE" = "false" ]; then
     rm -f "$VERDICT_JSON" "$VERDICT_JSON.raw"
     OUTPUT_FILE="$VERDICT_JSON"
     export OUTPUT_FILE
-    if run_agentic prompts/single-review.md "$ENGINE_SINGLE_MODEL" \
-         > "$VERDICT_JSON.raw" 2>"/tmp/cascade/single-review.log" \
-       && extract_verdict_json "$VERDICT_JSON.raw" "$VERDICT_JSON"; then
+    SINGLE_LOG="/tmp/cascade/single-review-attempt-${single_attempt}.log"
+
+    single_rc=0
+    run_agentic prompts/single-review.md "$ENGINE_SINGLE_MODEL" \
+      > "$VERDICT_JSON.raw" 2>"$SINGLE_LOG" || single_rc=$?
+
+    # Check for rate limit before retrying — exit code 2 lets review-batch.sh
+    # trigger engine fallback rather than burning retries on the same engine.
+    SINGLE_STDOUT=$(cat "$VERDICT_JSON.raw" 2>/dev/null || true)
+    SINGLE_STDERR=$(cat "$SINGLE_LOG" 2>/dev/null || true)
+    if is_rate_limited "$SINGLE_STDOUT" || is_rate_limited "$SINGLE_STDERR"; then
+      echo "    [approve] rate limit detected — exiting with code 2 for engine fallback"
+      [ -n "$SINGLE_STDERR" ] && echo "    limit stderr: $SINGLE_STDERR"
+      exit 2
+    fi
+
+    if [ "$single_rc" -eq 0 ] && extract_verdict_json "$VERDICT_JSON.raw" "$VERDICT_JSON"; then
       single_ok=true
       break
     fi
-    echo "    [approve] single-review attempt $single_attempt/$SINGLE_REVIEW_MAX_RETRIES produced no valid JSON"
+
+    echo "    [approve] single-review attempt $single_attempt/$SINGLE_REVIEW_MAX_RETRIES produced no valid JSON (exit $single_rc)"
     head -20 "$VERDICT_JSON.raw" 2>/dev/null || true
+    [ -n "$SINGLE_STDERR" ] && echo "    stderr: $SINGLE_STDERR"
     if [ "$single_attempt" -lt "$SINGLE_REVIEW_MAX_RETRIES" ]; then
       echo "    [approve] retrying in ${SINGLE_REVIEW_RETRY_DELAY_SEC}s"
       sleep "$SINGLE_REVIEW_RETRY_DELAY_SEC"
@@ -342,7 +358,10 @@ if [ "$TRIAGE_ESCALATE" = "false" ]; then
 
   if [ "$single_ok" = "false" ]; then
     echo "::warning::single-review failed after $SINGLE_REVIEW_MAX_RETRIES attempts — flagging for manual review"
-    [ -s "/tmp/cascade/single-review.log" ] && cat "/tmp/cascade/single-review.log"
+    for i in $(seq 1 "$SINGLE_REVIEW_MAX_RETRIES"); do
+      log="/tmp/cascade/single-review-attempt-${i}.log"
+      [ -s "$log" ] && { echo "    attempt $i stderr:"; cat "$log"; }
+    done
     if [ "${DRY_RUN:-false}" = "false" ]; then
       gh pr edit "$PR_URL" --add-label needs-human-review 2>/dev/null || true
     fi

--- a/scripts/review-one-pr.sh
+++ b/scripts/review-one-pr.sh
@@ -316,6 +316,8 @@ if [ "$TRIAGE_ESCALATE" = "false" ]; then
   echo "    [approve] triage cleared — running single confirmation ($ENGINE_SINGLE_MODEL)"
   export REVIEW_MODE="triage-approved"
   VERDICT_JSON="/tmp/cascade/single-review-verdict.json"
+  # SINGLE_REVIEW_MAX_RETRIES = total attempts including the first (same semantics
+  # as RETRY_MAX_ATTEMPTS in engine.sh). Default 2 = initial attempt + 1 retry.
   SINGLE_REVIEW_MAX_RETRIES="${SINGLE_REVIEW_MAX_RETRIES:-2}"
   SINGLE_REVIEW_RETRY_DELAY_SEC="${SINGLE_REVIEW_RETRY_DELAY_SEC:-15}"
 

--- a/scripts/review-one-pr.sh
+++ b/scripts/review-one-pr.sh
@@ -316,10 +316,38 @@ if [ "$TRIAGE_ESCALATE" = "false" ]; then
   echo "    [approve] triage cleared — running single confirmation ($ENGINE_SINGLE_MODEL)"
   export REVIEW_MODE="triage-approved"
   VERDICT_JSON="/tmp/cascade/single-review-verdict.json"
-  OUTPUT_FILE="$VERDICT_JSON"
-  export OUTPUT_FILE
-  run_agentic prompts/single-review.md "$ENGINE_SINGLE_MODEL" > "$VERDICT_JSON.raw"
-  extract_verdict_json "$VERDICT_JSON.raw" "$VERDICT_JSON" || { echo "::error::single-review did not produce valid JSON"; exit 1; }
+  SINGLE_REVIEW_MAX_RETRIES="${SINGLE_REVIEW_MAX_RETRIES:-2}"
+  SINGLE_REVIEW_RETRY_DELAY_SEC="${SINGLE_REVIEW_RETRY_DELAY_SEC:-15}"
+
+  single_attempt=1
+  single_ok=false
+  while [ "$single_attempt" -le "$SINGLE_REVIEW_MAX_RETRIES" ]; do
+    rm -f "$VERDICT_JSON" "$VERDICT_JSON.raw"
+    OUTPUT_FILE="$VERDICT_JSON"
+    export OUTPUT_FILE
+    if run_agentic prompts/single-review.md "$ENGINE_SINGLE_MODEL" \
+         > "$VERDICT_JSON.raw" 2>"/tmp/cascade/single-review.log" \
+       && extract_verdict_json "$VERDICT_JSON.raw" "$VERDICT_JSON"; then
+      single_ok=true
+      break
+    fi
+    echo "    [approve] single-review attempt $single_attempt/$SINGLE_REVIEW_MAX_RETRIES produced no valid JSON"
+    head -20 "$VERDICT_JSON.raw" 2>/dev/null || true
+    if [ "$single_attempt" -lt "$SINGLE_REVIEW_MAX_RETRIES" ]; then
+      echo "    [approve] retrying in ${SINGLE_REVIEW_RETRY_DELAY_SEC}s"
+      sleep "$SINGLE_REVIEW_RETRY_DELAY_SEC"
+    fi
+    single_attempt=$((single_attempt + 1))
+  done
+
+  if [ "$single_ok" = "false" ]; then
+    echo "::warning::single-review failed after $SINGLE_REVIEW_MAX_RETRIES attempts — flagging for manual review"
+    [ -s "/tmp/cascade/single-review.log" ] && cat "/tmp/cascade/single-review.log"
+    if [ "${DRY_RUN:-false}" = "false" ]; then
+      gh pr edit "$PR_URL" --add-label needs-human-review 2>/dev/null || true
+    fi
+    exit 1
+  fi
   rm -f "$VERDICT_JSON.raw"
 
   # Post the review using the verdict

--- a/tests/dev-lead/fixtures/engines/stub-claude
+++ b/tests/dev-lead/fixtures/engines/stub-claude
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Configurable via: STUB_ENGINE_RESPONSE, STUB_ENGINE_EXIT, STUB_ENGINE_DELAY
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --print|--model|--permission-mode|--allowed-tools|--disallowed-tools|--max-turns)
+      shift; shift ;;
+    *) shift ;;
+  esac
+done
+sleep "${STUB_ENGINE_DELAY:-0}"
+printf '%s\n' "${STUB_ENGINE_RESPONSE:-stub engine response}"
+exit "${STUB_ENGINE_EXIT:-0}"

--- a/tests/dev-lead/fixtures/engines/stub-gemini
+++ b/tests/dev-lead/fixtures/engines/stub-gemini
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Configurable via: STUB_ENGINE_RESPONSE, STUB_ENGINE_EXIT, STUB_ENGINE_DELAY
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --prompt|--model|--approval-mode|--output-format)
+      shift; shift ;;
+    *) shift ;;
+  esac
+done
+sleep "${STUB_ENGINE_DELAY:-0}"
+printf '%s\n' "${STUB_ENGINE_RESPONSE:-stub engine response}"
+exit "${STUB_ENGINE_EXIT:-0}"

--- a/tests/dev-lead/fixtures/events/check_run_dev_lead_self.json
+++ b/tests/dev-lead/fixtures/events/check_run_dev_lead_self.json
@@ -1,0 +1,22 @@
+{
+  "_test_expected_intent": "skip",
+  "action": "completed",
+  "check_run": {
+    "name": "dev-lead / intent",
+    "conclusion": "failure",
+    "head_sha": "abc123def456",
+    "details_url": "https://github.com/petry-projects/.github-private/actions/runs/12349",
+    "app": { "slug": "github-actions" },
+    "pull_requests": [
+      {
+        "number": 45,
+        "head": {
+          "sha": "abc123def456",
+          "repo": { "full_name": "petry-projects/.github-private" }
+        }
+      }
+    ]
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "github-actions[bot]", "type": "Bot" }
+}

--- a/tests/dev-lead/fixtures/events/check_run_failure.json
+++ b/tests/dev-lead/fixtures/events/check_run_failure.json
@@ -1,0 +1,22 @@
+{
+  "_test_expected_intent": "ci-relay",
+  "action": "completed",
+  "check_run": {
+    "name": "lint / eslint",
+    "conclusion": "failure",
+    "head_sha": "abc123def456",
+    "details_url": "https://github.com/petry-projects/.github-private/actions/runs/12345",
+    "app": { "slug": "github-actions" },
+    "pull_requests": [
+      {
+        "number": 42,
+        "head": {
+          "sha": "abc123def456",
+          "repo": { "full_name": "petry-projects/.github-private" }
+        }
+      }
+    ]
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "donpetry", "type": "User" }
+}

--- a/tests/dev-lead/fixtures/events/check_run_failure_fork.json
+++ b/tests/dev-lead/fixtures/events/check_run_failure_fork.json
@@ -1,0 +1,22 @@
+{
+  "_test_expected_intent": "skip",
+  "action": "completed",
+  "check_run": {
+    "name": "lint / eslint",
+    "conclusion": "failure",
+    "head_sha": "abc123def456",
+    "details_url": "https://github.com/someuser/.github-private/actions/runs/12347",
+    "app": { "slug": "github-actions" },
+    "pull_requests": [
+      {
+        "number": 43,
+        "head": {
+          "sha": "abc123def456",
+          "repo": { "full_name": "someuser/.github-private" }
+        }
+      }
+    ]
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "someuser", "type": "User" }
+}

--- a/tests/dev-lead/fixtures/events/check_run_failure_no_pr.json
+++ b/tests/dev-lead/fixtures/events/check_run_failure_no_pr.json
@@ -1,0 +1,14 @@
+{
+  "_test_expected_intent": "skip",
+  "action": "completed",
+  "check_run": {
+    "name": "lint / eslint",
+    "conclusion": "failure",
+    "head_sha": "abc123def456",
+    "details_url": "https://github.com/petry-projects/.github-private/actions/runs/12346",
+    "app": { "slug": "github-actions" },
+    "pull_requests": []
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "donpetry", "type": "User" }
+}

--- a/tests/dev-lead/fixtures/events/check_run_success.json
+++ b/tests/dev-lead/fixtures/events/check_run_success.json
@@ -1,0 +1,22 @@
+{
+  "_test_expected_intent": "skip",
+  "action": "completed",
+  "check_run": {
+    "name": "lint / eslint",
+    "conclusion": "success",
+    "head_sha": "abc123def456",
+    "details_url": "https://github.com/petry-projects/.github-private/actions/runs/12348",
+    "app": { "slug": "github-actions" },
+    "pull_requests": [
+      {
+        "number": 44,
+        "head": {
+          "sha": "abc123def456",
+          "repo": { "full_name": "petry-projects/.github-private" }
+        }
+      }
+    ]
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "donpetry", "type": "User" }
+}

--- a/tests/dev-lead/fixtures/events/issue_comment_coderabbit.json
+++ b/tests/dev-lead/fixtures/events/issue_comment_coderabbit.json
@@ -1,0 +1,22 @@
+{
+  "_test_expected_intent": "fix-bot-comment",
+  "action": "created",
+  "issue": {
+    "number": 62,
+    "title": "feat: database optimizations",
+    "state": "open",
+    "pull_request": {
+      "url": "https://api.github.com/repos/petry-projects/.github-private/pulls/62"
+    }
+  },
+  "comment": {
+    "id": 3002,
+    "body": "**CodeRabbit Review**\n\n## Summary\nThis PR introduces several database optimizations but has some concerns:\n1. Missing index on `user_id` column\n2. N+1 query in `getUserOrders` function\n3. Consider using connection pooling",
+    "user": {
+      "login": "coderabbitai[bot]",
+      "type": "Bot"
+    }
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "coderabbitai[bot]", "type": "Bot" }
+}

--- a/tests/dev-lead/fixtures/events/issue_comment_dev_lead_bot.json
+++ b/tests/dev-lead/fixtures/events/issue_comment_dev_lead_bot.json
@@ -1,0 +1,22 @@
+{
+  "_test_expected_intent": "skip",
+  "action": "created",
+  "issue": {
+    "number": 66,
+    "title": "feat: automated fixes",
+    "state": "open",
+    "pull_request": {
+      "url": "https://api.github.com/repos/petry-projects/.github-private/pulls/66"
+    }
+  },
+  "comment": {
+    "id": 3006,
+    "body": "I've applied the requested fixes. Please review the changes.",
+    "user": {
+      "login": "donpetry-bot",
+      "type": "Bot"
+    }
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "donpetry-bot", "type": "Bot" }
+}

--- a/tests/dev-lead/fixtures/events/issue_comment_human_no_trigger.json
+++ b/tests/dev-lead/fixtures/events/issue_comment_human_no_trigger.json
@@ -1,0 +1,23 @@
+{
+  "_test_expected_intent": "skip",
+  "action": "created",
+  "issue": {
+    "number": 64,
+    "title": "feat: minor improvements",
+    "state": "open",
+    "author_association": "OWNER",
+    "pull_request": {
+      "url": "https://api.github.com/repos/petry-projects/.github-private/pulls/64"
+    }
+  },
+  "comment": {
+    "id": 3004,
+    "body": "This looks good to me. I'll merge after the CI passes.",
+    "user": {
+      "login": "donpetry",
+      "type": "User"
+    }
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "donpetry", "type": "User" }
+}

--- a/tests/dev-lead/fixtures/events/issue_comment_human_trigger.json
+++ b/tests/dev-lead/fixtures/events/issue_comment_human_trigger.json
@@ -1,0 +1,23 @@
+{
+  "_test_expected_intent": "human",
+  "action": "created",
+  "issue": {
+    "number": 63,
+    "title": "feat: test improvements",
+    "state": "open",
+    "author_association": "OWNER",
+    "pull_request": {
+      "url": "https://api.github.com/repos/petry-projects/.github-private/pulls/63"
+    }
+  },
+  "comment": {
+    "id": 3003,
+    "body": "@dev-lead please fix the tests - the integration tests are failing in CI",
+    "user": {
+      "login": "donpetry",
+      "type": "User"
+    }
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "donpetry", "type": "User" }
+}

--- a/tests/dev-lead/fixtures/events/issue_comment_rebase_sentinel.json
+++ b/tests/dev-lead/fixtures/events/issue_comment_rebase_sentinel.json
@@ -1,0 +1,22 @@
+{
+  "_test_expected_intent": "rebase",
+  "action": "created",
+  "issue": {
+    "number": 65,
+    "title": "feat: long-running feature branch",
+    "state": "open",
+    "pull_request": {
+      "url": "https://api.github.com/repos/petry-projects/.github-private/pulls/65"
+    }
+  },
+  "comment": {
+    "id": 3005,
+    "body": "<!-- auto-rebase-conflict: main -->\n\nThis branch has conflicts with main and needs to be rebased.",
+    "user": {
+      "login": "donpetry-bot",
+      "type": "Bot"
+    }
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "donpetry-bot", "type": "Bot" }
+}

--- a/tests/dev-lead/fixtures/events/issue_comment_sonarqube.json
+++ b/tests/dev-lead/fixtures/events/issue_comment_sonarqube.json
@@ -1,0 +1,22 @@
+{
+  "_test_expected_intent": "fix-bot-comment",
+  "action": "created",
+  "issue": {
+    "number": 61,
+    "title": "feat: security improvements",
+    "state": "open",
+    "pull_request": {
+      "url": "https://api.github.com/repos/petry-projects/.github-private/pulls/61"
+    }
+  },
+  "comment": {
+    "id": 3001,
+    "body": "SonarQube analysis found 3 new issues:\n- Critical: SQL injection vulnerability in line 42\n- Major: Unused variable in line 15\n- Minor: Missing documentation",
+    "user": {
+      "login": "sonarqubecloud[bot]",
+      "type": "Bot"
+    }
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "sonarqubecloud[bot]", "type": "Bot" }
+}

--- a/tests/dev-lead/fixtures/events/issues_labeled_claude.json
+++ b/tests/dev-lead/fixtures/events/issues_labeled_claude.json
@@ -1,0 +1,18 @@
+{
+  "_test_expected_intent": "issue",
+  "action": "labeled",
+  "issue": {
+    "number": 101,
+    "title": "fix: resolve memory leak in worker pool",
+    "body": "The worker pool has a memory leak when tasks are cancelled mid-execution.\n\n## Steps to reproduce\n1. Start worker pool with 10 workers\n2. Queue 100 tasks\n3. Cancel all tasks\n4. Check memory usage\n\nExpected: memory released\nActual: memory not released",
+    "state": "open",
+    "author_association": "OWNER",
+    "labels": [
+      { "name": "claude" },
+      { "name": "bug" }
+    ]
+  },
+  "label": { "name": "claude" },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "donpetry", "type": "User" }
+}

--- a/tests/dev-lead/fixtures/events/issues_labeled_dev_lead.json
+++ b/tests/dev-lead/fixtures/events/issues_labeled_dev_lead.json
@@ -1,0 +1,18 @@
+{
+  "_test_expected_intent": "issue",
+  "action": "labeled",
+  "issue": {
+    "number": 100,
+    "title": "feat: implement OAuth2 support",
+    "body": "We need to add OAuth2 authentication support for third-party integrations.\n\n## Requirements\n- Support Google OAuth2\n- Support GitHub OAuth2\n- Add token refresh logic",
+    "state": "open",
+    "author_association": "OWNER",
+    "labels": [
+      { "name": "dev-lead" },
+      { "name": "enhancement" }
+    ]
+  },
+  "label": { "name": "dev-lead" },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "donpetry", "type": "User" }
+}

--- a/tests/dev-lead/fixtures/events/issues_labeled_other.json
+++ b/tests/dev-lead/fixtures/events/issues_labeled_other.json
@@ -1,0 +1,18 @@
+{
+  "_test_expected_intent": "skip",
+  "action": "labeled",
+  "issue": {
+    "number": 102,
+    "title": "bug: login button not working on mobile",
+    "body": "The login button doesn't respond to taps on iOS Safari.",
+    "state": "open",
+    "author_association": "NONE",
+    "labels": [
+      { "name": "bug" },
+      { "name": "mobile" }
+    ]
+  },
+  "label": { "name": "bug" },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "external-user", "type": "User" }
+}

--- a/tests/dev-lead/fixtures/events/pr_opened_dependabot.json
+++ b/tests/dev-lead/fixtures/events/pr_opened_dependabot.json
@@ -1,0 +1,23 @@
+{
+  "_test_expected_intent": "skip",
+  "action": "opened",
+  "number": 51,
+  "pull_request": {
+    "number": 51,
+    "title": "Bump lodash from 4.17.20 to 4.17.21",
+    "body": "Bumps lodash from 4.17.20 to 4.17.21.",
+    "state": "open",
+    "author_association": "CONTRIBUTOR",
+    "head": {
+      "sha": "aaa111bbb222",
+      "ref": "dependabot/npm_and_yarn/lodash-4.17.21",
+      "repo": { "full_name": "petry-projects/.github-private" }
+    },
+    "base": {
+      "ref": "main",
+      "repo": { "full_name": "petry-projects/.github-private" }
+    }
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "dependabot[bot]", "type": "Bot" }
+}

--- a/tests/dev-lead/fixtures/events/pr_opened_fork.json
+++ b/tests/dev-lead/fixtures/events/pr_opened_fork.json
@@ -1,0 +1,23 @@
+{
+  "_test_expected_intent": "skip",
+  "action": "opened",
+  "number": 52,
+  "pull_request": {
+    "number": 52,
+    "title": "feat: fork contribution",
+    "body": "This PR comes from a fork.",
+    "state": "open",
+    "author_association": "NONE",
+    "head": {
+      "sha": "bbb222ccc333",
+      "ref": "feat/fork-feature",
+      "repo": { "full_name": "external-user/.github-private" }
+    },
+    "base": {
+      "ref": "main",
+      "repo": { "full_name": "petry-projects/.github-private" }
+    }
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "external-user", "type": "User" }
+}

--- a/tests/dev-lead/fixtures/events/pr_opened_human.json
+++ b/tests/dev-lead/fixtures/events/pr_opened_human.json
@@ -1,0 +1,23 @@
+{
+  "_test_expected_intent": "human-pr",
+  "action": "opened",
+  "number": 50,
+  "pull_request": {
+    "number": 50,
+    "title": "feat: add new feature",
+    "body": "This PR adds a new feature to the codebase.",
+    "state": "open",
+    "author_association": "OWNER",
+    "head": {
+      "sha": "def456abc789",
+      "ref": "feat/new-feature",
+      "repo": { "full_name": "petry-projects/.github-private" }
+    },
+    "base": {
+      "ref": "main",
+      "repo": { "full_name": "petry-projects/.github-private" }
+    }
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "donpetry", "type": "User" }
+}

--- a/tests/dev-lead/fixtures/events/pr_review_comment_copilot.json
+++ b/tests/dev-lead/fixtures/events/pr_review_comment_copilot.json
@@ -1,0 +1,31 @@
+{
+  "_test_expected_intent": "fix-reviews",
+  "action": "created",
+  "comment": {
+    "id": 2001,
+    "body": "This function has a potential null pointer dereference on line 42.",
+    "path": "src/utils/helpers.js",
+    "line": 42,
+    "user": {
+      "login": "copilot-pull-request-reviewer[bot]",
+      "type": "Bot"
+    }
+  },
+  "pull_request": {
+    "number": 58,
+    "title": "feat: utility functions",
+    "state": "open",
+    "author_association": "OWNER",
+    "head": {
+      "sha": "hhh888iii999",
+      "ref": "feat/utilities",
+      "repo": { "full_name": "petry-projects/.github-private" }
+    },
+    "base": {
+      "ref": "main",
+      "repo": { "full_name": "petry-projects/.github-private" }
+    }
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "copilot-pull-request-reviewer[bot]", "type": "Bot" }
+}

--- a/tests/dev-lead/fixtures/events/pr_review_comment_human_no_trigger.json
+++ b/tests/dev-lead/fixtures/events/pr_review_comment_human_no_trigger.json
@@ -1,0 +1,31 @@
+{
+  "_test_expected_intent": "skip",
+  "action": "created",
+  "comment": {
+    "id": 2003,
+    "body": "I think this approach could be improved but it works for now.",
+    "path": "src/api/endpoints.js",
+    "line": 88,
+    "user": {
+      "login": "donpetry",
+      "type": "User"
+    }
+  },
+  "pull_request": {
+    "number": 60,
+    "title": "feat: API endpoints",
+    "state": "open",
+    "author_association": "OWNER",
+    "head": {
+      "sha": "jjj000kkk111",
+      "ref": "feat/api",
+      "repo": { "full_name": "petry-projects/.github-private" }
+    },
+    "base": {
+      "ref": "main",
+      "repo": { "full_name": "petry-projects/.github-private" }
+    }
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "donpetry", "type": "User" }
+}

--- a/tests/dev-lead/fixtures/events/pr_review_comment_human_trigger.json
+++ b/tests/dev-lead/fixtures/events/pr_review_comment_human_trigger.json
@@ -1,0 +1,31 @@
+{
+  "_test_expected_intent": "human",
+  "action": "created",
+  "comment": {
+    "id": 2002,
+    "body": "@dev-lead fix this - the regex pattern here is wrong and will fail on edge cases",
+    "path": "src/validators/email.js",
+    "line": 15,
+    "user": {
+      "login": "donpetry",
+      "type": "User"
+    }
+  },
+  "pull_request": {
+    "number": 59,
+    "title": "feat: input validation",
+    "state": "open",
+    "author_association": "OWNER",
+    "head": {
+      "sha": "iii999jjj000",
+      "ref": "feat/validation",
+      "repo": { "full_name": "petry-projects/.github-private" }
+    },
+    "base": {
+      "ref": "main",
+      "repo": { "full_name": "petry-projects/.github-private" }
+    }
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "donpetry", "type": "User" }
+}

--- a/tests/dev-lead/fixtures/events/pr_review_copilot_approved.json
+++ b/tests/dev-lead/fixtures/events/pr_review_copilot_approved.json
@@ -1,0 +1,30 @@
+{
+  "_test_expected_intent": "skip",
+  "action": "submitted",
+  "review": {
+    "id": 1002,
+    "state": "APPROVED",
+    "body": "LGTM! No issues found.",
+    "user": {
+      "login": "copilot-pull-request-reviewer[bot]",
+      "type": "Bot"
+    }
+  },
+  "pull_request": {
+    "number": 55,
+    "title": "fix: bug fix",
+    "state": "open",
+    "author_association": "OWNER",
+    "head": {
+      "sha": "eee555fff666",
+      "ref": "fix/bug-fix",
+      "repo": { "full_name": "petry-projects/.github-private" }
+    },
+    "base": {
+      "ref": "main",
+      "repo": { "full_name": "petry-projects/.github-private" }
+    }
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "copilot-pull-request-reviewer[bot]", "type": "Bot" }
+}

--- a/tests/dev-lead/fixtures/events/pr_review_copilot_commented.json
+++ b/tests/dev-lead/fixtures/events/pr_review_copilot_commented.json
@@ -1,0 +1,30 @@
+{
+  "_test_expected_intent": "fix-reviews",
+  "action": "submitted",
+  "review": {
+    "id": 1001,
+    "state": "COMMENTED",
+    "body": "Please address the following issues in your code.",
+    "user": {
+      "login": "copilot-pull-request-reviewer[bot]",
+      "type": "Bot"
+    }
+  },
+  "pull_request": {
+    "number": 54,
+    "title": "feat: new feature",
+    "state": "open",
+    "author_association": "OWNER",
+    "head": {
+      "sha": "ddd444eee555",
+      "ref": "feat/new-feature",
+      "repo": { "full_name": "petry-projects/.github-private" }
+    },
+    "base": {
+      "ref": "main",
+      "repo": { "full_name": "petry-projects/.github-private" }
+    }
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "copilot-pull-request-reviewer[bot]", "type": "Bot" }
+}

--- a/tests/dev-lead/fixtures/events/pr_review_gemini_changes.json
+++ b/tests/dev-lead/fixtures/events/pr_review_gemini_changes.json
@@ -1,0 +1,30 @@
+{
+  "_test_expected_intent": "fix-reviews",
+  "action": "submitted",
+  "review": {
+    "id": 1003,
+    "state": "CHANGES_REQUESTED",
+    "body": "Several issues need to be addressed before this can be merged.",
+    "user": {
+      "login": "gemini-code-assist[bot]",
+      "type": "Bot"
+    }
+  },
+  "pull_request": {
+    "number": 56,
+    "title": "refactor: code cleanup",
+    "state": "open",
+    "author_association": "OWNER",
+    "head": {
+      "sha": "fff666ggg777",
+      "ref": "refactor/cleanup",
+      "repo": { "full_name": "petry-projects/.github-private" }
+    },
+    "base": {
+      "ref": "main",
+      "repo": { "full_name": "petry-projects/.github-private" }
+    }
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "gemini-code-assist[bot]", "type": "Bot" }
+}

--- a/tests/dev-lead/fixtures/events/pr_review_human_owner.json
+++ b/tests/dev-lead/fixtures/events/pr_review_human_owner.json
@@ -1,0 +1,30 @@
+{
+  "_test_expected_intent": "human-pr",
+  "action": "submitted",
+  "review": {
+    "id": 1004,
+    "state": "CHANGES_REQUESTED",
+    "body": "Please refactor the authentication logic and add more tests.",
+    "user": {
+      "login": "donpetry",
+      "type": "User"
+    }
+  },
+  "pull_request": {
+    "number": 57,
+    "title": "feat: authentication improvements",
+    "state": "open",
+    "author_association": "OWNER",
+    "head": {
+      "sha": "ggg777hhh888",
+      "ref": "feat/auth-improvements",
+      "repo": { "full_name": "petry-projects/.github-private" }
+    },
+    "base": {
+      "ref": "main",
+      "repo": { "full_name": "petry-projects/.github-private" }
+    }
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "donpetry", "type": "User" }
+}

--- a/tests/dev-lead/fixtures/events/pr_sync_dev_lead_commit.json
+++ b/tests/dev-lead/fixtures/events/pr_sync_dev_lead_commit.json
@@ -1,0 +1,23 @@
+{
+  "_test_expected_intent": "skip",
+  "action": "synchronize",
+  "number": 53,
+  "pull_request": {
+    "number": 53,
+    "title": "feat: auto-fix CI failures",
+    "body": "Automated fix by dev-lead agent.",
+    "state": "open",
+    "author_association": "OWNER",
+    "head": {
+      "sha": "ccc333ddd444",
+      "ref": "feat/auto-fix",
+      "repo": { "full_name": "petry-projects/.github-private" }
+    },
+    "base": {
+      "ref": "main",
+      "repo": { "full_name": "petry-projects/.github-private" }
+    }
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "donpetry-bot", "type": "Bot" }
+}

--- a/tests/dev-lead/fixtures/events/repository_dispatch_ci_failure.json
+++ b/tests/dev-lead/fixtures/events/repository_dispatch_ci_failure.json
@@ -1,0 +1,25 @@
+{
+  "_test_expected_intent": "fix-ci",
+  "action": "dev-lead-ci-failure",
+  "client_payload": {
+    "pr_number": 42,
+    "head_sha": "abc123def456",
+    "repo": "petry-projects/.github-private",
+    "checks": [
+      {
+        "name": "lint / eslint",
+        "conclusion": "failure",
+        "details_url": "https://github.com/petry-projects/.github-private/actions/runs/12345",
+        "app_slug": "github-actions"
+      },
+      {
+        "name": "test / unit",
+        "conclusion": "failure",
+        "details_url": "https://github.com/petry-projects/.github-private/actions/runs/12346",
+        "app_slug": "github-actions"
+      }
+    ]
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "github-actions[bot]", "type": "Bot" }
+}

--- a/tests/dev-lead/fixtures/logs/ci_failure_sample.txt
+++ b/tests/dev-lead/fixtures/logs/ci_failure_sample.txt
@@ -1,0 +1,239 @@
+Run npm run lint
+> project@1.0.0 lint
+> eslint src/ --ext .js,.ts --format stylish
+
+/home/runner/work/project/src/utils/helpers.js
+  42:15  error  'result' is assigned a value but never used  no-unused-vars
+  67:3   error  Expected a return value                      consistent-return
+  89:20  warning  Unexpected console statement               no-console
+
+/home/runner/work/project/src/api/endpoints.js
+  15:1   error  'express' is defined but never used          no-unused-vars
+  33:8   error  Missing semicolon                            semi
+  45:12  error  Unexpected use of 'eval'                    no-eval
+  78:5   error  'Promise' body should be split across lines  promise/param-names
+
+/home/runner/work/project/src/models/user.js
+  12:3   error  Missing JSDoc comment for function           valid-jsdoc
+  28:15  error  Unexpected token                             parse-errors
+  55:7   error  Useless constructor                          no-useless-constructor
+  91:1   error  Expected blank line before return statement  newline-before-return
+
+/home/runner/work/project/src/services/auth.js
+  8:10   error  'bcrypt' is not defined                      no-undef
+  24:3   error  Expected '===' and instead saw '=='          eqeqeq
+  37:18  error  Unsafe use of target                         no-unsafe-finally
+  62:5   error  Unexpected var, use let or const instead     no-var
+  85:12  error  Arrow function body should not use braces    arrow-body-style
+
+/home/runner/work/project/src/config/database.js
+  5:3    error  Connection string contains credentials       no-secrets
+  19:7   error  Unhandled promise rejection                  no-unhandled-promise
+
+18 errors, 1 warning
+
+npm ERR! code ELIFECYCLE
+npm ERR! errno 1
+npm ERR! project@1.0.0 lint: `eslint src/ --ext .js,.ts --format stylish`
+npm ERR! Exit status 1
+npm ERR!
+npm ERR! Failed at the project@1.0.0 lint script.
+npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
+
+Run npm test
+> project@1.0.0 test
+> jest --coverage --ci
+
+PASS src/utils/helpers.test.js
+  helpers
+    sanitizeInput
+      + should remove HTML tags (12ms)
+      + should handle empty strings (2ms)
+      + should preserve valid content (1ms)
+    formatDate
+      + should format ISO dates correctly (3ms)
+      - should handle invalid dates (5ms)
+
+FAIL src/api/endpoints.test.js
+  endpoints
+    GET /api/users
+      + should return 200 with user list (45ms)
+      - should require authentication (12ms)
+
+    POST /api/users
+      - should validate required fields (8ms)
+      - should reject duplicate emails (15ms)
+      - should hash passwords before storing (22ms)
+
+    DELETE /api/users/:id
+      + should soft-delete user (18ms)
+      - should require admin role (7ms)
+
+  FAIL  src/api/endpoints.test.js
+  endpoints > GET /api/users > should require authentication
+
+    expect(received).toBe(expected)
+
+    Expected: 401
+    Received: 200
+
+      67 |   it('should require authentication', async () => {
+      68 |     const response = await request(app).get('/api/users');
+    > 69 |     expect(response.status).toBe(401);
+         |                             ^
+      70 |     expect(response.body.error).toBe('Unauthorized');
+      71 |   });
+      72 |
+
+      at Object.<anonymous> (src/api/endpoints.test.js:69:29)
+
+  endpoints > POST /api/users > should validate required fields
+
+    expect(received).toBe(expected)
+
+    Expected: 422
+    Received: 201
+
+      89 |   it('should validate required fields', async () => {
+      90 |     const response = await request(app).post('/api/users').send({});
+    > 91 |     expect(response.status).toBe(422);
+         |                             ^
+      92 |   });
+      93 |
+
+      at Object.<anonymous> (src/api/endpoints.test.js:91:29)
+
+FAIL src/services/auth.test.js
+  AuthService
+    login
+      - should return JWT token on success (8ms)
+      - should reject invalid credentials (6ms)
+      - should lock account after 5 failed attempts (14ms)
+
+    register
+      - should create user with hashed password (11ms)
+      - should send verification email (9ms)
+
+  FAIL  src/services/auth.test.js
+  AuthService > login > should return JWT token on success
+
+    ReferenceError: bcrypt is not defined
+
+      5 | const AuthService = {
+      6 |   login: async (email, password) => {
+    > 7 |     const hash = await bcrypt.hash(password, 10);
+        |                        ^
+      8 |     // ...
+      9 |   }
+      10 | };
+
+      at Object.<anonymous> (src/services/auth.js:7:24)
+      at Object.<anonymous> (src/services/auth.test.js:15:5)
+
+FAIL src/models/user.test.js
+  UserModel
+    create
+      + should save to database (25ms)
+      - should validate email format (4ms)
+      - should enforce unique constraint (18ms)
+
+    findById
+      + should return user if found (11ms)
+      - should return null if not found (3ms)
+
+  FAIL  src/models/user.test.js
+  UserModel > create > should validate email format
+
+    TypeError: user.validate is not a function
+
+      34 |   it('should validate email format', async () => {
+      35 |     const user = new User({ email: 'not-an-email' });
+    > 36 |     await expect(user.validate()).rejects.toThrow();
+         |                       ^
+      37 |   });
+      38 |
+
+      at Object.<anonymous> (src/models/user.test.js:36:23)
+
+Test Suites: 3 failed, 1 passed, 4 total
+Tests:       11 failed, 8 passed, 19 total
+Snapshots:   0 total
+Time:        4.521s
+Ran all suites in 4.521s
+
+-------------------|---------|----------|---------|---------|-------------------
+File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
+-------------------|---------|----------|---------|---------|-------------------
+All files          |   58.33 |    45.21 |   62.50 |   57.89 |
+ src/api           |   67.89 |    55.00 |   75.00 |   68.42 | 15,33,45,78
+ endpoints.js      |   67.89 |    55.00 |   75.00 |   68.42 | 15,33,45,78
+ src/models        |   71.43 |    60.00 |   66.67 |   70.37 | 12,28,55,91
+ user.js           |   71.43 |    60.00 |   66.67 |   70.37 | 12,28,55,91
+ src/services      |   42.86 |    25.00 |   40.00 |   42.86 | 8,24,37,62,85
+ auth.js           |   42.86 |    25.00 |   40.00 |   42.86 | 8,24,37,62,85
+ src/utils         |   83.33 |    75.00 |   100.0 |   83.33 | 67,89
+ helpers.js        |   83.33 |    75.00 |   100.0 |   83.33 | 67,89
+ src/config        |   25.00 |    0.00  |   0.00  |   25.00 | 5,19
+ database.js       |   25.00 |    0.00  |   0.00  |   25.00 | 5,19
+-------------------|---------|----------|---------|---------|-------------------
+
+npm ERR! code ELIFECYCLE
+npm ERR! errno 1
+npm ERR! project@1.0.0 test: `jest --coverage --ci`
+npm ERR! Exit status 1
+npm ERR!
+npm ERR! Failed at the project@1.0.0 test script.
+npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
+
+Error: Process completed with exit code 1.
+
+Run npm run build
+> project@1.0.0 build
+> tsc --noEmit && webpack --config webpack.config.js
+
+src/api/endpoints.js(15,1): error TS2304: Cannot find name 'express'.
+src/services/auth.js(8,10): error TS2304: Cannot find name 'bcrypt'.
+src/models/user.js(28,15): error TS1005: ';' expected.
+src/config/database.js(5,3): error TS2345: Argument of type 'string' is not assignable to parameter of type 'ConnectionOptions'.
+
+Found 4 TypeScript errors.
+
+npm ERR! code ELIFECYCLE
+npm ERR! errno 1
+npm ERR! project@1.0.0 build: `tsc --noEmit && webpack --config webpack.config.js`
+npm ERR! Exit status 1
+
+##[group]Run npm run security-audit
+> project@1.0.0 security-audit
+> npm audit --audit-level=high
+
+# npm audit report
+
+lodash  <=4.17.20
+Severity: critical
+Prototype Pollution - https://npmjs.com/advisories/1523
+Prototype Pollution - https://npmjs.com/advisories/1544
+fix available via `npm audit fix --force`
+Will install lodash@4.17.21, which is a SemVer major change
+
+minimist  <1.2.6
+Severity: high
+Prototype Pollution in minimist - https://npmjs.com/advisories/1179
+fix available via `npm audit fix`
+
+3 vulnerabilities (1 high, 2 critical)
+
+To address all issues (including breaking changes), run:
+  npm audit fix --force
+
+npm ERR! code EAUDIT
+npm ERR! errno 1
+npm ERR! Found 3 vulnerabilities (1 high, 2 critical)
+
+##[endgroup]
+##[error]Process completed with exit code 1.
+
+##[group]Post Run actions/checkout@v4
+Cleaning up orphan processes
+Post job cleanup.
+##[endgroup]

--- a/tests/dev-lead/fixtures/stubs/gh
+++ b/tests/dev-lead/fixtures/stubs/gh
@@ -25,10 +25,6 @@ case "$ARGS" in
   *"run view"*)
     echo "${GH_STUB_RUN_LOG:-stub run log output}" ;;
   *)
-    # For anything else, try the real gh if available, otherwise return empty
-    if command -v /usr/bin/gh >/dev/null 2>&1; then
-      /usr/bin/gh "$@" 2>/dev/null || echo "{}"
-    else
-      echo "{}"
-    fi ;;
+    # For anything else, return empty — do not invoke real gh in tests
+    echo "{}" ;;
 esac

--- a/tests/dev-lead/fixtures/stubs/gh
+++ b/tests/dev-lead/fixtures/stubs/gh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Mock gh binary for testing. Configurable via environment variables.
+# GH_STUB_PR_NUMBER, GH_STUB_PR_HEAD_REPO, GH_STUB_COMMENT_BODY,
+# GH_STUB_CI_STATUS, GH_STUB_DISPATCH_CALLED
+
+ARGS="$*"
+case "$ARGS" in
+  *dispatches*)
+    echo "true" > "${GH_STUB_DISPATCH_FILE:-/tmp/gh_stub_dispatch_called}"
+    echo "{}" ;;
+  *"commits/"*"/pulls"*)
+    echo "[{\"number\":${GH_STUB_PR_NUMBER:-0},\"state\":\"open\",\"head\":{\"repo\":{\"full_name\":\"${GH_STUB_PR_HEAD_REPO:-petry-projects/.github-private}\"}}}]" ;;
+  *"pulls/${GH_STUB_PR_NUMBER:-0}"*|*"pulls/0"*)
+    echo "{\"number\":${GH_STUB_PR_NUMBER:-0},\"state\":\"open\",\"head\":{\"repo\":{\"full_name\":\"${GH_STUB_PR_HEAD_REPO:-petry-projects/.github-private}\"},\"sha\":\"abc123\"},\"base\":{\"ref\":\"main\"}}" ;;
+  *"comments"*)
+    echo "[{\"body\":\"${GH_STUB_COMMENT_BODY:-}\"}]" ;;
+  *"pr checks"*|*"checks run"*)
+    echo "${GH_STUB_CI_STATUS:-success}" ;;
+  *"pr comment"*)
+    exit 0 ;;
+  *"pr checkout"*)
+    exit 0 ;;
+  *"auth status"*)
+    echo "Logged in to github.com" ;;
+  *"run view"*)
+    echo "${GH_STUB_RUN_LOG:-stub run log output}" ;;
+  *)
+    # For anything else, try the real gh if available, otherwise return empty
+    if command -v /usr/bin/gh >/dev/null 2>&1; then
+      /usr/bin/gh "$@" 2>/dev/null || echo "{}"
+    else
+      echo "{}"
+    fi ;;
+esac

--- a/tests/dev-lead/helpers/assert-env.bash
+++ b/tests/dev-lead/helpers/assert-env.bash
@@ -1,0 +1,19 @@
+# Bats helper: assert GITHUB_ENV contents
+
+assert_env_contains() {
+  local key="$1" expected="$2"
+  local actual
+  actual=$(grep "^${key}=" "${GITHUB_ENV:-/dev/null}" | cut -d= -f2-)
+  if [ "$actual" != "$expected" ]; then
+    echo "Expected GITHUB_ENV[$key]='$expected', got '$actual'"
+    return 1
+  fi
+}
+
+assert_env_set() {
+  local key="$1"
+  if ! grep -q "^${key}=" "${GITHUB_ENV:-/dev/null}"; then
+    echo "Expected GITHUB_ENV[$key] to be set, but it was not"
+    return 1
+  fi
+}

--- a/tests/dev-lead/helpers/mock-gh.bash
+++ b/tests/dev-lead/helpers/mock-gh.bash
@@ -1,0 +1,14 @@
+# Bats helper: configure mock gh responses
+
+MOCK_GH_DIR="${BATS_TMPDIR:-/tmp}/mock-gh-bins"
+
+setup_mock_gh() {
+  mkdir -p "$MOCK_GH_DIR"
+  cp "$(dirname "${BASH_SOURCE[0]}")/../fixtures/stubs/gh" "$MOCK_GH_DIR/gh"
+  chmod +x "$MOCK_GH_DIR/gh"
+  export PATH="$MOCK_GH_DIR:$PATH"
+}
+
+teardown_mock_gh() {
+  rm -rf "$MOCK_GH_DIR"
+}

--- a/tests/dev-lead/helpers/prompt-vars.bash
+++ b/tests/dev-lead/helpers/prompt-vars.bash
@@ -1,0 +1,19 @@
+# Bats helper: verify template variable coverage
+
+assert_prompt_vars_covered() {
+  local template="$1"
+  # Extract variables referenced in template (${VAR} style)
+  local used_vars
+  used_vars=$(grep -oP '\$\{[A-Z_]+\}' "$template" | sort -u | sed 's/[${}]//g')
+  # Extract variables declared in <!-- VARIABLES: --> comment
+  local declared_vars
+  declared_vars=$(grep -oP '(?<=<!-- VARIABLES: )[^>]+(?= -->)' "$template" | tr ',' '\n' | tr -d ' ' | sort -u)
+
+  while IFS= read -r var; do
+    [ -z "$var" ] && continue
+    if ! echo "$declared_vars" | grep -qx "$var"; then
+      echo "Variable \${$var} used in $template but not declared in <!-- VARIABLES: --> comment"
+      return 1
+    fi
+  done <<< "$used_vars"
+}

--- a/tests/dev-lead/helpers/stub-engine.bash
+++ b/tests/dev-lead/helpers/stub-engine.bash
@@ -1,0 +1,16 @@
+# Bats helper: install/remove engine stubs
+# Usage: source this file in bats tests
+
+STUB_BIN_DIR="${BATS_TMPDIR:-/tmp}/stub-bins"
+
+setup_stub_engines() {
+  mkdir -p "$STUB_BIN_DIR"
+  cp "$(dirname "${BASH_SOURCE[0]}")/../fixtures/engines/stub-claude" "$STUB_BIN_DIR/claude"
+  cp "$(dirname "${BASH_SOURCE[0]}")/../fixtures/engines/stub-gemini" "$STUB_BIN_DIR/gemini"
+  chmod +x "$STUB_BIN_DIR/claude" "$STUB_BIN_DIR/gemini"
+  export PATH="$STUB_BIN_DIR:$PATH"
+}
+
+teardown_stub_engines() {
+  rm -rf "$STUB_BIN_DIR"
+}

--- a/tests/dev-lead/integration/test_prompt_coverage.sh
+++ b/tests/dev-lead/integration/test_prompt_coverage.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Integration test: verify all dev-lead prompts have correct variable declarations.
+#
+# Checks:
+#   1. All 7 expected prompt files exist
+#   2. Each prompt has a <!-- VARIABLES: --> comment
+#   3. All ${VAR} references in each prompt are declared in that comment
+
+PROMPTS_DIR="$(dirname "$0")/../../../prompts/dev-lead"
+FAILED=0
+
+# ── 1. check all 7 prompts exist ─────────────────────────────────────────────
+
+EXPECTED_PROMPTS=(
+  "fix-ci.md"
+  "fix-reviews.md"
+  "fix-bot-comment.md"
+  "human.md"
+  "human-pr.md"
+  "fix-issue.md"
+  "rebase.md"
+)
+
+echo "Checking prompt files exist..."
+for prompt in "${EXPECTED_PROMPTS[@]}"; do
+  path="$PROMPTS_DIR/$prompt"
+  if [ ! -f "$path" ]; then
+    echo "  FAIL: missing prompt file: $path"
+    FAILED=1
+  else
+    echo "  ok: $prompt"
+  fi
+done
+
+# ── 2. check VARIABLES comment + 3. check variable coverage ──────────────────
+
+echo ""
+echo "Checking variable declarations..."
+for prompt in "${EXPECTED_PROMPTS[@]}"; do
+  path="$PROMPTS_DIR/$prompt"
+  [ -f "$path" ] || continue
+
+  # Extract declared variables from <!-- VARIABLES: VAR1, VAR2, ... --> comment
+  declared_line=$(grep -oP '(?<=<!-- VARIABLES: )[^>]+(?= -->)' "$path" 2>/dev/null | head -1 || true)
+
+  if [ -z "$declared_line" ]; then
+    echo "  FAIL: $prompt — missing <!-- VARIABLES: ... --> comment"
+    FAILED=1
+    continue
+  fi
+
+  # Build declared vars as a space-delimited list
+  declared_vars=$(echo "$declared_line" | tr ',' '\n' | tr -d ' ' | sort -u)
+
+  # Extract ${VAR} style references used in file
+  used_vars=$(grep -oP '\$\{[A-Z_]+\}' "$path" 2>/dev/null | sed 's/[${}]//g' | sort -u || true)
+
+  if [ -z "$used_vars" ]; then
+    echo "  ok: $prompt (no variables used)"
+    continue
+  fi
+
+  prompt_failed=0
+  while IFS= read -r var; do
+    [ -z "$var" ] && continue
+    if ! echo "$declared_vars" | grep -qx "$var"; then
+      echo "  FAIL: $prompt — \${$var} used but not declared in VARIABLES comment"
+      FAILED=1
+      prompt_failed=1
+    fi
+  done <<< "$used_vars"
+
+  if [ "$prompt_failed" -eq 0 ]; then
+    echo "  ok: $prompt (declared: $(echo "$declared_vars" | tr '\n' ',' | sed 's/,$//') )"
+  fi
+done
+
+# ── result ────────────────────────────────────────────────────────────────────
+
+echo ""
+if [ "$FAILED" -ne 0 ]; then
+  echo "FAIL: prompt coverage check failed"
+  exit 1
+fi
+
+echo "PASS: all prompts have correct variable declarations"

--- a/tests/dev-lead/unit/test_engine_fallback.bats
+++ b/tests/dev-lead/unit/test_engine_fallback.bats
@@ -1,0 +1,139 @@
+#!/usr/bin/env bats
+# Unit tests for engine.sh — run_writer_with_fallback (Phase 6)
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+ENGINE_SCRIPT="$SCRIPT_DIR/scripts/engine.sh"
+STUB_ENGINES_DIR="$SCRIPT_DIR/tests/dev-lead/fixtures/engines"
+
+setup() {
+  export GITHUB_ENV="$(mktemp)"
+  export GITHUB_OUTPUT="$(mktemp)"
+
+  STUB_BIN_DIR="$(mktemp -d)"
+  cp "$STUB_ENGINES_DIR/stub-claude" "$STUB_BIN_DIR/claude"
+  cp "$STUB_ENGINES_DIR/stub-gemini" "$STUB_BIN_DIR/gemini"
+  chmod +x "$STUB_BIN_DIR/claude" "$STUB_BIN_DIR/gemini"
+  export PATH="$STUB_BIN_DIR:$PATH"
+  export STUB_BIN_DIR
+
+  # Create a test prompt file
+  TEST_PROMPT="$(mktemp)"
+  echo "test prompt content" > "$TEST_PROMPT"
+  export TEST_PROMPT
+
+  export DEV_LEAD_DRY_RUN="false"
+}
+
+teardown() {
+  rm -f "$GITHUB_ENV" "$GITHUB_OUTPUT" "$TEST_PROMPT"
+  rm -rf "$STUB_BIN_DIR"
+}
+
+# Helper: source engine with a given engine type (suppresses info line)
+_source_engine() {
+  local engine="${1:-claude}"
+  export REVIEW_ENGINE="$engine"
+  source "$ENGINE_SCRIPT" 2>/dev/null || true
+}
+
+# Helper: create a stub that always returns a given exit code
+_make_stub() {
+  local name="$1" exit_code="$2"
+  cat > "$STUB_BIN_DIR/$name" <<STUBEOF
+#!/usr/bin/env bash
+while [[ \$# -gt 0 ]]; do
+  case "\$1" in
+    --print|--model|--permission-mode|--allowed-tools|--prompt|--approval-mode|--output-format) shift; shift ;;
+    *) shift ;;
+  esac
+done
+exit ${exit_code}
+STUBEOF
+  chmod +x "$STUB_BIN_DIR/$name"
+}
+
+# Helper: create a stub that records calls and returns a given exit code
+_make_recording_stub() {
+  local name="$1" exit_code="$2" record_file="$3"
+  cat > "$STUB_BIN_DIR/$name" <<STUBEOF
+#!/usr/bin/env bash
+echo "\$0" >> "${record_file}"
+while [[ \$# -gt 0 ]]; do
+  case "\$1" in
+    --print|--model|--permission-mode|--allowed-tools|--prompt|--approval-mode|--output-format) shift; shift ;;
+    *) shift ;;
+  esac
+done
+exit ${exit_code}
+STUBEOF
+  chmod +x "$STUB_BIN_DIR/$name"
+}
+
+# ── run_writer_with_fallback tests ────────────────────────────────────────────
+
+@test "fallback: primary exits 0 → success" {
+  _make_stub "claude" 0
+  _source_engine "claude"
+
+  run run_writer_with_fallback "$TEST_PROMPT"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "fallback: primary exits 2 → tries next engine" {
+  # claude exits 2 (rate-limited), gemini exits 0
+  _make_stub "claude" 2
+  _make_stub "gemini" 0
+  _source_engine "claude"
+
+  run run_writer_with_fallback "$TEST_PROMPT"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "fallback: all rate-limited → returns 2" {
+  # All engines exit 2
+  _make_stub "claude" 2
+  _make_stub "gemini" 2
+  # copilot falls back to claude internally, so we only need claude and gemini
+  # Create a copilot stub that also fails with 2
+  cat > "$STUB_BIN_DIR/copilot" <<'STUBEOF'
+#!/usr/bin/env bash
+exit 2
+STUBEOF
+  chmod +x "$STUB_BIN_DIR/copilot"
+  _source_engine "claude"
+
+  run run_writer_with_fallback "$TEST_PROMPT"
+
+  [ "$status" -eq 2 ]
+}
+
+@test "fallback: non-rate-limit exit 1 → no fallback" {
+  # claude exits 1 (real failure, not rate-limit)
+  _make_stub "claude" 1
+  # gemini should NOT be called - if it were, it would succeed (exit 0)
+  _make_stub "gemini" 0
+  _source_engine "claude"
+
+  run run_writer_with_fallback "$TEST_PROMPT"
+
+  # Should fail with 1 immediately, not succeed via gemini
+  [ "$status" -eq 1 ]
+}
+
+@test "fallback: fallback engine order is claude → gemini → copilot" {
+  # Primary = gemini (exits 2), then fallback order should try claude first
+  _make_stub "gemini" 2
+  local record_file
+  record_file="$(mktemp)"
+  _make_recording_stub "claude" 0 "$record_file"
+  _source_engine "gemini"
+
+  run run_writer_with_fallback "$TEST_PROMPT"
+
+  [ "$status" -eq 0 ]
+  # claude should have been called (recorded in record_file)
+  [ -s "$record_file" ]
+  rm -f "$record_file"
+}

--- a/tests/dev-lead/unit/test_engine_writer.bats
+++ b/tests/dev-lead/unit/test_engine_writer.bats
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+# Unit tests for engine.sh — run_writer and run_writer_with_fallback (Phase 2)
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+ENGINE_SCRIPT="$SCRIPT_DIR/scripts/engine.sh"
+STUB_ENGINES_DIR="$SCRIPT_DIR/tests/dev-lead/fixtures/engines"
+
+setup() {
+  export GITHUB_ENV="$(mktemp)"
+  export GITHUB_OUTPUT="$(mktemp)"
+  # Create a temp bin dir with stub engines
+  STUB_BIN_DIR="$(mktemp -d)"
+  cp "$STUB_ENGINES_DIR/stub-claude" "$STUB_BIN_DIR/claude"
+  cp "$STUB_ENGINES_DIR/stub-gemini" "$STUB_BIN_DIR/gemini"
+  chmod +x "$STUB_BIN_DIR/claude" "$STUB_BIN_DIR/gemini"
+  export PATH="$STUB_BIN_DIR:$PATH"
+  # Create a test prompt file
+  TEST_PROMPT="$(mktemp)"
+  echo "test prompt content" > "$TEST_PROMPT"
+  export TEST_PROMPT
+  export STUB_BIN_DIR
+}
+
+teardown() {
+  rm -f "$GITHUB_ENV" "$GITHUB_OUTPUT" "$TEST_PROMPT"
+  rm -rf "$STUB_BIN_DIR"
+}
+
+# Helper: source engine with a given engine type (suppresses info line)
+_source_engine() {
+  local engine="${1:-claude}"
+  export REVIEW_ENGINE="$engine"
+  source "$ENGINE_SCRIPT" 2>/dev/null || true
+}
+
+# ── run_writer tests ──────────────────────────────────────────────────────────
+
+@test "writer: run_writer with stub claude exits 0 on success" {
+  _source_engine "claude"
+  export STUB_ENGINE_EXIT=0
+  export DEV_LEAD_DRY_RUN=false
+
+  run run_writer "$TEST_PROMPT"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "writer: run_writer dry-run exits 0 without calling engine" {
+  _source_engine "claude"
+  export DEV_LEAD_DRY_RUN=true
+  # Remove the claude stub to verify it's not called
+  rm -f "$STUB_BIN_DIR/claude"
+
+  run run_writer "$TEST_PROMPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[dry-run]"* ]]
+}
+
+@test "writer: run_writer dry-run: no engine binary needed" {
+  _source_engine "claude"
+  export DEV_LEAD_DRY_RUN=true
+  # Even without claude in PATH, dry-run should succeed
+  local saved_path="$PATH"
+  export PATH="/usr/bin:/bin"
+
+  run run_writer "$TEST_PROMPT"
+
+  export PATH="$saved_path"
+  [ "$status" -eq 0 ]
+}
+
+@test "writer: run_writer exits non-zero on engine failure" {
+  _source_engine "claude"
+  export STUB_ENGINE_EXIT=1
+  export DEV_LEAD_DRY_RUN=false
+
+  run run_writer "$TEST_PROMPT"
+
+  [ "$status" -ne 0 ]
+}
+
+@test "writer: gemini engine exits 0 on success" {
+  _source_engine "gemini"
+  export STUB_ENGINE_EXIT=0
+  export DEV_LEAD_DRY_RUN=false
+
+  run run_writer "$TEST_PROMPT"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "writer: copilot falls back to claude in run_writer (internal)" {
+  # When REVIEW_ENGINE=copilot, run_writer internally falls back to claude
+  _source_engine "copilot"
+  export STUB_ENGINE_EXIT=0
+  export DEV_LEAD_DRY_RUN=false
+
+  run run_writer "$TEST_PROMPT"
+
+  # Should succeed because the internal claude stub is present
+  [ "$status" -eq 0 ]
+}
+
+@test "writer: run_writer dry-run logs prompt line count" {
+  _source_engine "claude"
+  export DEV_LEAD_DRY_RUN=true
+  printf 'line1\nline2\nline3\n' > "$TEST_PROMPT"
+
+  run run_writer "$TEST_PROMPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"3 lines"* ]]
+}

--- a/tests/dev-lead/unit/test_fix_ci.bats
+++ b/tests/dev-lead/unit/test_fix_ci.bats
@@ -1,0 +1,226 @@
+#!/usr/bin/env bats
+# Unit tests for dev-lead-fix-ci.sh (Phase 2)
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+FIX_CI_SCRIPT="$SCRIPT_DIR/scripts/dev-lead-fix-ci.sh"
+STUB_ENGINES_DIR="$SCRIPT_DIR/tests/dev-lead/fixtures/engines"
+GH_STUBS_DIR="$SCRIPT_DIR/tests/dev-lead/fixtures/stubs"
+
+setup() {
+  export GITHUB_ENV="$(mktemp)"
+  export GITHUB_OUTPUT="$(mktemp)"
+
+  # Set up stub binary directory
+  STUB_BIN_DIR="$(mktemp -d)"
+  cp "$STUB_ENGINES_DIR/stub-claude" "$STUB_BIN_DIR/claude"
+  cp "$STUB_ENGINES_DIR/stub-gemini" "$STUB_BIN_DIR/gemini"
+  cp "$GH_STUBS_DIR/gh" "$STUB_BIN_DIR/gh"
+  chmod +x "$STUB_BIN_DIR/claude" "$STUB_BIN_DIR/gemini" "$STUB_BIN_DIR/gh"
+  export PATH="$STUB_BIN_DIR:$PATH"
+  export STUB_BIN_DIR
+
+  # Default environment for fix-ci
+  export PR_NUMBER="42"
+  export HEAD_SHA="abc123def456"
+  export CHECKS_JSON='[{"name":"lint / eslint","conclusion":"failure","details_url":"https://github.com/petry-projects/.github-private/actions/runs/12345","app_slug":"github-actions","id":99}]'
+  export REPO="petry-projects/.github-private"
+  export REVIEW_ENGINE="claude"
+  export DEV_LEAD_DRY_RUN="true"
+  export GH_STUB_COMMENT_BODY=""
+  # Point to project root for prompts
+  cd "$SCRIPT_DIR"
+}
+
+teardown() {
+  rm -f "$GITHUB_ENV" "$GITHUB_OUTPUT"
+  rm -rf "$STUB_BIN_DIR"
+}
+
+# ── idempotency tests ────────────────────────────────────────────────────────
+
+@test "fix-ci: idempotency: marker found → exits 0" {
+  # Stub gh to return a comment with our marker
+  local marker="<!-- dev-lead-fix-ci sha=${HEAD_SHA}"
+  export GH_STUB_COMMENT_BODY="$marker"
+
+  # Create a gh stub that returns an existing marker comment
+  cat > "$STUB_BIN_DIR/gh" <<'GHEOF'
+#!/usr/bin/env bash
+ARGS="$*"
+case "$ARGS" in
+  *"issues/"*"/comments"*)
+    echo "[{\"body\":\"<!-- dev-lead-fix-ci sha=${GH_STUB_COMMENT_BODY:-} status=applied -->\"}]" ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN_DIR/gh"
+
+  # Override with a script that returns length > 0
+  cat > "$STUB_BIN_DIR/gh" <<GHEOF2
+#!/usr/bin/env bash
+ARGS="\$*"
+case "\$ARGS" in
+  *"issues/"*"/comments"*)
+    echo "[{\"body\":\"<!-- dev-lead-fix-ci sha=abc123def456 status=applied -->\"}]" ;;
+  *) echo "{}" ;;
+esac
+GHEOF2
+  chmod +x "$STUB_BIN_DIR/gh"
+
+  export DEV_LEAD_DRY_RUN="false"
+  run bash "$FIX_CI_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"idempotent"* ]]
+}
+
+@test "fix-ci: idempotency: no marker → proceeds" {
+  # gh returns no comments with our marker
+  cat > "$STUB_BIN_DIR/gh" <<'GHEOF'
+#!/usr/bin/env bash
+ARGS="$*"
+case "$ARGS" in
+  *"issues/"*"/comments"*)
+    echo "[]" ;;
+  *"pr comment"*)
+    exit 0 ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN_DIR/gh"
+  export DEV_LEAD_DRY_RUN="true"
+
+  run bash "$FIX_CI_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  # Should reach dry-run output (not idempotent skip)
+  [[ "$output" == *"[dry-run]"* ]]
+}
+
+# ── log truncation test ───────────────────────────────────────────────────────
+
+@test "fix-ci: log truncation: >200 lines → ≤200 lines output" {
+  # Create a gh stub that returns 300 log lines
+  local lines_300
+  lines_300=$(python3 -c "print('\n'.join(['log line ' + str(i) for i in range(300)]))")
+  cat > "$STUB_BIN_DIR/gh" <<'GHEOF'
+#!/usr/bin/env bash
+ARGS="$*"
+case "$ARGS" in
+  *"run view"*)
+    python3 -c "print('\n'.join(['log line ' + str(i) for i in range(300)]))" ;;
+  *"issues/"*"/comments"*)
+    echo "[]" ;;
+  *"pr comment"*)
+    exit 0 ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN_DIR/gh"
+  export DEV_LEAD_DRY_RUN="true"
+
+  run bash "$FIX_CI_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  # The dry-run runs and succeeds; we can't easily check log truncation
+  # in dry-run mode, but we verify the script doesn't error out
+}
+
+# ── dry-run tests ─────────────────────────────────────────────────────────────
+
+@test "fix-ci: dry-run: DEV_LEAD_DRY_RUN=true builds prompt but does not commit" {
+  cat > "$STUB_BIN_DIR/gh" <<'GHEOF'
+#!/usr/bin/env bash
+ARGS="$*"
+case "$ARGS" in
+  *"issues/"*"/comments"*) echo "[]" ;;
+  *"pr comment"*) exit 0 ;;
+  *"run view"*) echo "log output" ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN_DIR/gh"
+  export DEV_LEAD_DRY_RUN="true"
+
+  run bash "$FIX_CI_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[dry-run]"* ]]
+  # Ensure git commit was NOT called (no "git" in output with "commit")
+  [[ "$output" != *"git commit"* ]]
+}
+
+# ── prompt build test ─────────────────────────────────────────────────────────
+
+@test "fix-ci: prompt build: CHECK_NAME in prompt" {
+  cat > "$STUB_BIN_DIR/gh" <<'GHEOF'
+#!/usr/bin/env bash
+ARGS="$*"
+case "$ARGS" in
+  *"issues/"*"/comments"*) echo "[]" ;;
+  *"pr comment"*) exit 0 ;;
+  *"run view"*) echo "log output" ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN_DIR/gh"
+  export DEV_LEAD_DRY_RUN="true"
+  export CHECKS_JSON='[{"name":"my-check-name","conclusion":"failure","details_url":"","app_slug":"github-actions"}]'
+
+  run bash "$FIX_CI_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  # The dry-run output mentions it built a prompt
+  [[ "$output" == *"fix-ci"* ]]
+}
+
+# ── error cases ───────────────────────────────────────────────────────────────
+
+@test "fix-ci: missing PR_NUMBER → exits 1" {
+  unset PR_NUMBER
+
+  run bash "$FIX_CI_SCRIPT"
+
+  [ "$status" -eq 1 ]
+}
+
+@test "fix-ci: dry-run: post_summary outputs [dry-run] prefix" {
+  cat > "$STUB_BIN_DIR/gh" <<'GHEOF'
+#!/usr/bin/env bash
+ARGS="$*"
+case "$ARGS" in
+  *"issues/"*"/comments"*) echo "[]" ;;
+  *"pr comment"*) exit 0 ;;
+  *"run view"*) echo "log output" ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN_DIR/gh"
+  export DEV_LEAD_DRY_RUN="true"
+
+  run bash "$FIX_CI_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[dry-run]"* ]]
+}
+
+@test "fix-ci: CHECKS_JSON single check → name appears in dry-run output" {
+  cat > "$STUB_BIN_DIR/gh" <<'GHEOF'
+#!/usr/bin/env bash
+ARGS="$*"
+case "$ARGS" in
+  *"issues/"*"/comments"*) echo "[]" ;;
+  *"pr comment"*) exit 0 ;;
+  *"run view"*) echo "log output" ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN_DIR/gh"
+  export DEV_LEAD_DRY_RUN="true"
+  export CHECKS_JSON='[{"name":"eslint-check","conclusion":"failure","details_url":"","app_slug":"github-actions"}]'
+
+  run bash "$FIX_CI_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"eslint-check"* ]]
+}

--- a/tests/dev-lead/unit/test_fix_ci.bats
+++ b/tests/dev-lead/unit/test_fix_ci.bats
@@ -39,32 +39,18 @@ teardown() {
 # ── idempotency tests ────────────────────────────────────────────────────────
 
 @test "fix-ci: idempotency: marker found → exits 0" {
-  # Stub gh to return a comment with our marker
-  local marker="<!-- dev-lead-fix-ci sha=${HEAD_SHA}"
-  export GH_STUB_COMMENT_BODY="$marker"
-
-  # Create a gh stub that returns an existing marker comment
+  # Stub gh to return count 1 when queried for existing marker comments
+  # The script uses: gh api ... --jq "[.[] | select(...)] | length"
+  # Our stub needs to return "1" for that query
   cat > "$STUB_BIN_DIR/gh" <<'GHEOF'
 #!/usr/bin/env bash
-ARGS="$*"
-case "$ARGS" in
+# Return "1" for the comments/idempotency check (simulates marker found)
+case "$*" in
   *"issues/"*"/comments"*)
-    echo "[{\"body\":\"<!-- dev-lead-fix-ci sha=${GH_STUB_COMMENT_BODY:-} status=applied -->\"}]" ;;
+    echo "1" ;;
   *) echo "{}" ;;
 esac
 GHEOF
-  chmod +x "$STUB_BIN_DIR/gh"
-
-  # Override with a script that returns length > 0
-  cat > "$STUB_BIN_DIR/gh" <<GHEOF2
-#!/usr/bin/env bash
-ARGS="\$*"
-case "\$ARGS" in
-  *"issues/"*"/comments"*)
-    echo "[{\"body\":\"<!-- dev-lead-fix-ci sha=abc123def456 status=applied -->\"}]" ;;
-  *) echo "{}" ;;
-esac
-GHEOF2
   chmod +x "$STUB_BIN_DIR/gh"
 
   export DEV_LEAD_DRY_RUN="false"

--- a/tests/dev-lead/unit/test_fix_issue.bats
+++ b/tests/dev-lead/unit/test_fix_issue.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+# Unit tests for dev-lead-fix-issue.sh (Phase 5)
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+FIX_ISSUE_SCRIPT="$SCRIPT_DIR/scripts/dev-lead-fix-issue.sh"
+STUB_ENGINES_DIR="$SCRIPT_DIR/tests/dev-lead/fixtures/engines"
+GH_STUBS_DIR="$SCRIPT_DIR/tests/dev-lead/fixtures/stubs"
+
+setup() {
+  export GITHUB_ENV="$(mktemp)"
+  export GITHUB_OUTPUT="$(mktemp)"
+
+  STUB_BIN_DIR="$(mktemp -d)"
+  cp "$STUB_ENGINES_DIR/stub-claude" "$STUB_BIN_DIR/claude"
+  cp "$STUB_ENGINES_DIR/stub-gemini" "$STUB_BIN_DIR/gemini"
+  chmod +x "$STUB_BIN_DIR/claude" "$STUB_BIN_DIR/gemini"
+  export PATH="$STUB_BIN_DIR:$PATH"
+  export STUB_BIN_DIR
+
+  # Default gh stub that returns no existing PRs (no dedup)
+  cat > "$STUB_BIN_DIR/gh" <<'GHEOF'
+#!/usr/bin/env bash
+ARGS="$*"
+case "$ARGS" in
+  *"pulls?state=open"*)
+    echo "[]" ;;
+  *"api"*"repos/"*"issues/"*)
+    echo '{"title":"Test Issue","body":"Test issue body"}' ;;
+  *"issue comment"*)
+    exit 0 ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN_DIR/gh"
+
+  # Default env
+  export ISSUE_NUMBER="100"
+  export REPO="petry-projects/.github-private"
+  export REVIEW_ENGINE="claude"
+  export DEV_LEAD_DRY_RUN="true"
+  export GITHUB_REPOSITORY="petry-projects/.github-private"
+
+  cd "$SCRIPT_DIR"
+}
+
+teardown() {
+  rm -f "$GITHUB_ENV" "$GITHUB_OUTPUT"
+  rm -rf "$STUB_BIN_DIR"
+}
+
+# ── dedup tests ───────────────────────────────────────────────────────────────
+
+@test "fix-issue: dedup: existing open PR → exits 0 with comment" {
+  # Stub gh to return an existing PR for this issue branch
+  cat > "$STUB_BIN_DIR/gh" <<'GHEOF'
+#!/usr/bin/env bash
+ARGS="$*"
+case "$ARGS" in
+  *"pulls?state=open"*)
+    echo '[{"number":50,"head":{"ref":"dev-lead/issue-100-20260101-1200"}}]' ;;
+  *"issue comment"*)
+    exit 0 ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN_DIR/gh"
+  export DEV_LEAD_DRY_RUN="false"
+
+  run bash "$FIX_ISSUE_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"dedup"* ]] || [[ "$output" == *"Existing open PR"* ]]
+}
+
+@test "fix-issue: dry-run: DEV_LEAD_DRY_RUN=true → logs [dry-run]" {
+  export DEV_LEAD_DRY_RUN="true"
+
+  run bash "$FIX_ISSUE_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[dry-run]"* ]]
+}
+
+@test "fix-issue: missing ISSUE_NUMBER → exits 1" {
+  unset ISSUE_NUMBER
+
+  run bash "$FIX_ISSUE_SCRIPT"
+
+  [ "$status" -eq 1 ]
+}
+
+@test "fix-issue: ISSUE_TITLE and ISSUE_BODY exported to env before envsubst" {
+  export DEV_LEAD_DRY_RUN="true"
+
+  # Create a gh stub that returns known title/body
+  cat > "$STUB_BIN_DIR/gh" <<'GHEOF'
+#!/usr/bin/env bash
+ARGS="$*"
+case "$ARGS" in
+  *"pulls?state=open"*)
+    echo "[]" ;;
+  *"api"*"repos/"*"issues/"*)
+    echo '{"title":"My Known Title","body":"My Known Body"}' ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN_DIR/gh"
+
+  run bash "$FIX_ISSUE_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[dry-run]"* ]]
+}
+
+@test "fix-issue: ORG_STANDARDS_HINT included in prompt context" {
+  export DEV_LEAD_DRY_RUN="true"
+
+  # We can verify by checking the generated prompt in dry-run mode
+  # The dry-run message references the prompt file
+  run bash "$FIX_ISSUE_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  # Prompt was built (dry-run says would implement)
+  [[ "$output" == *"[dry-run]"* ]]
+}
+
+@test "fix-issue: dry-run: check_existing_pr result does not affect dry-run path" {
+  # Even if gh returns an empty list, dry-run should work
+  export DEV_LEAD_DRY_RUN="true"
+
+  run bash "$FIX_ISSUE_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[dry-run]"* ]]
+}
+
+@test "fix-issue: dry-run: prompt file path appears in output" {
+  export DEV_LEAD_DRY_RUN="true"
+
+  run bash "$FIX_ISSUE_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  # Dry-run message contains reference to the issue
+  [[ "$output" == *"issue #${ISSUE_NUMBER}"* ]]
+}

--- a/tests/dev-lead/unit/test_fix_issue.bats
+++ b/tests/dev-lead/unit/test_fix_issue.bats
@@ -51,13 +51,14 @@ teardown() {
 # ── dedup tests ───────────────────────────────────────────────────────────────
 
 @test "fix-issue: dedup: existing open PR → exits 0 with comment" {
-  # Stub gh to return an existing PR for this issue branch
+  # Stub gh to return count > 0 for the dedup check
+  # The script uses: gh api ".../pulls?state=open" --jq "[.[] | select(...)] | length"
+  # Our stub returns "1" to simulate existing PR found
   cat > "$STUB_BIN_DIR/gh" <<'GHEOF'
 #!/usr/bin/env bash
-ARGS="$*"
-case "$ARGS" in
+case "$*" in
   *"pulls?state=open"*)
-    echo '[{"number":50,"head":{"ref":"dev-lead/issue-100-20260101-1200"}}]' ;;
+    echo "1" ;;
   *"issue comment"*)
     exit 0 ;;
   *) echo "{}" ;;

--- a/tests/dev-lead/unit/test_fix_reviews.bats
+++ b/tests/dev-lead/unit/test_fix_reviews.bats
@@ -1,0 +1,154 @@
+#!/usr/bin/env bats
+# Unit tests for dev-lead-fix-reviews.sh (Phase 3)
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+FIX_REVIEWS_SCRIPT="$SCRIPT_DIR/scripts/dev-lead-fix-reviews.sh"
+STUB_ENGINES_DIR="$SCRIPT_DIR/tests/dev-lead/fixtures/engines"
+GH_STUBS_DIR="$SCRIPT_DIR/tests/dev-lead/fixtures/stubs"
+
+setup() {
+  export GITHUB_ENV="$(mktemp)"
+  export GITHUB_OUTPUT="$(mktemp)"
+
+  STUB_BIN_DIR="$(mktemp -d)"
+  cp "$STUB_ENGINES_DIR/stub-claude" "$STUB_BIN_DIR/claude"
+  cp "$STUB_ENGINES_DIR/stub-gemini" "$STUB_BIN_DIR/gemini"
+  cp "$GH_STUBS_DIR/gh" "$STUB_BIN_DIR/gh"
+  chmod +x "$STUB_BIN_DIR/claude" "$STUB_BIN_DIR/gemini" "$STUB_BIN_DIR/gh"
+  export PATH="$STUB_BIN_DIR:$PATH"
+  export STUB_BIN_DIR
+
+  # Default env
+  export PR_NUMBER="54"
+  export HEAD_SHA="ddd444eee555"
+  export REPO="petry-projects/.github-private"
+  export REVIEW_ENGINE="claude"
+  export DEV_LEAD_DRY_RUN="true"
+  export GITHUB_REPOSITORY="petry-projects/.github-private"
+  export BASE_REF="main"
+  export ACTOR="donpetry"
+
+  # Install a graphql-aware gh stub
+  cat > "$STUB_BIN_DIR/gh" <<'GHEOF'
+#!/usr/bin/env bash
+ARGS="$*"
+case "$ARGS" in
+  *"graphql"*)
+    echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}' ;;
+  *"api"*"repos/"*"issues/"*)
+    echo "[]" ;;
+  *"pr comment"*)
+    exit 0 ;;
+  *"pr checkout"*)
+    exit 0 ;;
+  *"issue comment"*)
+    exit 0 ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN_DIR/gh"
+
+  cd "$SCRIPT_DIR"
+}
+
+teardown() {
+  rm -f "$GITHUB_ENV" "$GITHUB_OUTPUT"
+  rm -rf "$STUB_BIN_DIR"
+}
+
+# ── dry-run tests ─────────────────────────────────────────────────────────────
+
+@test "fix-reviews: dry-run: no engine called" {
+  export INTENT_TYPE="fix-reviews"
+  export DEV_LEAD_DRY_RUN="true"
+  # Remove engine binaries to verify they're not called
+  rm -f "$STUB_BIN_DIR/claude"
+
+  run bash "$FIX_REVIEWS_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[dry-run]"* ]]
+}
+
+@test "fix-reviews: INTENT_TYPE=fix-reviews → runs fix-reviews" {
+  export INTENT_TYPE="fix-reviews"
+  export DEV_LEAD_DRY_RUN="true"
+
+  run bash "$FIX_REVIEWS_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[dry-run]"* ]]
+}
+
+@test "fix-reviews: INTENT_TYPE=human → runs human intent" {
+  export INTENT_TYPE="human"
+  export DEV_LEAD_DRY_RUN="true"
+  export USER_INSTRUCTION="Please fix the tests"
+  export PR_DESCRIPTION="Test PR"
+
+  run bash "$FIX_REVIEWS_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[dry-run]"* ]]
+}
+
+@test "fix-reviews: INTENT_TYPE=fix-bot-comment → runs fix-bot-comment" {
+  export INTENT_TYPE="fix-bot-comment"
+  export DEV_LEAD_DRY_RUN="true"
+  export COMMENT_BODY="SonarQube found issues"
+
+  run bash "$FIX_REVIEWS_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[dry-run]"* ]]
+}
+
+@test "fix-reviews: INTENT_TYPE=rebase dry-run → logs [dry-run]" {
+  export INTENT_TYPE="rebase"
+  export DEV_LEAD_DRY_RUN="true"
+
+  run bash "$FIX_REVIEWS_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[dry-run]"* ]]
+}
+
+@test "fix-reviews: unknown INTENT_TYPE → exits 1" {
+  export INTENT_TYPE="totally-unknown-intent"
+  export DEV_LEAD_DRY_RUN="true"
+
+  run bash "$FIX_REVIEWS_SCRIPT"
+
+  [ "$status" -eq 1 ]
+}
+
+@test "fix-reviews: fix-reviews in dry-run: outputs [dry-run] message" {
+  export INTENT_TYPE="fix-reviews"
+  export DEV_LEAD_DRY_RUN="true"
+
+  run bash "$FIX_REVIEWS_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[dry-run]"* ]]
+}
+
+@test "fix-reviews: human-pr in dry-run: outputs [dry-run] message" {
+  export INTENT_TYPE="human-pr"
+  export DEV_LEAD_DRY_RUN="true"
+  export PR_TITLE="Test PR"
+  export PR_DESCRIPTION="A test pull request"
+
+  run bash "$FIX_REVIEWS_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[dry-run]"* ]]
+}
+
+@test "fix-reviews: missing PR_NUMBER → exits 1 for non-rebase intents" {
+  export INTENT_TYPE="fix-reviews"
+  unset PR_NUMBER
+
+  run bash "$FIX_REVIEWS_SCRIPT"
+
+  [ "$status" -eq 1 ]
+}

--- a/tests/dev-lead/unit/test_intent_ci.bats
+++ b/tests/dev-lead/unit/test_intent_ci.bats
@@ -1,0 +1,142 @@
+#!/usr/bin/env bats
+# Unit tests for dev-lead-intent.sh — CI / repository_dispatch routing (Phase 2)
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+INTENT_SCRIPT="$SCRIPT_DIR/scripts/dev-lead-intent.sh"
+FIXTURES_DIR="$SCRIPT_DIR/tests/dev-lead/fixtures/events"
+
+setup() {
+  export GITHUB_ENV="$(mktemp)"
+  export GITHUB_OUTPUT="$(mktemp)"
+  export BOT_USER="donpetry-bot"
+  export TRUSTED_BOTS="copilot-pull-request-reviewer[bot],gemini-code-assist[bot],sonarqubecloud[bot],coderabbitai[bot]"
+  export TRIGGER_PHRASES="@dev-lead"
+  export GITHUB_REPOSITORY="petry-projects/.github-private"
+}
+
+teardown() {
+  rm -f "$GITHUB_ENV" "$GITHUB_OUTPUT"
+}
+
+_get_env() {
+  local key="$1"
+  grep "^${key}=" "$GITHUB_ENV" | cut -d= -f2- | head -1
+}
+
+_get_context_field() {
+  local field="$1"
+  local ctx
+  ctx=$(_get_env INTENT_CONTEXT)
+  echo "$ctx" | jq -r ".${field} // empty" 2>/dev/null || true
+}
+
+# ── repository_dispatch tests ────────────────────────────────────────────────
+
+@test "ci: repository_dispatch dev-lead-ci-failure → fix-ci" {
+  export GITHUB_EVENT_NAME="repository_dispatch"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/repository_dispatch_ci_failure.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "fix-ci" ]
+}
+
+@test "ci: context has pr_number from payload" {
+  export GITHUB_EVENT_NAME="repository_dispatch"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/repository_dispatch_ci_failure.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_context_field pr_number)" = "42" ]
+}
+
+@test "ci: context has checks array" {
+  export GITHUB_EVENT_NAME="repository_dispatch"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/repository_dispatch_ci_failure.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  local ctx
+  ctx=$(_get_env INTENT_CONTEXT)
+  # checks should be a non-empty JSON array
+  result=$(echo "$ctx" | jq -r '.checks | length' 2>/dev/null || echo "0")
+  [ "$result" -gt 0 ]
+}
+
+@test "ci: unknown repository_dispatch type → skip" {
+  local tmp_event
+  tmp_event=$(mktemp --suffix=.json)
+  cat > "$tmp_event" <<'EOF'
+{
+  "action": "some-other-type",
+  "client_payload": { "foo": "bar" }
+}
+EOF
+  export GITHUB_EVENT_NAME="repository_dispatch"
+  export GITHUB_EVENT_PATH="$tmp_event"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "skip" ]
+  rm -f "$tmp_event"
+}
+
+@test "ci: repository_dispatch with no pr_number → skip" {
+  local tmp_event
+  tmp_event=$(mktemp --suffix=.json)
+  cat > "$tmp_event" <<'EOF'
+{
+  "action": "dev-lead-ci-failure",
+  "client_payload": {
+    "head_sha": "abc123",
+    "checks": []
+  }
+}
+EOF
+  export GITHUB_EVENT_NAME="repository_dispatch"
+  export GITHUB_EVENT_PATH="$tmp_event"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "skip" ]
+  rm -f "$tmp_event"
+}
+
+# ── pull_request_review tests ────────────────────────────────────────────────
+
+@test "ci: pull_request review from copilot COMMENTED → fix-reviews" {
+  export GITHUB_EVENT_NAME="pull_request_review"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/pr_review_copilot_commented.json"
+  export TRUSTED_BOTS="copilot-pull-request-reviewer[bot],gemini-code-assist[bot],sonarqubecloud[bot],coderabbitai[bot]"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "fix-reviews" ]
+}
+
+@test "ci: pull_request review from copilot APPROVED → skip" {
+  export GITHUB_EVENT_NAME="pull_request_review"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/pr_review_copilot_approved.json"
+  export TRUSTED_BOTS="copilot-pull-request-reviewer[bot],gemini-code-assist[bot],sonarqubecloud[bot],coderabbitai[bot]"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "skip" ]
+}
+
+@test "ci: issues labeled dev-lead → issue" {
+  export GITHUB_EVENT_NAME="issues"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/issues_labeled_dev_lead.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "issue" ]
+}

--- a/tests/dev-lead/unit/test_intent_issue.bats
+++ b/tests/dev-lead/unit/test_intent_issue.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+# Unit tests for dev-lead-intent.sh — issue routing (Phase 5)
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+INTENT_SCRIPT="$SCRIPT_DIR/scripts/dev-lead-intent.sh"
+FIXTURES_DIR="$SCRIPT_DIR/tests/dev-lead/fixtures/events"
+
+setup() {
+  export GITHUB_ENV="$(mktemp)"
+  export GITHUB_OUTPUT="$(mktemp)"
+  export BOT_USER="donpetry-bot"
+  export TRUSTED_BOTS="copilot-pull-request-reviewer[bot],gemini-code-assist[bot],sonarqubecloud[bot],coderabbitai[bot]"
+  export TRIGGER_PHRASES="@dev-lead"
+  export GITHUB_REPOSITORY="petry-projects/.github-private"
+}
+
+teardown() {
+  rm -f "$GITHUB_ENV" "$GITHUB_OUTPUT"
+}
+
+_get_env() {
+  local key="$1"
+  grep "^${key}=" "$GITHUB_ENV" | cut -d= -f2- | head -1
+}
+
+_get_context_field() {
+  local field="$1"
+  local ctx
+  ctx=$(_get_env INTENT_CONTEXT)
+  echo "$ctx" | jq -r ".${field} // empty" 2>/dev/null || true
+}
+
+# ── issue tests ───────────────────────────────────────────────────────────────
+
+@test "issue: issues labeled dev-lead → issue" {
+  export GITHUB_EVENT_NAME="issues"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/issues_labeled_dev_lead.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "issue" ]
+}
+
+@test "issue: issues labeled claude → issue (backward compat)" {
+  export GITHUB_EVENT_NAME="issues"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/issues_labeled_claude.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "issue" ]
+}
+
+@test "issue: issues labeled bug → skip" {
+  export GITHUB_EVENT_NAME="issues"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/issues_labeled_other.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "skip" ]
+}
+
+@test "issue: issues labeled dev-lead without body → issue with empty context" {
+  local tmp_event
+  tmp_event=$(mktemp --suffix=.json)
+  cat > "$tmp_event" <<'EOF'
+{
+  "action": "labeled",
+  "issue": {
+    "number": 200,
+    "title": "New feature request",
+    "body": null,
+    "state": "open",
+    "author_association": "OWNER",
+    "labels": [{ "name": "dev-lead" }]
+  },
+  "label": { "name": "dev-lead" },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "donpetry", "type": "User" }
+}
+EOF
+  export GITHUB_EVENT_NAME="issues"
+  export GITHUB_EVENT_PATH="$tmp_event"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "issue" ]
+  # issue_number should be set in context
+  [ "$(_get_context_field issue_number)" = "200" ]
+  rm -f "$tmp_event"
+}

--- a/tests/dev-lead/unit/test_intent_reviews.bats
+++ b/tests/dev-lead/unit/test_intent_reviews.bats
@@ -1,0 +1,245 @@
+#!/usr/bin/env bats
+# Unit tests for dev-lead-intent.sh — review-related routing (Phase 3)
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+INTENT_SCRIPT="$SCRIPT_DIR/scripts/dev-lead-intent.sh"
+FIXTURES_DIR="$SCRIPT_DIR/tests/dev-lead/fixtures/events"
+
+setup() {
+  export GITHUB_ENV="$(mktemp)"
+  export GITHUB_OUTPUT="$(mktemp)"
+  export BOT_USER="donpetry-bot"
+  export TRUSTED_BOTS="copilot-pull-request-reviewer[bot],gemini-code-assist[bot],sonarqubecloud[bot],coderabbitai[bot]"
+  export TRIGGER_PHRASES="@dev-lead"
+  export GITHUB_REPOSITORY="petry-projects/.github-private"
+}
+
+teardown() {
+  rm -f "$GITHUB_ENV" "$GITHUB_OUTPUT"
+}
+
+_get_env() {
+  local key="$1"
+  grep "^${key}=" "$GITHUB_ENV" | cut -d= -f2- | head -1
+}
+
+# ── pull_request_review tests ────────────────────────────────────────────────
+
+@test "reviews: pull_request_review copilot COMMENTED → fix-reviews" {
+  export GITHUB_EVENT_NAME="pull_request_review"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/pr_review_copilot_commented.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "fix-reviews" ]
+}
+
+@test "reviews: pull_request_review copilot APPROVED → skip" {
+  export GITHUB_EVENT_NAME="pull_request_review"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/pr_review_copilot_approved.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "skip" ]
+}
+
+@test "reviews: pull_request_review gemini CHANGES_REQUESTED → fix-reviews" {
+  export GITHUB_EVENT_NAME="pull_request_review"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/pr_review_gemini_changes.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "fix-reviews" ]
+}
+
+@test "reviews: pull_request_review human OWNER → human-pr" {
+  export GITHUB_EVENT_NAME="pull_request_review"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/pr_review_human_owner.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "human-pr" ]
+}
+
+@test "reviews: pull_request_review human NONE → skip" {
+  local tmp_event
+  tmp_event=$(mktemp --suffix=.json)
+  cat > "$tmp_event" <<'EOF'
+{
+  "action": "submitted",
+  "review": {
+    "id": 999,
+    "state": "CHANGES_REQUESTED",
+    "body": "Please fix this.",
+    "user": { "login": "external-user", "type": "User" }
+  },
+  "pull_request": {
+    "number": 10,
+    "author_association": "NONE",
+    "head": { "sha": "abc", "repo": { "full_name": "petry-projects/.github-private" } }
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "external-user", "type": "User" }
+}
+EOF
+  export GITHUB_EVENT_NAME="pull_request_review"
+  export GITHUB_EVENT_PATH="$tmp_event"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "skip" ]
+  rm -f "$tmp_event"
+}
+
+@test "reviews: pull_request_review fork PR → skip" {
+  export GITHUB_EVENT_NAME="pull_request_review"
+  # Create a review event for a fork PR
+  local tmp_event
+  tmp_event=$(mktemp --suffix=.json)
+  cat > "$tmp_event" <<'EOF'
+{
+  "action": "submitted",
+  "review": {
+    "id": 998,
+    "state": "COMMENTED",
+    "body": "Looks good.",
+    "user": { "login": "copilot-pull-request-reviewer[bot]", "type": "Bot" }
+  },
+  "pull_request": {
+    "number": 11,
+    "author_association": "OWNER",
+    "head": { "sha": "def", "repo": { "full_name": "fork-user/.github-private" } },
+    "base": { "repo": { "full_name": "petry-projects/.github-private" } }
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "copilot-pull-request-reviewer[bot]", "type": "Bot" }
+}
+EOF
+  export GITHUB_EVENT_PATH="$tmp_event"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "skip" ]
+  rm -f "$tmp_event"
+}
+
+@test "reviews: pull_request_review self-actor → skip" {
+  local tmp_event
+  tmp_event=$(mktemp --suffix=.json)
+  cat > "$tmp_event" <<'EOF'
+{
+  "action": "submitted",
+  "review": {
+    "id": 997,
+    "state": "APPROVED",
+    "body": "Self-approval",
+    "user": { "login": "donpetry-bot", "type": "Bot" }
+  },
+  "pull_request": {
+    "number": 12,
+    "author_association": "OWNER",
+    "head": { "sha": "ghi", "repo": { "full_name": "petry-projects/.github-private" } }
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "donpetry-bot", "type": "Bot" }
+}
+EOF
+  export GITHUB_EVENT_NAME="pull_request_review"
+  export GITHUB_EVENT_PATH="$tmp_event"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "skip" ]
+  rm -f "$tmp_event"
+}
+
+# ── pull_request_review_comment tests ────────────────────────────────────────
+
+@test "reviews: pull_request_review_comment copilot → fix-reviews" {
+  export GITHUB_EVENT_NAME="pull_request_review_comment"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/pr_review_comment_copilot.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "fix-reviews" ]
+}
+
+@test "reviews: pull_request_review_comment human + @dev-lead → human" {
+  export GITHUB_EVENT_NAME="pull_request_review_comment"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/pr_review_comment_human_trigger.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "human" ]
+}
+
+@test "reviews: pull_request_review_comment human no trigger → skip" {
+  export GITHUB_EVENT_NAME="pull_request_review_comment"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/pr_review_comment_human_no_trigger.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "skip" ]
+}
+
+# ── issue_comment tests ───────────────────────────────────────────────────────
+
+@test "reviews: issue_comment sonarqube on PR → fix-bot-comment" {
+  export GITHUB_EVENT_NAME="issue_comment"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/issue_comment_sonarqube.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "fix-bot-comment" ]
+}
+
+@test "reviews: issue_comment coderabbit on PR → fix-bot-comment" {
+  export GITHUB_EVENT_NAME="issue_comment"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/issue_comment_coderabbit.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "fix-bot-comment" ]
+}
+
+@test "reviews: issue_comment human + @dev-lead → human" {
+  export GITHUB_EVENT_NAME="issue_comment"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/issue_comment_human_trigger.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "human" ]
+}
+
+@test "reviews: issue_comment human no trigger → skip" {
+  export GITHUB_EVENT_NAME="issue_comment"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/issue_comment_human_no_trigger.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "skip" ]
+}
+
+@test "reviews: issue_comment rebase sentinel → rebase" {
+  export GITHUB_EVENT_NAME="issue_comment"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/issue_comment_rebase_sentinel.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "rebase" ]
+}

--- a/tests/dev-lead/unit/test_intent_stub.bats
+++ b/tests/dev-lead/unit/test_intent_stub.bats
@@ -50,14 +50,15 @@ _get_output() {
   [ "$(_get_env INTENT_REASON)" = "not-implemented" ]
 }
 
-@test "stub: pull_request opened emits skip (not-implemented in Phase 1)" {
+@test "routing: pull_request opened by human emits human-pr" {
   export GITHUB_EVENT_NAME="pull_request"
   export GITHUB_EVENT_PATH="$FIXTURES_DIR/pr_opened_human.json"
+  export GITHUB_REPOSITORY="petry-projects/.github-private"
 
   run bash "$INTENT_SCRIPT"
 
   [ "$status" -eq 0 ]
-  [ "$(_get_env INTENT_TYPE)" = "skip" ]
+  [ "$(_get_env INTENT_TYPE)" = "human-pr" ]
 }
 
 @test "anti-loop: pull_request synchronize from BOT_USER emits skip" {
@@ -72,17 +73,17 @@ _get_output() {
   [ "$(_get_env INTENT_REASON)" = "dev-lead-own-commit" ]
 }
 
-@test "anti-loop: pull_request synchronize from different user does not trigger anti-loop skip with not-implemented" {
-  # A sync from a human should still be skip in Phase 1 (not-implemented)
-  # but should NOT have reason dev-lead-own-commit
+@test "anti-loop: pull_request opened by human does not trigger anti-loop skip" {
+  # A PR opened by a human should NOT have reason dev-lead-own-commit
   export GITHUB_EVENT_NAME="pull_request"
   export GITHUB_EVENT_PATH="$FIXTURES_DIR/pr_opened_human.json"
   export BOT_USER="donpetry-bot"
+  export GITHUB_REPOSITORY="petry-projects/.github-private"
 
   run bash "$INTENT_SCRIPT"
 
   [ "$status" -eq 0 ]
-  [ "$(_get_env INTENT_TYPE)" = "skip" ]
+  # Should not be skipped due to anti-loop
   [ "$(_get_env INTENT_REASON)" != "dev-lead-own-commit" ]
 }
 
@@ -97,34 +98,39 @@ _get_output() {
   [ "$(_get_env INTENT_REASON)" = "check-run-handled-by-ci-relay" ]
 }
 
-@test "issue_comment event emits skip (not-implemented in Phase 1)" {
+@test "issue_comment human trigger event emits human intent" {
   export GITHUB_EVENT_NAME="issue_comment"
   export GITHUB_EVENT_PATH="$FIXTURES_DIR/issue_comment_human_trigger.json"
+  export TRUSTED_BOTS="copilot-pull-request-reviewer[bot],gemini-code-assist[bot],sonarqubecloud[bot],coderabbitai[bot]"
+  export TRIGGER_PHRASES="@dev-lead"
+  export GITHUB_REPOSITORY="petry-projects/.github-private"
 
   run bash "$INTENT_SCRIPT"
 
   [ "$status" -eq 0 ]
-  [ "$(_get_env INTENT_TYPE)" = "skip" ]
+  [ "$(_get_env INTENT_TYPE)" = "human" ]
 }
 
-@test "issues labeled event emits skip (not-implemented in Phase 1)" {
+@test "issues labeled dev-lead event emits issue intent" {
   export GITHUB_EVENT_NAME="issues"
   export GITHUB_EVENT_PATH="$FIXTURES_DIR/issues_labeled_dev_lead.json"
+  export GITHUB_REPOSITORY="petry-projects/.github-private"
 
   run bash "$INTENT_SCRIPT"
 
   [ "$status" -eq 0 ]
-  [ "$(_get_env INTENT_TYPE)" = "skip" ]
+  [ "$(_get_env INTENT_TYPE)" = "issue" ]
 }
 
-@test "repository_dispatch event emits skip (not-implemented in Phase 1)" {
+@test "repository_dispatch ci-failure event emits fix-ci intent" {
   export GITHUB_EVENT_NAME="repository_dispatch"
   export GITHUB_EVENT_PATH="$FIXTURES_DIR/repository_dispatch_ci_failure.json"
+  export GITHUB_REPOSITORY="petry-projects/.github-private"
 
   run bash "$INTENT_SCRIPT"
 
   [ "$status" -eq 0 ]
-  [ "$(_get_env INTENT_TYPE)" = "skip" ]
+  [ "$(_get_env INTENT_TYPE)" = "fix-ci" ]
 }
 
 @test "INTENT_TYPE is written to both GITHUB_ENV and GITHUB_OUTPUT" {

--- a/tests/dev-lead/unit/test_intent_stub.bats
+++ b/tests/dev-lead/unit/test_intent_stub.bats
@@ -1,0 +1,173 @@
+#!/usr/bin/env bats
+# Unit tests for dev-lead-intent.sh (Phase 1 stub)
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+INTENT_SCRIPT="$SCRIPT_DIR/scripts/dev-lead-intent.sh"
+FIXTURES_DIR="$SCRIPT_DIR/tests/dev-lead/fixtures/events"
+
+setup() {
+  # Create a temp GITHUB_ENV and GITHUB_OUTPUT file for each test
+  export GITHUB_ENV="$(mktemp)"
+  export GITHUB_OUTPUT="$(mktemp)"
+  export BOT_USER="donpetry-bot"
+}
+
+teardown() {
+  rm -f "$GITHUB_ENV" "$GITHUB_OUTPUT"
+}
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+_get_env() {
+  local key="$1"
+  grep "^${key}=" "$GITHUB_ENV" | cut -d= -f2- | head -1
+}
+
+_get_output() {
+  local key="$1"
+  grep "^${key}=" "$GITHUB_OUTPUT" | cut -d= -f2- | head -1
+}
+
+# ── tests ────────────────────────────────────────────────────────────────────
+
+@test "stub: unknown event emits skip" {
+  export GITHUB_EVENT_NAME="push"
+  export GITHUB_EVENT_PATH="/dev/null"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "skip" ]
+}
+
+@test "stub: unknown event reason is not-implemented" {
+  export GITHUB_EVENT_NAME="workflow_dispatch"
+  export GITHUB_EVENT_PATH="/dev/null"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_REASON)" = "not-implemented" ]
+}
+
+@test "stub: pull_request opened emits skip (not-implemented in Phase 1)" {
+  export GITHUB_EVENT_NAME="pull_request"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/pr_opened_human.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "skip" ]
+}
+
+@test "anti-loop: pull_request synchronize from BOT_USER emits skip" {
+  export GITHUB_EVENT_NAME="pull_request"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/pr_sync_dev_lead_commit.json"
+  export BOT_USER="donpetry-bot"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "skip" ]
+  [ "$(_get_env INTENT_REASON)" = "dev-lead-own-commit" ]
+}
+
+@test "anti-loop: pull_request synchronize from different user does not trigger anti-loop skip with not-implemented" {
+  # A sync from a human should still be skip in Phase 1 (not-implemented)
+  # but should NOT have reason dev-lead-own-commit
+  export GITHUB_EVENT_NAME="pull_request"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/pr_opened_human.json"
+  export BOT_USER="donpetry-bot"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "skip" ]
+  [ "$(_get_env INTENT_REASON)" != "dev-lead-own-commit" ]
+}
+
+@test "check_run event emits skip with check-run-handled-by-ci-relay" {
+  export GITHUB_EVENT_NAME="check_run"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/check_run_failure.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "skip" ]
+  [ "$(_get_env INTENT_REASON)" = "check-run-handled-by-ci-relay" ]
+}
+
+@test "issue_comment event emits skip (not-implemented in Phase 1)" {
+  export GITHUB_EVENT_NAME="issue_comment"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/issue_comment_human_trigger.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "skip" ]
+}
+
+@test "issues labeled event emits skip (not-implemented in Phase 1)" {
+  export GITHUB_EVENT_NAME="issues"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/issues_labeled_dev_lead.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "skip" ]
+}
+
+@test "repository_dispatch event emits skip (not-implemented in Phase 1)" {
+  export GITHUB_EVENT_NAME="repository_dispatch"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/repository_dispatch_ci_failure.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "skip" ]
+}
+
+@test "INTENT_TYPE is written to both GITHUB_ENV and GITHUB_OUTPUT" {
+  export GITHUB_EVENT_NAME="push"
+  export GITHUB_EVENT_PATH="/dev/null"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "skip" ]
+  [ "$(_get_output intent_type)" = "skip" ]
+}
+
+@test "missing GITHUB_EVENT_NAME exits 1" {
+  unset GITHUB_EVENT_NAME || true
+  export GITHUB_EVENT_PATH="/dev/null"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -ne 0 ]
+}
+
+@test "pre-flight: missing CLAUDE_CODE_OAUTH_TOKEN exits 1" {
+  unset CLAUDE_CODE_OAUTH_TOKEN || true
+
+  run bash "$SCRIPT_DIR/scripts/dev-lead-preflight.sh"
+
+  [ "$status" -eq 1 ]
+}
+
+@test "pre-flight: with CLAUDE_CODE_OAUTH_TOKEN set exits 0" {
+  export CLAUDE_CODE_OAUTH_TOKEN="test-token-value"
+
+  run bash "$SCRIPT_DIR/scripts/dev-lead-preflight.sh"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "dry-run: DEV_LEAD_DRY_RUN=true is logged by preflight" {
+  export CLAUDE_CODE_OAUTH_TOKEN="test-token-value"
+  export DEV_LEAD_DRY_RUN="true"
+
+  run bash "$SCRIPT_DIR/scripts/dev-lead-preflight.sh"
+
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- **Phase 0 — Test infrastructure**: 26 event fixtures (all valid JSON with `_test_expected_intent`), stub claude/gemini engines, mock `gh` binary, sample CI failure log (239 lines), 4 bats helpers, 7 prompt templates with `<!-- VARIABLES: -->` declarations, pre-flight secret-check script, prompt-coverage integration test, and `test-dev-lead.yml` CI workflow
- **Phase 1 — Scaffold**: `dev-lead.yml` workflow (all 7 trigger event types, `dispatch` + `ci-relay` jobs, SHA-pinned actions) and `dev-lead-intent.sh` stub (anti-loop guard live from day 1; all other events emit `skip/not-implemented`)
- **Tests**: 14/14 bats unit tests pass locally; prompt coverage integration test passes for all 7 prompts

## Test plan

- [ ] Validate event fixtures: `find tests/dev-lead/fixtures/events -name '*.json' -exec jq empty {} \;`
- [ ] Run prompt coverage test: `bash tests/dev-lead/integration/test_prompt_coverage.sh`
- [ ] Run bats unit tests: `bats tests/dev-lead/unit/ --formatter tap`
- [ ] Verify pre-flight fails without `CLAUDE_CODE_OAUTH_TOKEN`: `unset CLAUDE_CODE_OAUTH_TOKEN; bash scripts/dev-lead-preflight.sh; echo $?` (should be 1)
- [ ] Check anti-loop guard: set `BOT_USER=donpetry-bot` and run with `pr_sync_dev_lead_commit.json` — should emit `skip/dev-lead-own-commit`
- [ ] Confirm `test-dev-lead.yml` and `dev-lead.yml` workflows appear in Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)