### PR TITLE
Fix: Resolve YAML syntax error in dev-lead-reusable workflow

### DIFF
--- a/.github/workflows/dev-lead-reusable.yml
+++ b/.github/workflows/dev-lead-reusable.yml
@@ -302,7 +302,3 @@ jobs:
           echo "$payload" | gh api \
             --method POST "repos/$RELAY_REPO/dispatches" --input -
           echo "::notice::Relayed CI failure for PR $RELAY_PR_NUMBER"
-$conclusion,details_url:$details_url,app_slug:$app_slug}]}}')
-          echo "$payload" | gh api \
-            --method POST "repos/$RELAY_REPO/dispatches" --input -
-          echo "::notice::Relayed CI failure for PR $RELAY_PR_NUMBER"


### PR DESCRIPTION
Removes corrupted duplicate lines at the end of the file that were causing YAML parsing failures in OpenSSF Scorecard.