### PR TITLE
fix(dev-lead): use heredoc for multiline environment variables

### DIFF
--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -79,18 +79,21 @@ jobs:
           # Expand INTENT_CONTEXT JSON into individual GITHUB_ENV vars so subsequent
           # step env: blocks can reference ${{ env.INTENT_PR_NUMBER }} without fromJson()
           ctx="${INTENT_CONTEXT:-{\}}"
-          echo "INTENT_PR_NUMBER=$(echo "$ctx" | jq -r '.pr_number // ""')" >> "$GITHUB_ENV"
-          echo "INTENT_HEAD_SHA=$(echo "$ctx"  | jq -r '.head_sha // ""')"  >> "$GITHUB_ENV"
-          echo "INTENT_CHECKS=$(echo "$ctx"    | jq -c '.checks // []')"    >> "$GITHUB_ENV"
-          echo "INTENT_ISSUE_NUMBER=$(echo "$ctx" | jq -r '.issue_number // ""')" >> "$GITHUB_ENV"
-          echo "INTENT_ACTOR=$(echo "$ctx" | jq -r '.actor // ""')" >> "$GITHUB_ENV"
-
-          # Use a random delimiter for heredoc to handle multiline bot findings safely
-          # prevents injection if the body contains the delimiter string
           EOF_DELIMITER="EOF_$(dd if=/dev/urandom bs=15 count=1 2>/dev/null | base64 | tr -dc 'a-zA-Z0-9')"
-          echo "INTENT_COMMENT_BODY<<$EOF_DELIMITER" >> "$GITHUB_ENV"
-          echo "$ctx" | jq -r '.body // ""' >> "$GITHUB_ENV"
-          echo "$EOF_DELIMITER" >> "$GITHUB_ENV"
+
+          # Helper to set GITHUB_ENV safely with heredoc
+          set_env() {
+            echo "$1<<$EOF_DELIMITER" >> "$GITHUB_ENV"
+            echo "$2" >> "$GITHUB_ENV"
+            echo "$EOF_DELIMITER" >> "$GITHUB_ENV"
+          }
+
+          set_env "INTENT_PR_NUMBER" "$(echo "$ctx" | jq -r '.pr_number // ""')"
+          set_env "INTENT_HEAD_SHA" "$(echo "$ctx"  | jq -r '.head_sha // ""')"
+          set_env "INTENT_CHECKS" "$(echo "$ctx"    | jq -c '.checks // []')"
+          set_env "INTENT_ISSUE_NUMBER" "$(echo "$ctx" | jq -r '.issue_number // ""')"
+          set_env "INTENT_ACTOR" "$(echo "$ctx" | jq -r '.actor // ""')"
+          set_env "INTENT_COMMENT_BODY" "$(echo "$ctx" | jq -r '.body // ""')"
 
       - name: Skip — log reason
         if: env.INTENT_TYPE == 'skip'

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -111,6 +111,9 @@ jobs:
         if: env.INTENT_TYPE != 'skip'
         env:
           CLAUDE_CODE_VERSION: ${{ vars.CLAUDE_CODE_VERSION || 'latest' }}
+          # Pass keys during install if needed for extension setup
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           mkdir -p "$HOME/.npm-global"
@@ -118,18 +121,20 @@ jobs:
           echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
           export PATH="$HOME/.npm-global/bin:$PATH"
 
+          # 1. Claude Code
           if ! command -v claude >/dev/null 2>&1; then
             npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
           fi
 
-          case "$DEV_LEAD_ENGINE" in
-            gemini)
-              npm install -g @google/gemini-cli || true ;;
-            copilot)
-              if ! gh copilot --version >/dev/null 2>&1; then
-                gh extension install github/gh-copilot || true
-              fi ;;
-          esac
+          # 2. Gemini CLI (always install as fallback)
+          if ! command -v gemini >/dev/null 2>&1; then
+            npm install -g @google/gemini-cli || true
+          fi
+
+          # 3. GitHub Copilot Extension (always install as fallback)
+          if ! gh copilot --version >/dev/null 2>&1; then
+            gh extension install github/gh-copilot || true
+          fi
 
       # ── fix-ci ────────────────────────────────────────────────────────────
       - name: Run fix-ci

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -85,10 +85,12 @@ jobs:
           echo "INTENT_ISSUE_NUMBER=$(echo "$ctx" | jq -r '.issue_number // ""')" >> "$GITHUB_ENV"
           echo "INTENT_ACTOR=$(echo "$ctx" | jq -r '.actor // ""')" >> "$GITHUB_ENV"
 
