### PR TITLE
fix(dev-lead): resolve context loss, missing checkout, and push logic

### DIFF
--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -83,6 +83,8 @@ jobs:
           echo "INTENT_HEAD_SHA=$(echo "$ctx"  | jq -r '.head_sha // ""')"  >> "$GITHUB_ENV"
           echo "INTENT_CHECKS=$(echo "$ctx"    | jq -c '.checks // []')"    >> "$GITHUB_ENV"
           echo "INTENT_ISSUE_NUMBER=$(echo "$ctx" | jq -r '.issue_number // ""')" >> "$GITHUB_ENV"
+          echo "INTENT_ACTOR=$(echo "$ctx" | jq -r '.actor // ""')" >> "$GITHUB_ENV"
+          echo "INTENT_COMMENT_BODY=$(echo "$ctx" | jq -r '.body // ""')" >> "$GITHUB_ENV"
 
       - name: Skip — log reason
         if: env.INTENT_TYPE == 'skip'
@@ -152,6 +154,8 @@ jobs:
         env:
           PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}
           HEAD_SHA: ${{ env.INTENT_HEAD_SHA }}
+          ACTOR: ${{ env.INTENT_ACTOR }}
+          COMMENT_BODY: ${{ env.INTENT_COMMENT_BODY }}
           REPO: ${{ github.repository }}
           REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
         run: bash scripts/dev-lead-fix-reviews.sh
@@ -162,6 +166,8 @@ jobs:
         env:
           PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}
           HEAD_SHA: ${{ env.INTENT_HEAD_SHA }}
+          ACTOR: ${{ env.INTENT_ACTOR }}
+          USER_INSTRUCTION: ${{ env.INTENT_COMMENT_BODY }}
           REPO: ${{ github.repository }}
           REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
         run: bash scripts/dev-lead-fix-reviews.sh

--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -245,8 +245,11 @@ case "$INTENT_TYPE" in
     build_and_run "fix-reviews" || rc=$?
     [ "$rc" -eq 2 ] && handle_rate_limit "fix-reviews"
     if [ "$rc" -eq 0 ]; then
-      commit_and_push "fix-reviews"
-      post_reviews_terminal "fix-reviews" "applied"
+      if commit_and_push "fix-reviews"; then
+        post_reviews_terminal "fix-reviews" "applied"
+      else
+        post_reviews_terminal "fix-reviews" "no-changes" "No changes were needed for the open review threads."
+      fi
     fi
     exit "$rc"
     ;;
@@ -300,8 +303,11 @@ case "$INTENT_TYPE" in
     build_and_run "human-pr" || rc=$?
     [ "$rc" -eq 2 ] && handle_rate_limit "human-pr"
     if [ "$rc" -eq 0 ]; then
-      commit_and_push "human-pr"
-      post_reviews_terminal "human-pr" "applied"
+      if commit_and_push "human-pr"; then
+        post_reviews_terminal "human-pr" "applied"
+      else
+        post_reviews_terminal "human-pr" "no-changes" "No changes were needed for this PR."
+      fi
     fi
     exit "$rc"
     ;;

