### PR TITLE
feat(dev-lead): add reusable workflow (Phase 1.5) + shadow period (Phase 7)

### DIFF
--- a/.github/workflows/dev-lead-reusable.yml
+++ b/.github/workflows/dev-lead-reusable.yml
@@ -63,13 +63,15 @@ jobs:
           repository: petry-projects/.github-private
           ref: main
           path: .dev-lead
-          # GH_PAT_WORKFLOWS must have read access to petry-projects/.github-private.
           # Cross-repo callers: github.token cannot read a private org repo — ensure
           # GH_PAT_WORKFLOWS is set as an org or repo secret in the calling repo.
           token: ${{ secrets.GH_PAT_WORKFLOWS || github.token }}
           sparse-checkout: |
             scripts
             prompts/dev-lead
+
+      - name: Protect dev-lead scripts from accidental git staging
+        run: echo ".dev-lead/" >> .gitignore
 
       - name: Classify event intent
         id: intent
@@ -231,3 +233,68 @@ jobs:
           COPILOT_GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           PROMPTS_DIR: .dev-lead/prompts/dev-lead
         run: bash .dev-lead/scripts/dev-lead-fix-reviews.sh
+
+  # ── ci-relay ──────────────────────────────────────────────────────────────────
+  # Handles check_run completed failure events. No LLM — resolves PR number and
+  # fires repository_dispatch dev-lead-ci-failure back to the calling repo.
+  ci-relay:
+    if: >-
+      github.event_name == 'check_run' &&
+      github.event.action == 'completed' &&
+      github.event.check_run.conclusion == 'failure' &&
+      !startsWith(github.event.check_run.name, 'dev-lead / ')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check for associated non-fork PR
+        id: check-pr
+        env:
+          CHECK_RUN_PRS: ${{ toJson(github.event.check_run.pull_requests) }}
+          REPO_FULL_NAME: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          pr_count=$(echo "$CHECK_RUN_PRS" | jq 'length')
+          if [ "$pr_count" -eq 0 ]; then
+            echo "::notice::check_run has no associated PRs — skipping relay"
+            echo "should_relay=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          head_repo_url=$(echo "$CHECK_RUN_PRS" | jq -r '.[0].head.repo.url // empty')
+          expected_url="https://api.github.com/repos/${REPO_FULL_NAME}"
+          if [ -n "$head_repo_url" ] && [ "$head_repo_url" != "$expected_url" ]; then
+            echo "::notice::check_run is from a fork — skipping relay"
+            echo "should_relay=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          pr_number=$(echo "$CHECK_RUN_PRS" | jq -r '.[0].number')
+          echo "should_relay=true" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+
+      - name: Emit repository_dispatch dev-lead-ci-failure
+        if: steps.check-pr.outputs.should_relay == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS || github.token }}
+          RELAY_PR_NUMBER: ${{ steps.check-pr.outputs.pr_number }}
+          RELAY_HEAD_SHA: ${{ github.event.check_run.head_sha }}
+          RELAY_REPO: ${{ github.repository }}
+          RELAY_CHECK_NAME: ${{ github.event.check_run.name }}
+          RELAY_CONCLUSION: ${{ github.event.check_run.conclusion }}
+          RELAY_DETAILS_URL: ${{ github.event.check_run.details_url }}
+          RELAY_APP_SLUG: ${{ github.event.check_run.app.slug }}
+        run: |
+          set -euo pipefail
+          payload=$(jq -n \
+            --argjson pr_number "$RELAY_PR_NUMBER" \
+            --arg head_sha "$RELAY_HEAD_SHA" \
+            --arg repo "$RELAY_REPO" \
+            --arg name "$RELAY_CHECK_NAME" \
+            --arg conclusion "$RELAY_CONCLUSION" \
+            --arg details_url "$RELAY_DETAILS_URL" \
+            --arg app_slug "$RELAY_APP_SLUG" \
+            '{event_type:"dev-lead-ci-failure",client_payload:{pr_number:$pr_number,head_sha:$head_sha,repo:$repo,checks:[{name:$name,conclusion:$conclusion,details_url:$details_url,app_slug:$app_slug}]}}')
+          echo "$payload" | gh api \
+            --method POST "repos/$RELAY_REPO/dispatches" --input -
+          echo "::notice::Relayed CI failure for PR $RELAY_PR_NUMBER"