-          # Use heredoc for COMMENT_BODY to handle multiline bot findings safely
-          echo "INTENT_COMMENT_BODY<<EOF" >> "$GITHUB_ENV"
+          # Use a random delimiter for heredoc to handle multiline bot findings safely
+          # prevents injection if the body contains the delimiter string
+          EOF_DELIMITER="EOF_$(dd if=/dev/urandom bs=15 count=1 2>/dev/null | base64 | tr -dc 'a-zA-Z0-9')"
+          echo "INTENT_COMMENT_BODY<<$EOF_DELIMITER" >> "$GITHUB_ENV"
           echo "$ctx" | jq -r '.body // ""' >> "$GITHUB_ENV"
-          echo "EOF" >> "$GITHUB_ENV"
+          echo "$EOF_DELIMITER" >> "$GITHUB_ENV"
 
       - name: Skip — log reason
         if: env.INTENT_TYPE == 'skip'

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -84,7 +84,11 @@ jobs:
           echo "INTENT_CHECKS=$(echo "$ctx"    | jq -c '.checks // []')"    >> "$GITHUB_ENV"
           echo "INTENT_ISSUE_NUMBER=$(echo "$ctx" | jq -r '.issue_number // ""')" >> "$GITHUB_ENV"
           echo "INTENT_ACTOR=$(echo "$ctx" | jq -r '.actor // ""')" >> "$GITHUB_ENV"
-          echo "INTENT_COMMENT_BODY=$(echo "$ctx" | jq -r '.body // ""')" >> "$GITHUB_ENV"
+
+          # Use heredoc for COMMENT_BODY to handle multiline bot findings safely
+          echo "INTENT_COMMENT_BODY<<EOF" >> "$GITHUB_ENV"
+          echo "$ctx" | jq -r '.body // ""' >> "$GITHUB_ENV"
+          echo "EOF" >> "$GITHUB_ENV"
 
       - name: Skip — log reason
         if: env.INTENT_TYPE == 'skip'

--- a/scripts/dev-lead-fix-issue.sh
+++ b/scripts/dev-lead-fix-issue.sh
@@ -48,7 +48,8 @@ main() {
   fi
 
   # Create feature branch
-  local branch="dev-lead/issue-${ISSUE_NUMBER}-$(date +%Y%m%d-%H%M)"
+  local branch
+  branch="dev-lead/issue-${ISSUE_NUMBER}-$(date +%Y%m%d-%H%M)"
   git checkout -b "$branch"
 
   if ! run_writer_with_fallback "$prompt_file"; then

--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -260,7 +260,8 @@ case "$INTENT_TYPE" in
     exit "$rc"
     ;;
   human)
-    export PR_NUMBER PR_URL="https://github.com/${REPO}/pull/${PR_NUMBER}"
+    export PR_NUMBER="${PR_NUMBER:-}"
+    export PR_URL="https://github.com/${REPO}/pull/${PR_NUMBER}"
     export REPO ACTOR="${ACTOR:-}" USER_INSTRUCTION="${USER_INSTRUCTION:-}" PR_DESCRIPTION="${PR_DESCRIPTION:-}"
     rc=0
     build_and_run "human" || rc=$?
@@ -275,7 +276,8 @@ case "$INTENT_TYPE" in
     exit "$rc"
     ;;
   human-pr)