--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -26,6 +26,11 @@ if [ -z "${HEAD_SHA:-}" ] && [ -n "${PR_NUMBER:-}" ] && [ "${DEV_LEAD_DRY_RUN:-f
   HEAD_SHA=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha' 2>/dev/null || true)
 fi
 
+# Checkout the PR branch for modification (Requirement 1)
+if [ "${DEV_LEAD_DRY_RUN:-false}" = "false" ] && [ -n "${PR_NUMBER:-}" ]; then
+  gh pr checkout "$PR_NUMBER" --repo "$REPO"
+fi
+
 build_and_run() {
   local template_name="$1"
   local prompt_file="/tmp/dev-lead-${template_name}-prompt-$$.md"
@@ -57,16 +62,54 @@ post_comment() {
 # intent completes. This prevents the retry cron from re-dispatching the same
 # intent on subsequent runs when the SHA hasn't changed.
 post_reviews_terminal() {
-  local intent="$1" status="${2:-applied}"
+  local intent="$1" status="${2:-applied}" summary="${3:-}"
   local sha_part=""
   [ -n "${HEAD_SHA:-}" ] && sha_part=" sha=${HEAD_SHA}"
   local marker="${REVIEWS_MARKER_PREFIX}${PR_NUMBER}${sha_part} intent=${intent} status=${status} -->"
+
+  local body="${marker}"
+  if [ -n "$summary" ]; then
+    body="${body}
+## Dev-Lead — ${intent} (${status})
+${summary}"
+  fi
+
   if [ "$DEV_LEAD_DRY_RUN" = "true" ]; then
     echo "[dry-run] would post reviews terminal marker: intent=${intent} status=${status}"
+    [ -n "$summary" ] && echo "$body"
     return 0
   fi
   # Best-effort: don't fail the overall script if the marker post fails
-  gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$marker" 2>/dev/null || true
+  gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$body" 2>/dev/null || true
+}
+
+# commit_and_push: adds all changes, commits with an intent-specific message,
+# and pushes to the PR branch. Returns 0 if changes were made and pushed,
+# 1 if no changes were found.
+commit_and_push() {
+  local intent="$1"
+  if git diff --quiet && git diff --cached --quiet; then
+    echo "::notice::No changes to commit for intent=${intent}"
+    return 1
+  fi
+
+  local commit_msg
+  case "$intent" in
+    fix-reviews)     commit_msg="fix(reviews): address review comments [skip ci-relay]" ;;
+    fix-bot-comment) commit_msg="fix(bot): address bot feedback [skip ci-relay]" ;;
+    human|human-pr)  commit_msg="chore: apply manual instructions [skip ci-relay]" ;;
+    rebase)          commit_msg="chore: resolve rebase conflicts [skip ci-relay]" ;;
+    *)               commit_msg="chore: dev-lead update (${intent}) [skip ci-relay]" ;;
+  esac
+
+  if [ "$DEV_LEAD_DRY_RUN" = "true" ]; then
+    echo "[dry-run] would git add, commit with '${commit_msg}', and push"
+  else
+    git add -A
+    git commit -m "$commit_msg"
+    git push
+  fi
+  return 0
 }
 
 # has_reviews_rate_limited_marker: returns 0 if a rate-limited marker for this
@@ -201,7 +244,10 @@ case "$INTENT_TYPE" in
     rc=0
     build_and_run "fix-reviews" || rc=$?
     [ "$rc" -eq 2 ] && handle_rate_limit "fix-reviews"
-    [ "$rc" -eq 0 ] && post_reviews_terminal "fix-reviews" "applied"
+    if [ "$rc" -eq 0 ]; then
+      commit_and_push "fix-reviews"
+      post_reviews_terminal "fix-reviews" "applied"
+    fi
     exit "$rc"
     ;;
   fix-bot-comment)
@@ -210,6 +256,13 @@ case "$INTENT_TYPE" in
     rc=0
     build_and_run "fix-bot-comment" || rc=$?
     [ "$rc" -eq 2 ] && handle_rate_limit "fix-bot-comment"
+    if [ "$rc" -eq 0 ]; then
+      if commit_and_push "fix-bot-comment"; then
+        post_reviews_terminal "fix-bot-comment" "applied" "Changes committed and pushed."
+      else
+        post_reviews_terminal "fix-bot-comment" "no-changes" "Engine ran but made no changes."
+      fi
+    fi
     exit "$rc"
     ;;
   human)
@@ -218,6 +271,13 @@ case "$INTENT_TYPE" in
     rc=0
     build_and_run "human" || rc=$?
     [ "$rc" -eq 2 ] && handle_rate_limit "human"
+    if [ "$rc" -eq 0 ]; then
+      if commit_and_push "human"; then
+        post_reviews_terminal "human" "applied" "Changes committed and pushed."
+      else
+        post_reviews_terminal "human" "no-changes" "Engine ran but made no changes."
+      fi
+    fi
     exit "$rc"
     ;;
   human-pr)
@@ -239,7 +299,10 @@ case "$INTENT_TYPE" in
     rc=0
     build_and_run "human-pr" || rc=$?
     [ "$rc" -eq 2 ] && handle_rate_limit "human-pr"
-    [ "$rc" -eq 0 ] && post_reviews_terminal "human-pr" "applied"
+    if [ "$rc" -eq 0 ]; then
+      commit_and_push "human-pr"
+      post_reviews_terminal "human-pr" "applied"
+    fi
     exit "$rc"
     ;;
   rebase)
@@ -253,14 +316,16 @@ case "$INTENT_TYPE" in
       echo "::error::PR_NUMBER is required for rebase"
       exit 1
     fi