--- a/.github/workflows/dev-lead-reusable.yml
+++ b/.github/workflows/dev-lead-reusable.yml
@@ -1,0 +1,226 @@
+name: Dev-Lead Agent (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      event_name:
+        description: "GitHub event name (passed by caller for ci-relay routing)"
+        type: string
+        required: false
+        default: ""
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        required: true
+      GH_PAT_WORKFLOWS:
+        required: false
+      GOOGLE_API_KEY:
+        required: false
+      GH_PAT:
+        required: false
+
+permissions: {}
+
+jobs:
+  # ── dispatch ────────────────────────────────────────────────────────────────
+  # Handles all events except check_run (which is routed by the caller).
+  # 1. Checks out .github-private scripts/prompts into .dev-lead/
+  # 2. Runs dev-lead-intent.sh to classify the event into an intent.
+  # 3. Routes to the appropriate handler based on intent.
+  dispatch:
+    if: >-
+      (inputs.event_name == '' && github.event_name != 'check_run') ||
+      (inputs.event_name != '' && inputs.event_name != 'check_run')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+      checks: read
+    env:
+      BOT_USER: ${{ vars.BOT_USER || 'donpetry-bot' }}
+      TRUSTED_BOTS: ${{ vars.TRUSTED_BOTS || 'copilot-pull-request-reviewer[bot],gemini-code-assist[bot],sonarqubecloud[bot],coderabbitai[bot]' }}
+      TRIGGER_PHRASES: ${{ vars.TRIGGER_PHRASES || '@dev-lead' }}
+      DEV_LEAD_ENGINE: ${{ vars.DEV_LEAD_ENGINE || 'claude' }}
+      DEV_LEAD_DRY_RUN: ${{ vars.DEV_LEAD_DRY_RUN || 'false' }}
+      GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS || github.token }}
+      DEV_LEAD_SCRIPTS: .dev-lead/scripts
+      DEV_LEAD_PROMPTS: .dev-lead/prompts/dev-lead
+
+    steps:
+      - name: Checkout caller repo
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          token: ${{ secrets.GH_PAT_WORKFLOWS || github.token }}
+
+      - name: Checkout dev-lead scripts
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: petry-projects/.github-private
+          path: .dev-lead
+          token: ${{ secrets.GH_PAT_WORKFLOWS || github.token }}
+          sparse-checkout: |
+            scripts
+            prompts/dev-lead
+
+      - name: Classify event intent
+        id: intent
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+        run: bash .dev-lead/scripts/dev-lead-intent.sh
+
+      - name: Log intent
+        run: |
+          echo "::notice::intent=$INTENT_TYPE reason=$INTENT_REASON"
+
+      - name: Skip — log reason
+        if: env.INTENT_TYPE == 'skip'
+        run: |
+          echo "::notice::Skipping event: $INTENT_REASON"
+
+      - name: Pre-flight checks
+        if: env.INTENT_TYPE != 'skip'
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GH_PAT_WORKFLOWS: ${{ secrets.GH_PAT_WORKFLOWS }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: bash .dev-lead/scripts/dev-lead-preflight.sh
+
+      # ── Install engine CLIs ───────────────────────────────────────────────
+      - name: Cache claude-code CLI
+        if: env.INTENT_TYPE != 'skip'
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.npm-global
+          key: claude-code-${{ vars.CLAUDE_CODE_VERSION || 'latest' }}-${{ runner.os }}
+
+      - name: Install engine CLIs
+        if: env.INTENT_TYPE != 'skip'
+        env:
+          CLAUDE_CODE_VERSION: ${{ vars.CLAUDE_CODE_VERSION || 'latest' }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.npm-global"
+          npm config set prefix "$HOME/.npm-global"
+          echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.npm-global/bin:$PATH"
+
+          if ! command -v claude >/dev/null 2>&1; then
+            npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
+          fi
+
+          case "$DEV_LEAD_ENGINE" in
+            gemini)
+              npm install -g @google/gemini-cli || true ;;
+            copilot)
+              if ! gh copilot --version >/dev/null 2>&1; then
+                gh extension install github/gh-copilot || true
+              fi ;;
+          esac
+
+      # ── fix-ci ────────────────────────────────────────────────────────────
+      - name: Run fix-ci
+        if: env.INTENT_TYPE == 'fix-ci'
+        env:
+          PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
+          HEAD_SHA: ${{ fromJson(env.INTENT_CONTEXT).head_sha }}
+          CHECKS_JSON: ${{ toJson(fromJson(env.INTENT_CONTEXT).checks) }}
+          REPO: ${{ github.repository }}
+          REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          PROMPTS_DIR: .dev-lead/prompts/dev-lead
+        run: bash .dev-lead/scripts/dev-lead-fix-ci.sh
+
+      # ── fix-reviews ───────────────────────────────────────────────────────
+      - name: Run fix-reviews
+        if: env.INTENT_TYPE == 'fix-reviews'
+        env:
+          INTENT_TYPE: fix-reviews
+          PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
+          HEAD_SHA: ${{ fromJson(env.INTENT_CONTEXT).head_sha }}
+          REPO: ${{ github.repository }}
+          REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          PROMPTS_DIR: .dev-lead/prompts/dev-lead
+        run: bash .dev-lead/scripts/dev-lead-fix-reviews.sh
+
+      # ── fix-bot-comment ───────────────────────────────────────────────────
+      - name: Run fix-bot-comment
+        if: env.INTENT_TYPE == 'fix-bot-comment'
+        env:
+          INTENT_TYPE: fix-bot-comment
+          PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
+          HEAD_SHA: ${{ fromJson(env.INTENT_CONTEXT).head_sha }}
+          REPO: ${{ github.repository }}
+          REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          PROMPTS_DIR: .dev-lead/prompts/dev-lead
+        run: bash .dev-lead/scripts/dev-lead-fix-reviews.sh
+
+      # ── human ─────────────────────────────────────────────────────────────
+      - name: Run human
+        if: env.INTENT_TYPE == 'human'
+        env:
+          INTENT_TYPE: human
+          PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
+          HEAD_SHA: ${{ fromJson(env.INTENT_CONTEXT).head_sha }}
+          REPO: ${{ github.repository }}
+          REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          PROMPTS_DIR: .dev-lead/prompts/dev-lead
+        run: bash .dev-lead/scripts/dev-lead-fix-reviews.sh
+
+      # ── human-pr ──────────────────────────────────────────────────────────
+      - name: Run human-pr
+        if: env.INTENT_TYPE == 'human-pr'
+        env:
+          INTENT_TYPE: human-pr
+          PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
+          HEAD_SHA: ${{ fromJson(env.INTENT_CONTEXT).head_sha }}
+          REPO: ${{ github.repository }}
+          REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          PROMPTS_DIR: .dev-lead/prompts/dev-lead
+        run: bash .dev-lead/scripts/dev-lead-fix-reviews.sh
+
+      # ── issue ─────────────────────────────────────────────────────────────
+      - name: Run issue
+        if: env.INTENT_TYPE == 'issue'
+        env:
+          ISSUE_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).issue_number }}
+          REPO: ${{ github.repository }}
+          REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          PROMPTS_DIR: .dev-lead/prompts/dev-lead
+        run: bash .dev-lead/scripts/dev-lead-fix-issue.sh
+
+      # ── rebase ────────────────────────────────────────────────────────────
+      - name: Run rebase
+        if: env.INTENT_TYPE == 'rebase'
+        env:
+          INTENT_TYPE: rebase
+          PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
+          REPO: ${{ github.repository }}
+          REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          PROMPTS_DIR: .dev-lead/prompts/dev-lead
+        run: bash .dev-lead/scripts/dev-lead-fix-reviews.sh