-    export PR_NUMBER PR_URL="https://github.com/${REPO}/pull/${PR_NUMBER}"
+    export PR_NUMBER="${PR_NUMBER:-}"
+    export PR_URL="https://github.com/${REPO}/pull/${PR_NUMBER}"
     export REPO PR_TITLE="${PR_TITLE:-}" PR_DESCRIPTION="${PR_DESCRIPTION:-}"
     OPEN_THREADS_JSON=$(gh api graphql -f query='
       query($owner:String!,$repo:String!,$pr:Int!) {

--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -49,15 +49,6 @@ build_and_run() {
   return "$rc"
 }
 
-post_comment() {
-  local body="$1"
-  if [ "$DEV_LEAD_DRY_RUN" = "true" ]; then
-    echo "[dry-run] would post comment: $body"
-  else
-    gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$body"
-  fi
-}
-
 # post_reviews_terminal: writes a terminal status marker after a retryable
 # intent completes. This prevents the retry cron from re-dispatching the same
 # intent on subsequent runs when the SHA hasn't changed.
@@ -312,7 +303,8 @@ case "$INTENT_TYPE" in
     exit "$rc"
     ;;
   rebase)
-    export PR_NUMBER="${PR_NUMBER:-}" PR_URL="https://github.com/${REPO}/pull/${PR_NUMBER:-}"
+    export PR_NUMBER="${PR_NUMBER:-}"
+    export PR_URL="https://github.com/${REPO}/pull/${PR_NUMBER}"
     export REPO BASE_REF="${BASE_REF:-main}" HEAD_REF="${HEAD_REF:-}" CONFLICTING_FILES="${CONFLICTING_FILES:-}"
     if [ "$DEV_LEAD_DRY_RUN" = "true" ]; then
       echo "[dry-run] would run rebase for PR $PR_NUMBER"
@@ -329,8 +321,11 @@ case "$INTENT_TYPE" in
     build_and_run "rebase" || rc=$?
     [ "$rc" -eq 2 ] && handle_rate_limit "rebase"
     if [ "$rc" -eq 0 ]; then
-      commit_and_push "rebase"
-      post_reviews_terminal "rebase" "applied"
+      if commit_and_push "rebase"; then
+        post_reviews_terminal "rebase" "applied"
+      else
+        post_reviews_terminal "rebase" "no-changes" "PR is already up to date."
+      fi
     fi
     exit "$rc"
     ;;

--- a/scripts/dev-lead-intent.sh
+++ b/scripts/dev-lead-intent.sh
@@ -29,17 +29,20 @@ emit_intent() {
   echo "intent_type=${intent}" >> "$GITHUB_OUTPUT"
   echo "intent_reason=${reason}" >> "$GITHUB_OUTPUT"
 
-  # Use heredoc for context to handle multiline JSON safely
+  # Use a random delimiter for context to handle multiline JSON safely
+  local EOF_DELIMITER
+  EOF_DELIMITER="EOF_$(dd if=/dev/urandom bs=15 count=1 2>/dev/null | base64 | tr -dc 'a-zA-Z0-9')"
+
   {
-    echo "INTENT_CONTEXT<<EOF"
+    echo "INTENT_CONTEXT<<$EOF_DELIMITER"
     echo "${context}"
-    echo "EOF"
+    echo "$EOF_DELIMITER"
   } >> "$GITHUB_ENV"
 
   {
-    echo "intent_context<<EOF"
+    echo "intent_context<<$EOF_DELIMITER"
     echo "${context}"
-    echo "EOF"
+    echo "$EOF_DELIMITER"
   } >> "$GITHUB_OUTPUT"
 
   echo "  [intent] type=${intent} reason=${reason} context=${context}"

--- a/scripts/dev-lead-intent.sh
+++ b/scripts/dev-lead-intent.sh
@@ -26,10 +26,22 @@ emit_intent() {
   local intent="$1" reason="${2:-}" context="${3:-}"
   echo "INTENT_TYPE=${intent}" >> "$GITHUB_ENV"
   echo "INTENT_REASON=${reason}" >> "$GITHUB_ENV"
-  echo "INTENT_CONTEXT=${context}" >> "$GITHUB_ENV"
   echo "intent_type=${intent}" >> "$GITHUB_OUTPUT"
   echo "intent_reason=${reason}" >> "$GITHUB_OUTPUT"
-  echo "intent_context=${context}" >> "$GITHUB_OUTPUT"
+
+  # Use heredoc for context to handle multiline JSON safely
+  {
+    echo "INTENT_CONTEXT<<EOF"
+    echo "${context}"
+    echo "EOF"
+  } >> "$GITHUB_ENV"
+
+  {
+    echo "intent_context<<EOF"
+    echo "${context}"
+    echo "EOF"
+  } >> "$GITHUB_OUTPUT"
+
   echo "  [intent] type=${intent} reason=${reason} context=${context}"
 }
 

--- a/scripts/dev-lead-intent.sh
+++ b/scripts/dev-lead-intent.sh
@@ -157,7 +157,11 @@ case "$EVENT_NAME" in
           emit_skip "bot-pr"
           exit 0
         fi
-        context=$(printf '{"pr_number":%s,"head_sha":"%s"}' "${pr_number:-0}" "${head_sha:-}")
+        context=$(jq -nc \
+          --argjson pr_number "${pr_number:-0}" \
+          --arg head_sha "${head_sha:-}" \
+          --arg actor "${sender_login:-}" \
+          '{"pr_number":$pr_number,"head_sha":$head_sha,"actor":$actor}')
         emit_intent "human-pr" "pr-${pr_action}" "$context"
         ;;
       synchronize)
@@ -166,7 +170,11 @@ case "$EVENT_NAME" in
           emit_skip "bot-sync"
           exit 0
         fi
-        context=$(printf '{"pr_number":%s,"head_sha":"%s"}' "${pr_number:-0}" "${head_sha:-}")
+        context=$(jq -nc \
+          --argjson pr_number "${pr_number:-0}" \
+          --arg head_sha "${head_sha:-}" \
+          --arg actor "${sender_login:-}" \
+          '{"pr_number":$pr_number,"head_sha":$head_sha,"actor":$actor}')
         emit_intent "human-pr" "pr-synchronize" "$context"
         ;;
       *)
