### PR TITLE
chore: remove Phase 7 shadow period comment from dev-lead.yml

### DIFF
--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -1,6 +1,4 @@
 name: Dev-Lead Agent
-# Phase 7 shadow period: dev-lead.yml and claude.yml run in parallel until ~2026-05-29.
-# Tracking: petry-projects/.github-private#180
 
 on:
   pull_request:


### PR DESCRIPTION
## Summary

Removes the shadow period comment from `dev-lead.yml`:

```yaml
# Phase 7 shadow period: dev-lead.yml and claude.yml run in parallel until ~2026-05-29.
# Tracking: petry-projects/.github-private#180
```

The `claude.yml` file was already deleted from the repo. The ghost workflow entry (ID 261528781) was disabled via API on 2026-05-17. The cutover is confirmed complete — no need to keep the shadow period annotation.

## Context

Part of the Phase 7 dev-lead migration cleanup. See also:
- `petry-projects/.github` PR removing `claude-code-reusable.yml`
- Ghost `claude.yml` workflow disabled via `gh api repos/petry-projects/.github-private/actions/workflows/261528781/disable -X PUT`

## Test plan

- [ ] Confirm `dev-lead.yml` header is clean (no shadow period comment)
- [ ] Confirm dev-lead Actions runs continue normally after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)