--- a/.github/workflows/dev-lead-reusable.yml
+++ b/.github/workflows/dev-lead-reusable.yml
@@ -12,6 +12,9 @@ on:
       CLAUDE_CODE_OAUTH_TOKEN:
         required: true
       GH_PAT_WORKFLOWS:
+        # Required for cross-repo callers: the default github.token cannot read
+        # petry-projects/.github-private from another repo. Callers must pass a
+        # PAT that has read access to petry-projects/.github-private.
         required: false
       GOOGLE_API_KEY:
         required: false
@@ -58,7 +61,11 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: petry-projects/.github-private
+          ref: main
           path: .dev-lead
+          # GH_PAT_WORKFLOWS must have read access to petry-projects/.github-private.
+          # Cross-repo callers: github.token cannot read a private org repo — ensure
+          # GH_PAT_WORKFLOWS is set as an org or repo secret in the calling repo.
           token: ${{ secrets.GH_PAT_WORKFLOWS || github.token }}
           sparse-checkout: |
             scripts

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -1,11 +1,6 @@
-# ─────────────────────────────────────────────────────────────────────────────
-# Phase 7 — Shadow Period (started 2026-05-15)
-# Both claude.yml and dev-lead.yml run in parallel on .github-private PRs for
-# a 2-week observation window ending ~2026-05-29.
-# Tracking issue: petry-projects/.github-private#180
-# After the window passes without regressions, claude.yml will be removed.
-# ─────────────────────────────────────────────────────────────────────────────
 name: Dev-Lead Agent
