### PR TITLE
fix(dev-lead): remove step-level INTENT_TYPE env overrides shadowing if: conditions

### DIFF
--- a/.github/workflows/dev-lead-reusable.yml
+++ b/.github/workflows/dev-lead-reusable.yml
@@ -159,7 +159,6 @@ jobs:
       - name: Run fix-reviews
         if: env.INTENT_TYPE == 'fix-reviews'
         env:
-          INTENT_TYPE: fix-reviews
           PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}
           HEAD_SHA: ${{ env.INTENT_HEAD_SHA }}
           REPO: ${{ github.repository }}
@@ -174,7 +173,6 @@ jobs:
       - name: Run fix-bot-comment
         if: env.INTENT_TYPE == 'fix-bot-comment'
         env:
-          INTENT_TYPE: fix-bot-comment
           PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}
           HEAD_SHA: ${{ env.INTENT_HEAD_SHA }}
           REPO: ${{ github.repository }}
@@ -189,7 +187,6 @@ jobs:
       - name: Run human
         if: env.INTENT_TYPE == 'human'
         env:
-          INTENT_TYPE: human
           PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}
           HEAD_SHA: ${{ env.INTENT_HEAD_SHA }}
           REPO: ${{ github.repository }}
@@ -204,7 +201,6 @@ jobs:
       - name: Run human-pr
         if: env.INTENT_TYPE == 'human-pr'
         env:
-          INTENT_TYPE: human-pr
           PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}
           HEAD_SHA: ${{ env.INTENT_HEAD_SHA }}
           REPO: ${{ github.repository }}
@@ -232,7 +228,6 @@ jobs:
       - name: Run rebase
         if: env.INTENT_TYPE == 'rebase'
         env:
-          INTENT_TYPE: rebase
           PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}
           REPO: ${{ github.repository }}
           REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -140,7 +140,6 @@ jobs:
       - name: Run fix-reviews
         if: env.INTENT_TYPE == 'fix-reviews'
         env:
-          INTENT_TYPE: fix-reviews
           PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}
           HEAD_SHA: ${{ env.INTENT_HEAD_SHA }}
           REPO: ${{ github.repository }}
@@ -151,7 +150,6 @@ jobs:
       - name: Run fix-bot-comment
         if: env.INTENT_TYPE == 'fix-bot-comment'
         env:
-          INTENT_TYPE: fix-bot-comment
           PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}
           HEAD_SHA: ${{ env.INTENT_HEAD_SHA }}
           REPO: ${{ github.repository }}
@@ -162,7 +160,6 @@ jobs:
       - name: Run human
         if: env.INTENT_TYPE == 'human'
         env:
-          INTENT_TYPE: human
           PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}
           HEAD_SHA: ${{ env.INTENT_HEAD_SHA }}
           REPO: ${{ github.repository }}
@@ -173,7 +170,6 @@ jobs:
       - name: Run human-pr
         if: env.INTENT_TYPE == 'human-pr'
         env:
-          INTENT_TYPE: human-pr
           PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}
           HEAD_SHA: ${{ env.INTENT_HEAD_SHA }}
           REPO: ${{ github.repository }}
@@ -193,7 +189,6 @@ jobs:
       - name: Run rebase
         if: env.INTENT_TYPE == 'rebase'
         env:
-          INTENT_TYPE: rebase
           PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}
           REPO: ${{ github.repository }}
           REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}


### PR DESCRIPTION
Closes #186 (supersedes it with a clean rebase).

**Root cause:** Step-level `env:` overrides are visible in the step's `if:` condition context. `INTENT_TYPE: fix-reviews` in the step's env block caused `if: env.INTENT_TYPE == 'fix-reviews'` to always be true — all handler steps ran for every event. When intent was `skip`, scripts exited 1 because PR_NUMBER was empty.

**Fix:** Remove `INTENT_TYPE:` from all handler step `env:` blocks. Scripts read `INTENT_TYPE` from `GITHUB_ENV` (correctly set by `dev-lead-intent.sh`).