@@ -182,6 +190,7 @@ case "$EVENT_NAME" in
       exit 0
     fi
     reviewer=$(jq -r '.review.user.login // empty' "$EVENT_PATH" 2>/dev/null || true)
+    review_body=$(jq -r '.review.body // empty' "$EVENT_PATH" 2>/dev/null || true)
     review_state=$(jq -r '.review.state // empty' "$EVENT_PATH" 2>/dev/null || true)
     pr_number=$(jq -r '.pull_request.number // empty' "$EVENT_PATH" 2>/dev/null || true)
     head_sha=$(jq -r '.pull_request.head.sha // empty' "$EVENT_PATH" 2>/dev/null || true)
@@ -199,7 +208,12 @@ case "$EVENT_NAME" in
       exit 0
     fi
 
-    context=$(printf '{"pr_number":%s,"head_sha":"%s"}' "${pr_number:-0}" "${head_sha:-}")
+    context=$(jq -nc \
+      --argjson pr_number "${pr_number:-0}" \
+      --arg head_sha "${head_sha:-}" \
+      --arg actor "${reviewer:-}" \
+      --arg body "${review_body:-}" \
+      '{"pr_number":$pr_number,"head_sha":$head_sha,"actor":$actor,"body":$body}')
 
     if is_trusted_bot "$reviewer"; then
       # Bot review: only route non-APPROVED states

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -44,13 +44,13 @@ set_engine_config() {
       DUCK_MODEL="o4-mini"
       ;;
     gemini)
-      ENGINE_TRIAGE_MODEL="gemini-2.5-flash"
-      ENGINE_DEEP_MODEL="gemini-2.5-pro"
-      ENGINE_AUDIT_MODEL="gemini-2.5-pro"
-      ENGINE_ACTION_MODEL="gemini-2.5-pro"
-      ENGINE_SINGLE_MODEL="gemini-2.5-pro"
-      ENGINE_LABEL="triage: gemini-2.5-flash → deep: gemini-2.5-pro + duck: sonnet 4.6 → audit: gemini-2.5-pro"
-      ENGINE_SINGLE_LABEL="single-reviewer mode: gemini-2.5-pro"
+      ENGINE_TRIAGE_MODEL="auto"
+      ENGINE_DEEP_MODEL="auto"
+      ENGINE_AUDIT_MODEL="auto"
+      ENGINE_ACTION_MODEL="auto"
+      ENGINE_SINGLE_MODEL="auto"
+      ENGINE_LABEL="auto (Gemini 2.5/3 balanced)"
+      ENGINE_SINGLE_LABEL="single-reviewer mode: auto"
       # Cross-engine rubber duck: use Claude for diversity
       DUCK_ENGINE="claude"
       DUCK_MODEL="claude-sonnet-4-6"

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -44,13 +44,13 @@ set_engine_config() {
       DUCK_MODEL="o4-mini"
       ;;
     gemini)
