### PR TITLE
docs(pr-review-agent): document read:org requirement for team review requests

### DIFF
--- a/docs/pr-review-agent/bot-setup.md
+++ b/docs/pr-review-agent/bot-setup.md
@@ -53,7 +53,9 @@ This guide sets up the bot account that posts PR approvals on behalf of the PR R
    - **Scopes:**
      - ✅ `repo` (full control of repositories) — required for `addPullRequestReview`
      - ✅ `workflow` — required when AI delegation pushes workflow-file changes
-     - ✅ `read:org` — silences the `Missing required token scopes: 'read:org'` warning and enables team-based CODEOWNERS escalation
+     - ✅ `read:org` — **required** to read team-based review requests (`reviewRequests.requestedReviewer`
+       fails with a GraphQL permission error for any PR that has a team reviewer when this scope is absent);
+       also enables team-based CODEOWNERS escalation
 5. Click **Generate token**
 6. **Copy the token immediately** (you won't see it again)
 7. Store it temporarily (we'll add to repo secret next)
@@ -136,6 +138,14 @@ Repeat **Step 5** for any other repos where the bot should approve PRs:
 - Verify bot is a member of the organization
 - Check branch protection rules aren't blocking the bot
 - Verify bot has `repo` scope in its PAT
+
+### Issue: `gh pr view failed during metadata prefetch` / `Resource not accessible by personal access token (repository.pullRequest.reviewRequests.nodes.0.requestedReviewer)`
+- The classic PAT is missing `read:org`. This error surfaces the first time a PR
+  with a **team** requested reviewer is encountered — the `reviewRequests.requestedReviewer`
+  GraphQL field requires org-level member read access.
+- Edit the token at **Settings → Developer settings → Tokens (classic) → Edit** and
+  check the `read:org` box. No need to regenerate — editing scopes takes effect immediately.
+- Verify by re-running: `gh workflow run pr-review.yml --repo petry-projects/.github-private -f pr_url=<pr-url> -f force_review=true`
 
 ## Rotating the Token (Annually)
 

--- a/docs/pr-review-agent/machine-user-setup.md
+++ b/docs/pr-review-agent/machine-user-setup.md
@@ -78,9 +78,11 @@ Or path-specific rules as needed.
      - ✅ `repo` (full control of private repos) — required for the
        `addPullRequestReview` mutation
      - ✅ `workflow` — required when AI delegation pushes workflow-file changes
-     - ✅ `read:org` — silences `Missing required token scopes: 'read:org'`
-       in workflow logs and lets the agent resolve `@org/team` mentions in
-       CODEOWNERS escalations
+     - ✅ `read:org` — **required** to read team-based review requests; the
+       `reviewRequests.requestedReviewer` GraphQL field returns
+       `Resource not accessible by personal access token` for any PR with
+       a team reviewer when this scope is absent. Also enables `@org/team`
+       resolution in CODEOWNERS escalations.
 4. **Generate token** and copy it immediately (you won't see it again).
 
 ## Step 4: Store the PAT in `petry-projects/.github-private`
@@ -166,11 +168,18 @@ classic PAT (Step 3) and update the secret (Step 4). The fine-grained version
 is blocked by an org-policy gate that has no UI surface — there's no
 configuration that makes it work.
 
-### `Missing required token scopes: 'read:org'`
+### `Missing required token scopes: 'read:org'` or `gh pr view failed during metadata prefetch`
 
-The classic PAT was generated without `read:org`. Edit the token at
-**Settings → Developer settings → Tokens (classic) → Edit** and check the
-`read:org` box. (No need to regenerate — editing scopes is sufficient.)
+The classic PAT was generated without `read:org`. This scope is required for two reasons:
+
+1. **Team-based review requests** — the `reviewRequests.requestedReviewer` GraphQL field
+   returns `Resource not accessible by personal access token` for any PR that has a team
+   (not just a user) as a requested reviewer. This causes a hard prefetch failure and the
+   PR is skipped entirely.
+2. **CODEOWNERS escalation** — `@org/team` mentions cannot be resolved without org read access.
+
+Edit the token at **Settings → Developer settings → Tokens (classic) → Edit** and check
+the `read:org` box. (No need to regenerate — editing scopes takes effect immediately.)
 
 ### `gh auth status` reports the wrong account
 

--- a/docs/pr-review-agent/setup.md
+++ b/docs/pr-review-agent/setup.md
@@ -117,9 +117,21 @@ gh run list --repo petry-projects/.github-private -w pr-review.yml -L 5
 - The PAT was generated from the wrong account — `gh auth status` in the
   workflow log will show the actual login. Regenerate from `donpetry-bot`.
 - The PAT is missing required scopes. Edit the token and ensure `repo`,
-  `workflow`, and `read:org` are checked.
+  `workflow`, and `read:org` are checked. Note: `read:org` is required not
+  just for CODEOWNERS escalation but also to read team-based review requests —
+  omitting it causes a hard prefetch failure on any PR with a team reviewer.
 - The bot account doesn't have **Write** collaborator role on the target repo
   (Read or Triage isn't sufficient for review approvals).
+
+### `gh pr view failed during metadata prefetch` / `Resource not accessible by personal access token (repository.pullRequest.reviewRequests)`
+- The classic PAT is missing the `read:org` scope. This error occurs on any PR
+  that has a **team** (not just a user) as a requested reviewer — the
+  `reviewRequests.requestedReviewer` GraphQL field requires org-level member
+  read access and is hard-blocked without it.
+- Edit the token at **Settings → Developer settings → Tokens (classic) → Edit**
+  and check `read:org`. No regeneration needed — the scope update takes effect
+  immediately. See [BOT_SETUP.md → Step 3](BOT_SETUP.md) and
+  [MACHINE_USER_SETUP.md → Troubleshooting](machine-user-setup.md).
 
 ### Reviews not posting
 - Run a dry-run to verify agent decision

--- a/docs/pr-review-agent/setup.md
+++ b/docs/pr-review-agent/setup.md
@@ -123,14 +123,14 @@ gh run list --repo petry-projects/.github-private -w pr-review.yml -L 5
 - The bot account doesn't have **Write** collaborator role on the target repo
   (Read or Triage isn't sufficient for review approvals).
 
-### `gh pr view failed during metadata prefetch` / `Resource not accessible by personal access token (repository.pullRequest.reviewRequests)`
+### `gh pr view failed during metadata prefetch` / `Resource not accessible by personal access token (repository.pullRequest.reviewRequests.nodes.0.requestedReviewer)`
 - The classic PAT is missing the `read:org` scope. This error occurs on any PR
   that has a **team** (not just a user) as a requested reviewer — the
   `reviewRequests.requestedReviewer` GraphQL field requires org-level member
   read access and is hard-blocked without it.
 - Edit the token at **Settings → Developer settings → Tokens (classic) → Edit**
   and check `read:org`. No regeneration needed — the scope update takes effect
-  immediately. See [BOT_SETUP.md → Step 3](BOT_SETUP.md) and
+  immediately. See [BOT_SETUP.md → Step 3](bot-setup.md) and
   [MACHINE_USER_SETUP.md → Troubleshooting](machine-user-setup.md).
 
 ### Reviews not posting


### PR DESCRIPTION
## Summary

Closes the documentation gap exposed by run [#25974874120](https://github.com/petry-projects/.github-private/actions/runs/25974874120) / job [#76353169023](https://github.com/petry-projects/.github-private/actions/runs/25974874120/job/76353169023).

The `reviewRequests.requestedReviewer` GraphQL field returns `Resource not accessible by personal access token` when a PR has a **team** (not just a user) as a requested reviewer and the PAT lacks `read:org`. This was previously undocumented — `read:org` was described only as silencing a log warning and enabling CODEOWNERS escalation, not as a hard requirement for the metadata prefetch.

The failure was latent since [be66351c](https://github.com/petry-projects/.github-private/commit/be66351c53d0e8f37086166b70301170b2db893e) tightened prefetch error handling (silent `{}` → hard exit on May 15), and surfaced when petry-projects/.github#302 became the first team-reviewer PR encountered since then.

## Changes

| File | Change |
|---|---|
| `bot-setup.md` | Strengthen `read:org` scope description; add troubleshooting entry for the prefetch error |
| `machine-user-setup.md` | Strengthen `read:org` scope description; expand missing-scope troubleshooting to cover both failure modes |
| `setup.md` | Tighten existing scope note; add dedicated troubleshooting entry for the `reviewRequests` prefetch error |