### PR TITLE
feat: skip PRs with CHANGES_REQUESTED review decision

### DIFF
--- a/scripts/review-one-pr.sh
+++ b/scripts/review-one-pr.sh
@@ -40,7 +40,7 @@ echo "==> $PR_URL"
 #                NEUTRAL covers informational checks that don't gate merging.
 #      failing — anything else (FAILURE, ACTION_REQUIRED, TIMED_OUT, CANCELLED,
 #                STALE, STARTUP_FAILURE, or unknown conclusions)
-PR_SNAPSHOT=$(gh pr view "$PR_URL" --json headRefOid,statusCheckRollup)
+PR_SNAPSHOT=$(gh pr view "$PR_URL" --json headRefOid,statusCheckRollup,reviewDecision)
 PR_HEAD_SHA=$(echo "$PR_SNAPSHOT" | jq -r '.headRefOid')
 export PR_HEAD_SHA
 echo "    head SHA: $PR_HEAD_SHA"
@@ -61,9 +61,12 @@ CI_STATUS=$(echo "$PR_SNAPSHOT" | jq -r '
 ')
 echo "    CI status: $CI_STATUS"
 
+REVIEW_DECISION=$(echo "$PR_SNAPSHOT" | jq -r '.reviewDecision // ""')
+echo "    review decision: $REVIEW_DECISION"
+
 # Exit code 100 is the skip sentinel: the caller treats any 100 exit as a
 # no-op and does not count it against the MAX_PRS review budget.
-# Reasons that produce a skip: already-reviewed-at-head, ci-failing, ci-pending.
+# Reasons that produce a skip: already-reviewed-at-head, ci-failing, ci-pending, changes-requested.
 if [ "$CI_STATUS" = "failing" ]; then
   echo "    skip: CI checks are failing — will re-evaluate after fixes are pushed"
   echo "{\"pr\":\"$PR_URL\",\"sha\":\"$PR_HEAD_SHA\",\"decision\":\"skip\",\"reason\":\"ci-failing\"}"
@@ -72,6 +75,11 @@ fi
 if [ "$CI_STATUS" = "pending" ]; then
   echo "    skip: CI checks still in progress — will re-evaluate when checks complete"
   echo "{\"pr\":\"$PR_URL\",\"sha\":\"$PR_HEAD_SHA\",\"decision\":\"skip\",\"reason\":\"ci-pending\"}"
+  exit 100
+fi
+if [ "$REVIEW_DECISION" = "CHANGES_REQUESTED" ]; then
+  echo "    skip: changes requested — awaiting author response before reviewing"
+  echo "{\"pr\":\"$PR_URL\",\"sha\":\"$PR_HEAD_SHA\",\"decision\":\"skip\",\"reason\":\"changes-requested\"}"
   exit 100
 fi
 

--- a/scripts/review-one-pr.sh
+++ b/scripts/review-one-pr.sh
@@ -40,7 +40,7 @@ echo "==> $PR_URL"
 #                NEUTRAL covers informational checks that don't gate merging.
 #      failing — anything else (FAILURE, ACTION_REQUIRED, TIMED_OUT, CANCELLED,
 #                STALE, STARTUP_FAILURE, or unknown conclusions)
-PR_SNAPSHOT=$(gh pr view "$PR_URL" --json headRefOid,statusCheckRollup,reviewDecision)
+PR_SNAPSHOT=$(gh pr view "$PR_URL" --json headRefOid,statusCheckRollup,reviewDecision,reviews)
 PR_HEAD_SHA=$(echo "$PR_SNAPSHOT" | jq -r '.headRefOid')
 export PR_HEAD_SHA
 echo "    head SHA: $PR_HEAD_SHA"
@@ -77,10 +77,23 @@ if [ "$CI_STATUS" = "pending" ]; then
   echo "{\"pr\":\"$PR_URL\",\"sha\":\"$PR_HEAD_SHA\",\"decision\":\"skip\",\"reason\":\"ci-pending\"}"
   exit 100
 fi
-if [ "$REVIEW_DECISION" = "CHANGES_REQUESTED" ]; then
-  echo "    skip: changes requested — awaiting author response before reviewing"
-  echo "{\"pr\":\"$PR_URL\",\"sha\":\"$PR_HEAD_SHA\",\"decision\":\"skip\",\"reason\":\"changes-requested\"}"
-  exit 100
+# Skip when a human has requested changes, with two guards:
+#   1. FORCE_REVIEW bypasses the skip — mention-triggered runs always proceed so
+#      authors can request a re-review after addressing feedback.
+#   2. Only skip when a CHANGES_REQUESTED review targets the current head SHA.
+#      On repos that don't dismiss stale reviews, reviewDecision can stay
+#      CHANGES_REQUESTED after the author pushes new commits; in that case the
+#      review is stale and the cascade should re-engage with the updated code.
+if [ "$REVIEW_DECISION" = "CHANGES_REQUESTED" ] && [ "${FORCE_REVIEW:-false}" != "true" ]; then
+  CHANGES_REQUESTED_AT_HEAD=$(echo "$PR_SNAPSHOT" | jq -r --arg sha "$PR_HEAD_SHA" '
+    [.reviews[] | select(.state == "CHANGES_REQUESTED" and .commit.oid == $sha)]
+    | if length > 0 then "true" else "false" end
+  ')
+  if [ "$CHANGES_REQUESTED_AT_HEAD" = "true" ]; then
+    echo "    skip: changes requested at current head — awaiting author response before reviewing"
+    echo "{\"pr\":\"$PR_URL\",\"sha\":\"$PR_HEAD_SHA\",\"decision\":\"skip\",\"reason\":\"changes-requested\"}"
+    exit 100
+  fi
 fi
 
 # 2. Idempotency: look for our marker at this SHA in existing reviews+comments.


### PR DESCRIPTION
## Summary

- Adds `reviewDecision` to the initial `gh pr view` snapshot (same API call as `headRefOid` and `statusCheckRollup` — no extra cost)
- Extracts and logs `REVIEW_DECISION` alongside the existing CI status line
- Skips (exit 100) any PR where `reviewDecision == CHANGES_REQUESTED` — positioned after the CI guards so cheapest/broadest checks run first

## Why

Reviewing a PR that already has "Changes Requested" from a human wastes tokens and produces confusing parallel feedback threads. The author needs to respond to existing feedback first; the bot re-engages after a new push (which resets the `reviewDecision`).

## Not changed

CI skipping (failing/pending → exit 100) was already implemented in `review-one-pr.sh` — no changes needed there.

## Test plan

- [ ] Trigger `workflow_dispatch` with a PR URL that has an open "Changes Requested" review — confirm log shows `skip: changes requested` and the PR is counted as a no-op (not against `MAX_PRS` budget)
- [ ] Trigger with a PR that has no review decision — confirm it proceeds normally through the cascade
- [ ] Trigger with an approved PR — confirm `REVIEW_DECISION=APPROVED` is logged and no skip fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)