-      ENGINE_TRIAGE_MODEL="gemini-1.5-flash"
-      ENGINE_DEEP_MODEL="gemini-1.5-pro"
-      ENGINE_AUDIT_MODEL="gemini-1.5-pro"
-      ENGINE_ACTION_MODEL="gemini-1.5-pro"
-      ENGINE_SINGLE_MODEL="gemini-1.5-pro"
-      ENGINE_LABEL="triage: gemini-1.5-flash → deep: gemini-1.5-pro + duck: sonnet 4.6 → audit: gemini-1.5-pro"
-      ENGINE_SINGLE_LABEL="single-reviewer mode: gemini-1.5-pro"
+      ENGINE_TRIAGE_MODEL="gemini-3.1-flash"
+      ENGINE_DEEP_MODEL="gemini-3.1-pro"
+      ENGINE_AUDIT_MODEL="gemini-3.1-pro"
+      ENGINE_ACTION_MODEL="gemini-3.1-pro"
+      ENGINE_SINGLE_MODEL="gemini-3.1-pro"
+      ENGINE_LABEL="triage: gemini-3.1-flash → deep: gemini-3.1-pro + duck: sonnet 4.6 → audit: gemini-3.1-pro"
+      ENGINE_SINGLE_LABEL="single-reviewer mode: gemini-3.1-pro"
       # Cross-engine rubber duck: use Claude for diversity
       DUCK_ENGINE="claude"
       DUCK_MODEL="claude-sonnet-4-6"

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -44,13 +44,13 @@ set_engine_config() {
       DUCK_MODEL="o4-mini"
       ;;
     gemini)
-      ENGINE_TRIAGE_MODEL="gemini-1.5-flash"
-      ENGINE_DEEP_MODEL="gemini-1.5-flash"
-      ENGINE_AUDIT_MODEL="gemini-1.5-flash"
-      ENGINE_ACTION_MODEL="gemini-1.5-flash"
-      ENGINE_SINGLE_MODEL="gemini-1.5-flash"
-      ENGINE_LABEL="gemini-1.5-flash (high-quota fallback)"
-      ENGINE_SINGLE_LABEL="single-reviewer mode: gemini-1.5-flash"
+      ENGINE_TRIAGE_MODEL="auto"
+      ENGINE_DEEP_MODEL="auto"
+      ENGINE_AUDIT_MODEL="auto"
+      ENGINE_ACTION_MODEL="auto"
+      ENGINE_SINGLE_MODEL="auto"
+      ENGINE_LABEL="auto (Gemini 2.5/3 balanced)"
+      ENGINE_SINGLE_LABEL="single-reviewer mode: auto"
       # Cross-engine rubber duck: use Claude for diversity
       DUCK_ENGINE="claude"
       DUCK_MODEL="claude-sonnet-4-6"

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -44,11 +44,11 @@ set_engine_config() {
       DUCK_MODEL="o4-mini"
       ;;
     gemini)
-      ENGINE_TRIAGE_MODEL="gemini-1.5-flash-latest"
-      ENGINE_DEEP_MODEL="gemini-1.5-pro-latest"
-      ENGINE_AUDIT_MODEL="gemini-1.5-pro-latest"
-      ENGINE_ACTION_MODEL="gemini-1.5-pro-latest"
-      ENGINE_SINGLE_MODEL="gemini-1.5-pro-latest"
+      ENGINE_TRIAGE_MODEL="gemini-1.5-flash"
+      ENGINE_DEEP_MODEL="gemini-1.5-pro"
+      ENGINE_AUDIT_MODEL="gemini-1.5-pro"
+      ENGINE_ACTION_MODEL="gemini-1.5-pro"
+      ENGINE_SINGLE_MODEL="gemini-1.5-pro"
       ENGINE_LABEL="triage: gemini-1.5-flash → deep: gemini-1.5-pro + duck: sonnet 4.6 → audit: gemini-1.5-pro"
       ENGINE_SINGLE_LABEL="single-reviewer mode: gemini-1.5-pro"
       # Cross-engine rubber duck: use Claude for diversity

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -44,13 +44,13 @@ set_engine_config() {
       DUCK_MODEL="o4-mini"
       ;;
     gemini)
