### PR TITLE
fix(dev-lead): remove step-level INTENT_TYPE env overrides shadowing if: conditions

### DIFF
--- a/.github/workflows/dev-lead-reusable.yml
+++ b/.github/workflows/dev-lead-reusable.yml
@@ -151,7 +151,6 @@ jobs:
       - name: Run fix-reviews
         if: env.INTENT_TYPE == 'fix-reviews'
         env:
-          INTENT_TYPE: fix-reviews
           PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
           HEAD_SHA: ${{ fromJson(env.INTENT_CONTEXT).head_sha }}
           REPO: ${{ github.repository }}
@@ -166,7 +165,6 @@ jobs:
       - name: Run fix-bot-comment
         if: env.INTENT_TYPE == 'fix-bot-comment'
         env:
-          INTENT_TYPE: fix-bot-comment
           PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
           HEAD_SHA: ${{ fromJson(env.INTENT_CONTEXT).head_sha }}
           REPO: ${{ github.repository }}
@@ -181,7 +179,6 @@ jobs:
       - name: Run human
         if: env.INTENT_TYPE == 'human'
         env:
-          INTENT_TYPE: human
           PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
           HEAD_SHA: ${{ fromJson(env.INTENT_CONTEXT).head_sha }}
           REPO: ${{ github.repository }}
@@ -196,7 +193,6 @@ jobs:
       - name: Run human-pr
         if: env.INTENT_TYPE == 'human-pr'
         env:
-          INTENT_TYPE: human-pr
           PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
           HEAD_SHA: ${{ fromJson(env.INTENT_CONTEXT).head_sha }}
           REPO: ${{ github.repository }}
@@ -224,7 +220,6 @@ jobs:
       - name: Run rebase
         if: env.INTENT_TYPE == 'rebase'
         env:
-          INTENT_TYPE: rebase
           PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
           REPO: ${{ github.repository }}
           REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -130,7 +130,6 @@ jobs:
       - name: Run fix-reviews
         if: env.INTENT_TYPE == 'fix-reviews'
         env:
-          INTENT_TYPE: fix-reviews
           PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
           HEAD_SHA: ${{ fromJson(env.INTENT_CONTEXT).head_sha }}
           REPO: ${{ github.repository }}
@@ -141,7 +140,6 @@ jobs:
       - name: Run fix-bot-comment
         if: env.INTENT_TYPE == 'fix-bot-comment'
         env:
-          INTENT_TYPE: fix-bot-comment
           PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
           HEAD_SHA: ${{ fromJson(env.INTENT_CONTEXT).head_sha }}
           REPO: ${{ github.repository }}
@@ -152,7 +150,6 @@ jobs:
       - name: Run human
         if: env.INTENT_TYPE == 'human'
         env:
-          INTENT_TYPE: human
           PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
           HEAD_SHA: ${{ fromJson(env.INTENT_CONTEXT).head_sha }}
           REPO: ${{ github.repository }}
@@ -163,7 +160,6 @@ jobs:
       - name: Run human-pr
         if: env.INTENT_TYPE == 'human-pr'
         env:
-          INTENT_TYPE: human-pr
           PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
           HEAD_SHA: ${{ fromJson(env.INTENT_CONTEXT).head_sha }}
           REPO: ${{ github.repository }}
@@ -183,7 +179,6 @@ jobs:
       - name: Run rebase
         if: env.INTENT_TYPE == 'rebase'
         env:
-          INTENT_TYPE: rebase
           PR_NUMBER: ${{ fromJson(env.INTENT_CONTEXT).pr_number }}
           REPO: ${{ github.repository }}
           REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}

--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 source "$(dirname "$0")/engine.sh"
 
-INTENT_TYPE="${INTENT_TYPE:-fix-reviews}"
+INTENT_TYPE="${INTENT_TYPE:?INTENT_TYPE must be set by the workflow}"
 PR_NUMBER="${PR_NUMBER:-}"
 REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
 HEAD_SHA="${HEAD_SHA:-}"


### PR DESCRIPTION
## Root cause

Step-level `env:` overrides are included in the `env` context when GitHub evaluates the step's `if:` condition. This caused:

```yaml
- name: Run fix-reviews
  if: env.INTENT_TYPE == 'fix-reviews'   # Always TRUE — step-level env wins
  env:
    INTENT_TYPE: fix-reviews             # This value is used in the if: check
```

All handler steps ran for every event regardless of actual intent. When intent was `skip`, the scripts would exit 1 because PR_NUMBER/ISSUE_NUMBER were empty.

## Fix

Remove `INTENT_TYPE:` from step `env:` blocks in both `dev-lead.yml` and `dev-lead-reusable.yml`. The handler scripts already read `INTENT_TYPE` from `GITHUB_ENV` (set by `dev-lead-intent.sh`).

Also change the script fallback from `${INTENT_TYPE:-fix-reviews}` to `${INTENT_TYPE:?error}` so unset INTENT_TYPE is a loud failure rather than a silent wrong value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified workflow environment variable configuration in CI/CD pipeline by removing redundant declarations.
  * Enhanced parameter validation to require critical environment variables be explicitly set by the workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/petry-projects/.github-private/pull/186)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->