### PR TITLE
fix(dev-lead): replace fromJson(INTENT_CONTEXT) with pre-parsed env vars

### DIFF
--- a/.github/workflows/dev-lead-reusable.yml
+++ b/.github/workflows/dev-lead-reusable.yml
@@ -86,6 +86,14 @@ jobs:
         run: |
           echo "::notice::intent=$INTENT_TYPE reason=$INTENT_REASON"
 
+      - name: Parse intent context fields
+        run: |
+          ctx="${INTENT_CONTEXT:-{\}}"
+          echo "INTENT_PR_NUMBER=$(echo "$ctx"    | jq -r '.pr_number // ""')"    >> "$GITHUB_ENV"
+          echo "INTENT_HEAD_SHA=$(echo "$ctx"     | jq -r '.head_sha // ""')"     >> "$GITHUB_ENV"
+          echo "INTENT_CHECKS=$(echo "$ctx"       | jq -c '.checks // []')"       >> "$GITHUB_ENV"
+          echo "INTENT_ISSUE_NUMBER=$(echo "$ctx" | jq -r '.issue_number // ""')" >> "$GITHUB_ENV"
+
       - name: Skip — log reason
         if: env.INTENT_TYPE == 'skip'
         run: |
@@ -136,9 +144,9 @@ jobs:
       - name: Run fix-ci
         if: env.INTENT_TYPE == 'fix-ci'
         env:
-          PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
-          HEAD_SHA: ${{ fromJson(env.INTENT_CONTEXT).head_sha }}
-          CHECKS_JSON: ${{ toJson(fromJson(env.INTENT_CONTEXT).checks) }}
+          PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}
+          HEAD_SHA: ${{ env.INTENT_HEAD_SHA }}
+          CHECKS_JSON: ${{ env.INTENT_CHECKS }}
           REPO: ${{ github.repository }}
           REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -152,8 +160,8 @@ jobs:
         if: env.INTENT_TYPE == 'fix-reviews'
         env:
           INTENT_TYPE: fix-reviews
-          PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
-          HEAD_SHA: ${{ fromJson(env.INTENT_CONTEXT).head_sha }}
+          PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}
+          HEAD_SHA: ${{ env.INTENT_HEAD_SHA }}
           REPO: ${{ github.repository }}
           REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -167,8 +175,8 @@ jobs:
         if: env.INTENT_TYPE == 'fix-bot-comment'
         env:
           INTENT_TYPE: fix-bot-comment
-          PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
-          HEAD_SHA: ${{ fromJson(env.INTENT_CONTEXT).head_sha }}
+          PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}
+          HEAD_SHA: ${{ env.INTENT_HEAD_SHA }}
           REPO: ${{ github.repository }}
           REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -182,8 +190,8 @@ jobs:
         if: env.INTENT_TYPE == 'human'
         env:
           INTENT_TYPE: human
-          PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
-          HEAD_SHA: ${{ fromJson(env.INTENT_CONTEXT).head_sha }}
+          PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}
+          HEAD_SHA: ${{ env.INTENT_HEAD_SHA }}
           REPO: ${{ github.repository }}
           REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -197,8 +205,8 @@ jobs:
         if: env.INTENT_TYPE == 'human-pr'
         env:
           INTENT_TYPE: human-pr
-          PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
-          HEAD_SHA: ${{ fromJson(env.INTENT_CONTEXT).head_sha }}
+          PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}
+          HEAD_SHA: ${{ env.INTENT_HEAD_SHA }}
           REPO: ${{ github.repository }}
           REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -211,7 +219,7 @@ jobs:
       - name: Run issue
         if: env.INTENT_TYPE == 'issue'
         env:
-          ISSUE_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).issue_number }}
+          ISSUE_NUMBER: ${{ env.INTENT_ISSUE_NUMBER }}
           REPO: ${{ github.repository }}
           REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -225,7 +233,7 @@ jobs:
         if: env.INTENT_TYPE == 'rebase'
         env:
           INTENT_TYPE: rebase
-          PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
+          PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}
           REPO: ${{ github.repository }}
           REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -74,6 +74,16 @@ jobs:
         run: |
           echo "::notice::intent=$INTENT_TYPE reason=$INTENT_REASON"
 
+      - name: Parse intent context fields
+        run: |
+          # Expand INTENT_CONTEXT JSON into individual GITHUB_ENV vars so subsequent
+          # step env: blocks can reference ${{ env.INTENT_PR_NUMBER }} without fromJson()
+          ctx="${INTENT_CONTEXT:-{\}}"
+          echo "INTENT_PR_NUMBER=$(echo "$ctx" | jq -r '.pr_number // ""')" >> "$GITHUB_ENV"
+          echo "INTENT_HEAD_SHA=$(echo "$ctx"  | jq -r '.head_sha // ""')"  >> "$GITHUB_ENV"
+          echo "INTENT_CHECKS=$(echo "$ctx"    | jq -c '.checks // []')"    >> "$GITHUB_ENV"
+          echo "INTENT_ISSUE_NUMBER=$(echo "$ctx" | jq -r '.issue_number // ""')" >> "$GITHUB_ENV"
+
       - name: Skip — log reason
         if: env.INTENT_TYPE == 'skip'
         run: |