+# Phase 7 shadow period: dev-lead.yml and claude.yml run in parallel until ~2026-05-29.
+# Tracking: petry-projects/.github-private#180
 
 on:
   pull_request:

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -2,7 +2,7 @@
 # Phase 7 — Shadow Period (started 2026-05-15)
 # Both claude.yml and dev-lead.yml run in parallel on .github-private PRs for
 # a 2-week observation window ending ~2026-05-29.
-# Tracking issue: petry-projects/.github-private#<shadow-period-issue>
+# Tracking issue: petry-projects/.github-private#180
 # After the window passes without regressions, claude.yml will be removed.
 # ─────────────────────────────────────────────────────────────────────────────
 name: Dev-Lead Agent

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -1,3 +1,10 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 7 — Shadow Period (started 2026-05-15)
+# Both claude.yml and dev-lead.yml run in parallel on .github-private PRs for
+# a 2-week observation window ending ~2026-05-29.
+# Tracking issue: petry-projects/.github-private#<shadow-period-issue>
+# After the window passes without regressions, claude.yml will be removed.
+# ─────────────────────────────────────────────────────────────────────────────
 name: Dev-Lead Agent
 
 on:

--- a/scripts/dev-lead-fix-ci.sh
+++ b/scripts/dev-lead-fix-ci.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 # Called when a CI check fails on a PR.
 # Env: PR_NUMBER, HEAD_SHA, CHECKS_JSON, REPO, GITHUB_REPOSITORY,
 #      DEV_LEAD_DRY_RUN, REVIEW_ENGINE, GH_TOKEN
+# Optional: PROMPTS_DIR (defaults to prompts/dev-lead relative to CWD)
 
 source "$(dirname "$0")/engine.sh"
 
@@ -14,6 +15,7 @@ REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
 MAX_CI_CYCLES="${MAX_CI_CYCLES:-3}"
 LOG_MAX_LINES="${LOG_MAX_LINES:-200}"
 MARKER_PREFIX="<!-- dev-lead-fix-ci sha="