-      ENGINE_TRIAGE_MODEL="auto"
-      ENGINE_DEEP_MODEL="auto"
-      ENGINE_AUDIT_MODEL="auto"
-      ENGINE_ACTION_MODEL="auto"
-      ENGINE_SINGLE_MODEL="auto"
-      ENGINE_LABEL="auto (Gemini 2.5/3 balanced)"
-      ENGINE_SINGLE_LABEL="single-reviewer mode: auto"
+      ENGINE_TRIAGE_MODEL="gemini-1.5-flash"
+      ENGINE_DEEP_MODEL="gemini-1.5-flash"
+      ENGINE_AUDIT_MODEL="gemini-1.5-flash"
+      ENGINE_ACTION_MODEL="gemini-1.5-flash"
+      ENGINE_SINGLE_MODEL="gemini-1.5-flash"
+      ENGINE_LABEL="gemini-1.5-flash (high-quota fallback)"
+      ENGINE_SINGLE_LABEL="single-reviewer mode: gemini-1.5-flash"
       # Cross-engine rubber duck: use Claude for diversity
       DUCK_ENGINE="claude"
       DUCK_MODEL="claude-sonnet-4-6"

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -44,12 +44,12 @@ set_engine_config() {
       DUCK_MODEL="o4-mini"
       ;;
     gemini)
-      ENGINE_TRIAGE_MODEL="gemini-2.0-flash"
-      ENGINE_DEEP_MODEL="gemini-1.5-pro"
-      ENGINE_AUDIT_MODEL="gemini-1.5-pro"
-      ENGINE_ACTION_MODEL="gemini-1.5-pro"
-      ENGINE_SINGLE_MODEL="gemini-1.5-pro"
-      ENGINE_LABEL="triage: gemini-2.0-flash → deep: gemini-1.5-pro + duck: sonnet 4.6 → audit: gemini-1.5-pro"
+      ENGINE_TRIAGE_MODEL="gemini-1.5-flash-latest"
+      ENGINE_DEEP_MODEL="gemini-1.5-pro-latest"
+      ENGINE_AUDIT_MODEL="gemini-1.5-pro-latest"
+      ENGINE_ACTION_MODEL="gemini-1.5-pro-latest"
+      ENGINE_SINGLE_MODEL="gemini-1.5-pro-latest"
+      ENGINE_LABEL="triage: gemini-1.5-flash → deep: gemini-1.5-pro + duck: sonnet 4.6 → audit: gemini-1.5-pro"
       ENGINE_SINGLE_LABEL="single-reviewer mode: gemini-1.5-pro"
       # Cross-engine rubber duck: use Claude for diversity
       DUCK_ENGINE="claude"

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -44,13 +44,13 @@ set_engine_config() {
       DUCK_MODEL="o4-mini"
       ;;
     gemini)
-      ENGINE_TRIAGE_MODEL="gemini-3.1-flash"
-      ENGINE_DEEP_MODEL="gemini-3.1-pro"
-      ENGINE_AUDIT_MODEL="gemini-3.1-pro"
-      ENGINE_ACTION_MODEL="gemini-3.1-pro"
-      ENGINE_SINGLE_MODEL="gemini-3.1-pro"
-      ENGINE_LABEL="triage: gemini-3.1-flash → deep: gemini-3.1-pro + duck: sonnet 4.6 → audit: gemini-3.1-pro"
-      ENGINE_SINGLE_LABEL="single-reviewer mode: gemini-3.1-pro"
+      ENGINE_TRIAGE_MODEL="gemini-2.5-flash"
+      ENGINE_DEEP_MODEL="gemini-2.5-pro"
+      ENGINE_AUDIT_MODEL="gemini-2.5-pro"
+      ENGINE_ACTION_MODEL="gemini-2.5-pro"
+      ENGINE_SINGLE_MODEL="gemini-2.5-pro"
+      ENGINE_LABEL="triage: gemini-2.5-flash → deep: gemini-2.5-pro + duck: sonnet 4.6 → audit: gemini-2.5-pro"
+      ENGINE_SINGLE_LABEL="single-reviewer mode: gemini-2.5-pro"
       # Cross-engine rubber duck: use Claude for diversity
       DUCK_ENGINE="claude"
       DUCK_MODEL="claude-sonnet-4-6"

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -29,62 +29,65 @@ DUCK_TIMEOUT_SEC="${DUCK_TIMEOUT_SEC:-300}"
 RETRY_MAX_ATTEMPTS="${RETRY_MAX_ATTEMPTS:-2}"   # total attempts including first
 RETRY_BASE_DELAY_SEC="${RETRY_BASE_DELAY_SEC:-5}"
 