@@ -119,9 +129,9 @@ jobs:
       - name: Run fix-ci
         if: env.INTENT_TYPE == 'fix-ci'
         env:
-          PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
-          HEAD_SHA: ${{ fromJson(env.INTENT_CONTEXT).head_sha }}
-          CHECKS_JSON: ${{ toJson(fromJson(env.INTENT_CONTEXT).checks) }}
+          PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}
+          HEAD_SHA: ${{ env.INTENT_HEAD_SHA }}
+          CHECKS_JSON: ${{ env.INTENT_CHECKS }}
           REPO: ${{ github.repository }}
           REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
         run: bash scripts/dev-lead-fix-ci.sh
@@ -131,8 +141,8 @@ jobs:
         if: env.INTENT_TYPE == 'fix-reviews'
         env:
           INTENT_TYPE: fix-reviews
-          PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
-          HEAD_SHA: ${{ fromJson(env.INTENT_CONTEXT).head_sha }}
+          PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}
+          HEAD_SHA: ${{ env.INTENT_HEAD_SHA }}
           REPO: ${{ github.repository }}
           REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
         run: bash scripts/dev-lead-fix-reviews.sh
@@ -142,8 +152,8 @@ jobs:
         if: env.INTENT_TYPE == 'fix-bot-comment'
         env:
           INTENT_TYPE: fix-bot-comment
-          PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
-          HEAD_SHA: ${{ fromJson(env.INTENT_CONTEXT).head_sha }}
+          PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}
+          HEAD_SHA: ${{ env.INTENT_HEAD_SHA }}
           REPO: ${{ github.repository }}
           REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
         run: bash scripts/dev-lead-fix-reviews.sh
@@ -153,8 +163,8 @@ jobs:
         if: env.INTENT_TYPE == 'human'
         env:
           INTENT_TYPE: human
-          PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
-          HEAD_SHA: ${{ fromJson(env.INTENT_CONTEXT).head_sha }}
+          PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}
+          HEAD_SHA: ${{ env.INTENT_HEAD_SHA }}
           REPO: ${{ github.repository }}
           REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
         run: bash scripts/dev-lead-fix-reviews.sh
@@ -164,8 +174,8 @@ jobs:
         if: env.INTENT_TYPE == 'human-pr'
         env:
           INTENT_TYPE: human-pr
-          PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
-          HEAD_SHA: ${{ fromJson(env.INTENT_CONTEXT).head_sha }}
+          PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}
+          HEAD_SHA: ${{ env.INTENT_HEAD_SHA }}
           REPO: ${{ github.repository }}
           REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
         run: bash scripts/dev-lead-fix-reviews.sh
@@ -174,7 +184,7 @@ jobs:
       - name: Run issue
         if: env.INTENT_TYPE == 'issue'
         env:
-          ISSUE_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).issue_number }}
+          ISSUE_NUMBER: ${{ env.INTENT_ISSUE_NUMBER }}
           REPO: ${{ github.repository }}
           REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
         run: bash scripts/dev-lead-fix-issue.sh
@@ -184,7 +194,7 @@ jobs:
         if: env.INTENT_TYPE == 'rebase'
         env:
           INTENT_TYPE: rebase
-          PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
+          PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}
           REPO: ${{ github.repository }}
           REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
         run: bash scripts/dev-lead-fix-reviews.sh


### PR DESCRIPTION
## Problem
Template validation in `workflow_call` context fails because GitHub evaluates `fromJson(env.INTENT_CONTEXT)` at workflow parse time, before the intent script has populated `INTENT_CONTEXT` in `GITHUB_ENV`. This causes all cross-repo callers of `dev-lead-reusable.yml` to fail with:
```
Error reading JToken from JsonReader. Path '', line 0, position 0.
```

## Fix
Add a **Parse intent context fields** step that runs right after intent classification and writes individual values to `GITHUB_ENV`:
- `INTENT_PR_NUMBER`, `INTENT_HEAD_SHA`, `INTENT_CHECKS`, `INTENT_ISSUE_NUMBER`

Then replace all `${{ fromJson(env.INTENT_CONTEXT).x }}` in step `env:` blocks with plain `${{ env.INTENT_PR_NUMBER }}` etc. — these are simple string lookups that GitHub can safely evaluate at parse time (they'll be empty string if not yet set, not an error).

Both `dev-lead.yml` and `dev-lead-reusable.yml` receive the same fix for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized GitHub Actions workflows by refactoring intent context data processing. Updated automation steps to use pre-parsed environment variables for improved efficiency and maintainability across build and review workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/petry-projects/.github-private/pull/185)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->