-    gh pr checkout "$PR_NUMBER" --repo "$REPO"
     git fetch origin "$BASE_REF"
     CONFLICTING_FILES=$(git merge-tree "$(git merge-base HEAD "origin/${BASE_REF}")" HEAD "origin/${BASE_REF}" 2>/dev/null | grep "^changed in both" | awk '{print $NF}' || true)
     export CONFLICTING_FILES
     rc=0
     build_and_run "rebase" || rc=$?
     [ "$rc" -eq 2 ] && handle_rate_limit "rebase"
-    [ "$rc" -eq 0 ] && post_reviews_terminal "rebase" "applied"
+    if [ "$rc" -eq 0 ]; then
+      commit_and_push "rebase"
+      post_reviews_terminal "rebase" "applied"
+    fi
     exit "$rc"
     ;;
   *)

--- a/scripts/dev-lead-intent.sh
+++ b/scripts/dev-lead-intent.sh
@@ -215,7 +215,12 @@ case "$EVENT_NAME" in
     head_sha=$(jq -r '.pull_request.head.sha // empty' "$EVENT_PATH" 2>/dev/null || true)
     author_assoc=$(jq -r '.pull_request.author_association // empty' "$EVENT_PATH" 2>/dev/null || true)
 
-    context=$(printf '{"pr_number":%s,"head_sha":"%s"}' "${pr_number:-0}" "${head_sha:-}")
+    context=$(jq -nc \
+      --argjson pr_number "${pr_number:-0}" \
+      --arg head_sha "${head_sha:-}" \
+      --arg actor "${commenter:-}" \
+      --arg body "${comment_body:-}" \
+      '{"pr_number":$pr_number,"head_sha":$head_sha,"actor":$actor,"body":$body}')
 
     if is_trusted_bot "$commenter"; then
       emit_intent "fix-reviews" "bot-review-comment" "$context"
@@ -257,7 +262,11 @@ case "$EVENT_NAME" in
       exit 0
     fi
 
-    context=$(printf '{"pr_number":%s}' "${pr_number:-0}")
+    context=$(jq -nc \
+      --argjson pr_number "${pr_number:-0}" \
+      --arg actor "${commenter:-}" \
+      --arg body "${comment_body:-}" \
+      '{"pr_number":$pr_number,"actor":$actor,"body":$body}')
 
     if is_trusted_bot "$commenter"; then
       emit_intent "fix-bot-comment" "trusted-bot-comment" "$context"

--- a/scripts/review-one-pr.sh
+++ b/scripts/review-one-pr.sh
@@ -40,7 +40,7 @@ echo "==> $PR_URL"
 #                NEUTRAL covers informational checks that don't gate merging.
 #      failing — anything else (FAILURE, ACTION_REQUIRED, TIMED_OUT, CANCELLED,
 #                STALE, STARTUP_FAILURE, or unknown conclusions)
-PR_SNAPSHOT=$(gh pr view "$PR_URL" --json headRefOid,statusCheckRollup)
+PR_SNAPSHOT=$(gh pr view "$PR_URL" --json headRefOid,statusCheckRollup,reviewDecision)
 PR_HEAD_SHA=$(echo "$PR_SNAPSHOT" | jq -r '.headRefOid')
 export PR_HEAD_SHA
 echo "    head SHA: $PR_HEAD_SHA"
