### PR TITLE
fix(ci): ensure gemini-cli installs in reusable dev-lead workflow

### DIFF
--- a/.github/workflows/dev-lead-reusable.yml
+++ b/.github/workflows/dev-lead-reusable.yml
@@ -133,9 +133,15 @@ jobs:
           fi
 
           case "$DEV_LEAD_ENGINE" in
+            claude)
+              npm install -g @google/gemini-cli || true
+              if ! gh copilot --version >/dev/null 2>&1; then
+                gh extension install github/gh-copilot || true
+              fi ;;
             gemini)
               npm install -g @google/gemini-cli || true ;;
             copilot)
+              npm install -g @google/gemini-cli || true
               if ! gh copilot --version >/dev/null 2>&1; then
                 gh extension install github/gh-copilot || true
               fi ;;


### PR DESCRIPTION
This fixes a bug where the fallback logic was failing because gemini-cli was not installed when the engine was set to claude in the reusable workflow.