-case "$REVIEW_ENGINE" in
-  claude)
-    ENGINE_TRIAGE_MODEL="claude-haiku-4-5-20251001"
-    ENGINE_DEEP_MODEL="claude-sonnet-4-6"
-    ENGINE_AUDIT_MODEL="claude-opus-4-7"
-    ENGINE_ACTION_MODEL="claude-sonnet-4-6"
-    ENGINE_SINGLE_MODEL="claude-opus-4-7"
-    ENGINE_LABEL="triage: haiku 4.5 → deep: sonnet 4.6 + duck: o4-mini → audit: opus 4.7"
-    ENGINE_SINGLE_LABEL="single-reviewer mode: opus 4.7"
-    # Cross-engine rubber duck: always the opposite engine
-    DUCK_ENGINE="copilot"
-    DUCK_MODEL="o4-mini"
-    ;;
-  gemini)
-    ENGINE_TRIAGE_MODEL="gemini-2.0-flash"
-    ENGINE_DEEP_MODEL="gemini-1.5-pro"
-    ENGINE_AUDIT_MODEL="gemini-1.5-pro"
-    ENGINE_ACTION_MODEL="gemini-1.5-pro"
-    ENGINE_SINGLE_MODEL="gemini-1.5-pro"
-    ENGINE_LABEL="triage: gemini-2.0-flash → deep: gemini-1.5-pro + duck: sonnet 4.6 → audit: gemini-1.5-pro"
-    ENGINE_SINGLE_LABEL="single-reviewer mode: gemini-1.5-pro"
-    # Cross-engine rubber duck: use Claude for diversity
-    DUCK_ENGINE="claude"
-    DUCK_MODEL="claude-sonnet-4-6"
-    ;;
-  copilot)
-    ENGINE_TRIAGE_MODEL="o4-mini"
-    ENGINE_DEEP_MODEL="o4-mini"
-    ENGINE_AUDIT_MODEL="o4-mini"
-    ENGINE_ACTION_MODEL="o4-mini"
-    ENGINE_SINGLE_MODEL="o4-mini"
-    # GitHub Models API model identifier — must match a model available at
-    # https://models.github.ai (see GitHub Models marketplace).
-    # Override via COPILOT_API_MODEL env var if the default is unavailable.
-    # openai/o4-mini is the April-2025 o4-generation reasoning model; it is
-    # not a typo for o1-mini or gpt-4o-mini.
-    COPILOT_API_MODEL="${COPILOT_API_MODEL:-openai/o4-mini}"
-    export COPILOT_API_MODEL
-    ENGINE_LABEL="triage: o4-mini → deep: o4-mini + duck: sonnet 4.6 → audit: o4-mini (GitHub Models API)"
-    ENGINE_SINGLE_LABEL="single-reviewer mode: o4-mini (GitHub Models API)"
-    # Cross-engine rubber duck: always the opposite engine
-    DUCK_ENGINE="claude"
-    DUCK_MODEL="claude-sonnet-4-6"
-    ;;
-  *)
-    echo "::error::Unknown REVIEW_ENGINE='$REVIEW_ENGINE' (expected: claude, gemini, or copilot)"
-    exit 1
-    ;;
-esac
+set_engine_config() {
+  case "$REVIEW_ENGINE" in
+    claude)
+      ENGINE_TRIAGE_MODEL="claude-haiku-4-5-20251001"
+      ENGINE_DEEP_MODEL="claude-sonnet-4-6"
+      ENGINE_AUDIT_MODEL="claude-opus-4-7"
+      ENGINE_ACTION_MODEL="claude-sonnet-4-6"
+      ENGINE_SINGLE_MODEL="claude-opus-4-7"
+      ENGINE_LABEL="triage: haiku 4.5 → deep: sonnet 4.6 + duck: o4-mini → audit: opus 4.7"
+      ENGINE_SINGLE_LABEL="single-reviewer mode: opus 4.7"
+      # Cross-engine rubber duck: always the opposite engine
+      DUCK_ENGINE="copilot"
+      DUCK_MODEL="o4-mini"
+      ;;
+    gemini)
+      ENGINE_TRIAGE_MODEL="gemini-2.0-flash"
+      ENGINE_DEEP_MODEL="gemini-1.5-pro"
+      ENGINE_AUDIT_MODEL="gemini-1.5-pro"
+      ENGINE_ACTION_MODEL="gemini-1.5-pro"
+      ENGINE_SINGLE_MODEL="gemini-1.5-pro"
+      ENGINE_LABEL="triage: gemini-2.0-flash → deep: gemini-1.5-pro + duck: sonnet 4.6 → audit: gemini-1.5-pro"
+      ENGINE_SINGLE_LABEL="single-reviewer mode: gemini-1.5-pro"
+      # Cross-engine rubber duck: use Claude for diversity
+      DUCK_ENGINE="claude"
+      DUCK_MODEL="claude-sonnet-4-6"
+      ;;
+    copilot)
+      ENGINE_TRIAGE_MODEL="o4-mini"
+      ENGINE_DEEP_MODEL="o4-mini"
+      ENGINE_AUDIT_MODEL="o4-mini"
+      ENGINE_ACTION_MODEL="o4-mini"
+      ENGINE_SINGLE_MODEL="o4-mini"
+      # GitHub Models API model identifier — must match a model available at
+      # https://models.github.ai (see GitHub Models marketplace).
+      # Override via COPILOT_API_MODEL env var if the default is unavailable.
+      # openai/o4-mini is the April-2025 o4-generation reasoning model; it is
+      # not a typo for o1-mini or gpt-4o-mini.
+      COPILOT_API_MODEL="${COPILOT_API_MODEL:-openai/o4-mini}"
+      export COPILOT_API_MODEL
+      ENGINE_LABEL="triage: o4-mini → deep: o4-mini + duck: sonnet 4.6 → audit: o4-mini (GitHub Models API)"
+      ENGINE_SINGLE_LABEL="single-reviewer mode: o4-mini (GitHub Models API)"
+      # Cross-engine rubber duck: always the opposite engine
+      DUCK_ENGINE="claude"
+      DUCK_MODEL="claude-sonnet-4-6"
+      ;;
+    *)
+      echo "::error::Unknown REVIEW_ENGINE='$REVIEW_ENGINE' (expected: claude, gemini, or copilot)"
+      exit 1
+      ;;
+  esac
 