+PROMPTS_DIR="${PROMPTS_DIR:-prompts/dev-lead}"
 
 check_idempotency() {
   local existing
@@ -35,7 +37,7 @@ collect_logs() {
 }
 
 build_prompt() {
-  local prompt_template="prompts/dev-lead/fix-ci.md"
+  local prompt_template="${PROMPTS_DIR}/fix-ci.md"
   local check_name app_slug details_url
   check_name=$(echo "$CHECKS_JSON" | jq -r '.[0].name // "unknown"')
   app_slug=$(echo "$CHECKS_JSON" | jq -r '.[0].app_slug // "github-actions"')

--- a/scripts/dev-lead-fix-ci.sh
+++ b/scripts/dev-lead-fix-ci.sh
@@ -15,7 +15,7 @@ REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
 MAX_CI_CYCLES="${MAX_CI_CYCLES:-3}"
 LOG_MAX_LINES="${LOG_MAX_LINES:-200}"
 MARKER_PREFIX="<!-- dev-lead-fix-ci sha="
-PROMPTS_DIR="${PROMPTS_DIR:-prompts/dev-lead}"
+export PROMPTS_DIR="${PROMPTS_DIR:-prompts/dev-lead}"
 
 check_idempotency() {
   local existing

--- a/scripts/dev-lead-fix-issue.sh
+++ b/scripts/dev-lead-fix-issue.sh
@@ -8,7 +8,7 @@ source "$(dirname "$0")/engine.sh"
 ISSUE_NUMBER="${ISSUE_NUMBER:-}"
 REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
 DEV_LEAD_DRY_RUN="${DEV_LEAD_DRY_RUN:-false}"
-PROMPTS_DIR="${PROMPTS_DIR:-prompts/dev-lead}"
+export PROMPTS_DIR="${PROMPTS_DIR:-prompts/dev-lead}"
 
 check_existing_pr() {
   local existing

--- a/scripts/dev-lead-fix-issue.sh
+++ b/scripts/dev-lead-fix-issue.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 # dev-lead-fix-issue.sh — handles the issue intent
+# Optional: PROMPTS_DIR (defaults to prompts/dev-lead relative to CWD)
 
 source "$(dirname "$0")/engine.sh"
 
 ISSUE_NUMBER="${ISSUE_NUMBER:-}"
 REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
 DEV_LEAD_DRY_RUN="${DEV_LEAD_DRY_RUN:-false}"
+PROMPTS_DIR="${PROMPTS_DIR:-prompts/dev-lead}"
 
 check_existing_pr() {
   local existing
@@ -37,7 +39,7 @@ main() {
   export ISSUE_TITLE ISSUE_BODY ORG_STANDARDS_HINT
 
   local prompt_file="/tmp/dev-lead-fix-issue-prompt-$$.md"
-  envsubst < "prompts/dev-lead/fix-issue.md" > "$prompt_file"
+  envsubst < "${PROMPTS_DIR}/fix-issue.md" > "$prompt_file"
 
   if [ "$DEV_LEAD_DRY_RUN" = "true" ]; then
     echo "[dry-run] fix-issue: would implement issue #${ISSUE_NUMBER} using prompt: $prompt_file"

--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -10,7 +10,7 @@ PR_NUMBER="${PR_NUMBER:-}"
 REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
 HEAD_SHA="${HEAD_SHA:-}"
 DEV_LEAD_DRY_RUN="${DEV_LEAD_DRY_RUN:-false}"
-PROMPTS_DIR="${PROMPTS_DIR:-prompts/dev-lead}"
+export PROMPTS_DIR="${PROMPTS_DIR:-prompts/dev-lead}"
 
 if [ -z "$PR_NUMBER" ] && [ "$INTENT_TYPE" != "rebase" ]; then
   echo "::error::PR_NUMBER is required"

--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 # dev-lead-fix-reviews.sh — handles review-related intents
+# Optional: PROMPTS_DIR (defaults to prompts/dev-lead relative to CWD)
 
 source "$(dirname "$0")/engine.sh"
 
@@ -9,6 +10,7 @@ PR_NUMBER="${PR_NUMBER:-}"
 REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
 HEAD_SHA="${HEAD_SHA:-}"
 DEV_LEAD_DRY_RUN="${DEV_LEAD_DRY_RUN:-false}"
+PROMPTS_DIR="${PROMPTS_DIR:-prompts/dev-lead}"
 
 if [ -z "$PR_NUMBER" ] && [ "$INTENT_TYPE" != "rebase" ]; then
   echo "::error::PR_NUMBER is required"
@@ -19,7 +21,7 @@ build_and_run() {
   local template_name="$1"
   local prompt_file="/tmp/dev-lead-${template_name}-prompt-$$.md"
   # Export required vars then envsubst
-  envsubst < "prompts/dev-lead/${template_name}.md" > "$prompt_file"
+  envsubst < "${PROMPTS_DIR}/${template_name}.md" > "$prompt_file"
 
   if [ "$DEV_LEAD_DRY_RUN" = "true" ]; then
     echo "[dry-run] would run engine with prompt: $prompt_file ($(wc -l < "$prompt_file") lines)"


### PR DESCRIPTION
## Summary

- **Phase 1.5** — Create `.github/workflows/dev-lead-reusable.yml`: a `workflow_call` reusable that lets other repos invoke the dev-lead pipeline without bundling scripts. It sparse-checks out `.github-private` into `.dev-lead/` and runs the same intent→handler flow as `dev-lead.yml`, passing `PROMPTS_DIR=.dev-lead/prompts/dev-lead` to each handler.
- **PROMPTS_DIR support** — Add `PROMPTS_DIR` env-var to `dev-lead-fix-ci.sh`, `dev-lead-fix-reviews.sh`, and `dev-lead-fix-issue.sh`. Defaults to `prompts/dev-lead` (no change for existing users); reusable workflow sets it to `.dev-lead/prompts/dev-lead`.
- **Phase 7** — Annotate `dev-lead.yml` with shadow-period header: `claude.yml` and `dev-lead.yml` run in parallel from 2026-05-15 through ~2026-05-29. After the window closes without regressions, `claude.yml` is removed.

## Key design decisions

- Reusable uses two `actions/checkout` steps: caller repo at root, `.github-private` at `.dev-lead/`. All `bash` invocations are `bash .dev-lead/scripts/...` so `source "$(dirname "$0")/engine.sh"` resolves correctly.
- No `ci-relay` job in the reusable — `check_run` events don't flow through `workflow_call`. The caller stub (`petry-projects/.github/standards/workflows/dev-lead.yml`) is responsible for handling check_run by calling the reusable from its own ci-relay job with `inputs.event_name: check_run`.
- `dispatch` job `if:` condition guards against check_run events whether they arrive via `github.event_name` or `inputs.event_name`.
- All handler steps in the reusable carry engine secrets explicitly (they're not in the job-level env, since `secrets:` can't be mapped there from `workflow_call`).
- BATS tests are unaffected — they `cd` to repo root and don't set `PROMPTS_DIR`, so the default `prompts/dev-lead` path is used as before.

## Test plan

- [ ] CI passes on this PR (`Test Dev-Lead Agent` workflow runs BATS unit tests and prompt-coverage check)
- [ ] Manually verify `dev-lead-reusable.yml` parses with `gh workflow view` after merge
- [ ] Confirm `claude.yml` remains active (shadow period — both workflows run)
- [ ] After ~2026-05-29: open a follow-up PR to remove `claude.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable GitHub Actions workflow to route and handle automated events through dedicated handler scripts.
  * Introduced configurable prompt directory support across automation scripts for enhanced flexibility.

* **Chores**
  * Updated workflow documentation with phase tracking information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/petry-projects/.github-private/pull/179)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->