@@ -61,9 +61,12 @@ CI_STATUS=$(echo "$PR_SNAPSHOT" | jq -r '
 ')
 echo "    CI status: $CI_STATUS"
 
+REVIEW_DECISION=$(echo "$PR_SNAPSHOT" | jq -r '.reviewDecision // ""')
+echo "    review decision: $REVIEW_DECISION"
+
 # Exit code 100 is the skip sentinel: the caller treats any 100 exit as a
 # no-op and does not count it against the MAX_PRS review budget.
-# Reasons that produce a skip: already-reviewed-at-head, ci-failing, ci-pending.
+# Reasons that produce a skip: already-reviewed-at-head, ci-failing, ci-pending, changes-requested.
 if [ "$CI_STATUS" = "failing" ]; then
   echo "    skip: CI checks are failing — will re-evaluate after fixes are pushed"
   echo "{\"pr\":\"$PR_URL\",\"sha\":\"$PR_HEAD_SHA\",\"decision\":\"skip\",\"reason\":\"ci-failing\"}"
@@ -72,6 +75,11 @@ fi
 if [ "$CI_STATUS" = "pending" ]; then
   echo "    skip: CI checks still in progress — will re-evaluate when checks complete"
   echo "{\"pr\":\"$PR_URL\",\"sha\":\"$PR_HEAD_SHA\",\"decision\":\"skip\",\"reason\":\"ci-pending\"}"
+  exit 100
+fi
+if [ "$REVIEW_DECISION" = "CHANGES_REQUESTED" ]; then
+  echo "    skip: changes requested — awaiting author response before reviewing"
+  echo "{\"pr\":\"$PR_URL\",\"sha\":\"$PR_HEAD_SHA\",\"decision\":\"skip\",\"reason\":\"changes-requested\"}"
   exit 100
 fi
 

--- a/scripts/review-one-pr.sh
+++ b/scripts/review-one-pr.sh
@@ -40,7 +40,7 @@ echo "==> $PR_URL"
 #                NEUTRAL covers informational checks that don't gate merging.
 #      failing — anything else (FAILURE, ACTION_REQUIRED, TIMED_OUT, CANCELLED,
 #                STALE, STARTUP_FAILURE, or unknown conclusions)
-PR_SNAPSHOT=$(gh pr view "$PR_URL" --json headRefOid,statusCheckRollup,reviewDecision)
+PR_SNAPSHOT=$(gh pr view "$PR_URL" --json headRefOid,statusCheckRollup,reviewDecision,reviews)
 PR_HEAD_SHA=$(echo "$PR_SNAPSHOT" | jq -r '.headRefOid')
 export PR_HEAD_SHA
 echo "    head SHA: $PR_HEAD_SHA"
@@ -77,10 +77,23 @@ if [ "$CI_STATUS" = "pending" ]; then
   echo "{\"pr\":\"$PR_URL\",\"sha\":\"$PR_HEAD_SHA\",\"decision\":\"skip\",\"reason\":\"ci-pending\"}"
   exit 100
 fi
-if [ "$REVIEW_DECISION" = "CHANGES_REQUESTED" ]; then
-  echo "    skip: changes requested — awaiting author response before reviewing"
-  echo "{\"pr\":\"$PR_URL\",\"sha\":\"$PR_HEAD_SHA\",\"decision\":\"skip\",\"reason\":\"changes-requested\"}"
-  exit 100
+# Skip when a human has requested changes, with two guards:
+#   1. FORCE_REVIEW bypasses the skip — mention-triggered runs always proceed so
+#      authors can request a re-review after addressing feedback.
+#   2. Only skip when a CHANGES_REQUESTED review targets the current head SHA.
+#      On repos that don't dismiss stale reviews, reviewDecision can stay
+#      CHANGES_REQUESTED after the author pushes new commits; in that case the
+#      review is stale and the cascade should re-engage with the updated code.
+if [ "$REVIEW_DECISION" = "CHANGES_REQUESTED" ] && [ "${FORCE_REVIEW:-false}" != "true" ]; then
+  CHANGES_REQUESTED_AT_HEAD=$(echo "$PR_SNAPSHOT" | jq -r --arg sha "$PR_HEAD_SHA" '
+    [.reviews[] | select(.state == "CHANGES_REQUESTED" and .commit.oid == $sha)]
+    | if length > 0 then "true" else "false" end
+  ')
+  if [ "$CHANGES_REQUESTED_AT_HEAD" = "true" ]; then
+    echo "    skip: changes requested at current head — awaiting author response before reviewing"
+    echo "{\"pr\":\"$PR_URL\",\"sha\":\"$PR_HEAD_SHA\",\"decision\":\"skip\",\"reason\":\"changes-requested\"}"
+    exit 100
+  fi
 fi
 
 # 2. Idempotency: look for our marker at this SHA in existing reviews+comments.


### PR DESCRIPTION
This PR fixes the issue where the dev-lead workflow failed to handle bot comments and human mentions due to missing context and automation steps.

### Changes:
- **Context Preservation**: `dev-lead-intent.sh` now captures the actor and comment body.
- **Workflow Plumbing**: `dev-lead.yml` passes the new context to the agent scripts.
- **Automation Gap**: `dev-lead-fix-reviews.sh` now performs `gh pr checkout`, `git push`, and posts summaries back to the PR.

Closes #191 (internal tracking).