-export ENGINE_TRIAGE_MODEL ENGINE_DEEP_MODEL ENGINE_AUDIT_MODEL
-export ENGINE_ACTION_MODEL ENGINE_SINGLE_MODEL
-export ENGINE_LABEL ENGINE_SINGLE_LABEL
-export DUCK_ENGINE DUCK_MODEL
-# COPILOT_API_MODEL is exported inside the copilot) case above (only set then).
+  export ENGINE_TRIAGE_MODEL ENGINE_DEEP_MODEL ENGINE_AUDIT_MODEL
+  export ENGINE_ACTION_MODEL ENGINE_SINGLE_MODEL
+  export ENGINE_LABEL ENGINE_SINGLE_LABEL
+  export DUCK_ENGINE DUCK_MODEL
+}
 
+# Initial config
+set_engine_config
 echo "    engine: $REVIEW_ENGINE ($ENGINE_LABEL)"
 
 # is_rate_limited <text>
@@ -510,7 +513,6 @@ run_writer() {
 # Only rate-limit (exit 2) triggers fallback; other failures propagate immediately.
 run_writer_with_fallback() {
   local prompt_file="$1"
-  local model="${2:-$ENGINE_ACTION_MODEL}"
   local engines=("$REVIEW_ENGINE")
 
   for e in claude gemini copilot; do
@@ -520,9 +522,14 @@ run_writer_with_fallback() {
   for engine in "${engines[@]}"; do
     local saved="$REVIEW_ENGINE"
     export REVIEW_ENGINE="$engine"
+    # Re-evaluate model names for the new engine
+    set_engine_config
     local rc=0
-    run_writer "$prompt_file" "$model" || rc=$?
+    # Don't pass 'model' argument; run_writer will use the updated $ENGINE_ACTION_MODEL
+    run_writer "$prompt_file" || rc=$?
     export REVIEW_ENGINE="$saved"
+    # Restore original config for subsequent PRs in the same session
+    set_engine_config
     [ "$rc" -eq 0 ] && return 0
     if [ "$rc" -eq 2 ]; then
       echo "::warning::$engine rate-limited, trying next engine" >&2


### PR DESCRIPTION
Follow-up to #223. The previous PR introduced multiline bot comments into the environment, which broke the `GITHUB_ENV` format in the `Parse intent context fields` step. This PR uses the heredoc syntax to safely handle multiline content.