### PR TITLE
Disable scheduled cron triggers for PR Review Agent

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,19 +1,19 @@
 name: PR Review Agent
 
 on:
-  schedule:
-    # Strategy: four staggered offsets per hour to improve the reliability of
-    # getting at least one scheduled run per clock-hour. GitHub Actions scheduled
-    # workflows are frequently delayed or skipped under load. The shared concurrency
-    # group (pr-review-scheduled) serializes runs so at most one executes at a time;
-    # additional triggers queue rather than overlap. Queued runs are cheap to no-op:
-    # the per-PR idempotency check (head-SHA comparison) skips any PR already
-    # reviewed since the last push, so back-to-back queued runs won't produce
-    # duplicate reviews.
-    - cron: "7 * * * *"
-    - cron: "22 * * * *"
-    - cron: "37 * * * *"
-    - cron: "52 * * * *"
+  # schedule:
+  #   # Strategy: four staggered offsets per hour to improve the reliability of
+  #   # getting at least one scheduled run per clock-hour. GitHub Actions scheduled
+  #   # workflows are frequently delayed or skipped under load. The shared concurrency
+  #   # group (pr-review-scheduled) serializes runs so at most one executes at a time;
+  #   # additional triggers queue rather than overlap. Queued runs are cheap to no-op:
+  #   # the per-PR idempotency check (head-SHA comparison) skips any PR already
+  #   # reviewed since the last push, so back-to-back queued runs won't produce
+  #   # duplicate reviews.
+  #   - cron: "7 * * * *"
+  #   - cron: "22 * * * *"
+  #   - cron: "37 * * * *"
+  #   - cron: "52 * * * *"
   workflow_dispatch:
     inputs:
       pr_url:


### PR DESCRIPTION
## Summary

- Comments out all four `schedule` cron entries in `pr-review.yml`
- `workflow_dispatch` and `repository_dispatch` (mention-triggered) triggers remain active
- Re-enable by uncommenting the `schedule` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)