### PR TITLE
ci: add pr-review-mention.yml caller stub

### DIFF
--- a/.github/workflows/pr-review-mention.yml
+++ b/.github/workflows/pr-review-mention.yml
@@ -1,0 +1,40 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/pr-review-mention.yml
+# Standard:        petry-projects/.github/standards/ci-standards.md
+# Reusable:        petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml
+#
+# AGENTS — READ BEFORE EDITING:
+#   • This file is a THIN CALLER STUB. All review-dispatch logic lives in the
+#     reusable workflow above.
+#   • You MAY change: the tag in the `uses:` line when upgrading the reusable
+#     workflow version (e.g. bump `@v1` → `@v2` when petry-projects/.github cuts a new release).
+#   • You MUST NOT change: trigger events or the job-level `permissions:` block —
+#     reusable workflows can be granted no more permissions than the calling job,
+#     so removing the stanza breaks the reusable's gh API calls.
+#   • If you need different behaviour, open a PR against the reusable in the
+#     central repo.
+#   • When publishing a new version of this reusable, also update this template and
+#     open a fanout PR across all caller repos.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# PR Review Mention — thin caller for the org-level reusable.
+# To adopt: copy this file to .github/workflows/pr-review-mention.yml in your repo.
+# Requires: GH_PAT_WORKFLOWS org secret (already present in petry-projects org).
+name: PR Review — Mention Trigger
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request:
+    types: [review_requested]
+
+permissions: {}
+
+jobs:
+  pr-review-mention:
+    permissions:
+      pull-requests: write
+    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@v1
+    secrets: inherit

--- a/.github/workflows/pr-review-mention.yml
+++ b/.github/workflows/pr-review-mention.yml
@@ -19,7 +19,8 @@
 #
 # PR Review Mention — thin caller for the org-level reusable.
 # To adopt: copy this file to .github/workflows/pr-review-mention.yml in your repo.
-# Requires: GH_PAT_WORKFLOWS org secret (already present in petry-projects org).
+# Requires: GH_PAT_WORKFLOWS     org secret — API calls and dispatching the review agent
+#           DON_PETRY_BOT_GH_PAT org secret — posting acknowledgement comments as the bot
 name: PR Review — Mention Trigger
 
 on:
@@ -37,4 +38,6 @@ jobs:
     permissions:
       pull-requests: write
     uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@v2
-    secrets: inherit
+    secrets:
+      GH_PAT_WORKFLOWS: ${{ secrets.GH_PAT_WORKFLOWS }}
+      DON_PETRY_BOT_GH_PAT: ${{ secrets.DON_PETRY_BOT_GH_PAT }}

--- a/.github/workflows/pr-review-mention.yml
+++ b/.github/workflows/pr-review-mention.yml
@@ -36,5 +36,5 @@ jobs:
   pr-review-mention:
     permissions:
       pull-requests: write
-    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@v2
     secrets: inherit


### PR DESCRIPTION
## Summary

- Adds the missing `pr-review-mention.yml` thin caller stub so `@donpetry-bot` mentions and reviewer-assignment events in `.github-private` dispatch the pr-review agent cascade

## Root cause

The stub was never deployed to this repo when `pr-review-mention` was adopted as an org standard (petry-projects/.github@a2b3b46). As a result, `issue_comment` events fired here but nothing listened for them.

Closes #113

## Notes

Uses `@v2` — companion PR petry-projects/.github#302 updates the compliance checker to expect `@v2` for `pr-review-mention-reusable`, so this stub and the checker are in sync.

## Test plan

- [ ] Post `@donpetry-bot - please review` on a PR in this repo and verify a `pr-review-mention` workflow run starts and the bot posts an acknowledgement comment
- [ ] Compliance audit `missing-pr-review-mention.yml` finding for this repo (issue #113) closes on next Friday run

🤖 Generated with [Claude Code](https://claude.com/claude-code)