### PR TITLE
feat(fleet-monitor): track high-failure workflows as Issues with dev-lead label

### DIFF
--- a/.github/workflows/actions-fleet-monitor.yml
+++ b/.github/workflows/actions-fleet-monitor.yml
@@ -1,3 +1,18 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github-private/.github/workflows/actions-fleet-monitor.yml
+# Standard:        petry-projects/.github/standards/ci-standards.md
+#
+# AGENTS — READ BEFORE EDITING:
+#   • This is the canonical fleet-monitor implementation; there is no external
+#     reusable. The scanning logic lives in scripts/fleet_monitor.sh and
+#     scripts/fleet_report.sh.
+#   • The "Track high-failure workflows as Issues" step uses github.token (not
+#     the PAT) because the PAT lacks label-assignment rights on this repo.
+#     Dev-Lead Agent is explicitly woken via repository_dispatch in the
+#     "Dispatch dev-lead for critical items" step below.
+#   • Do NOT change checkout ref from 'main' — the github.ref_name variant is
+#     for feature-branch testing only and must never reach production.
+# ─────────────────────────────────────────────────────────────────────────────
 name: Actions Fleet Monitor
 
 on:
@@ -50,8 +65,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: petry-projects/.github-private
-          # TEST: use calling branch so feature-branch scripts are available; revert to 'main' before merge
-          ref: ${{ github.ref_name }}
+          ref: main  # Always checkout .github-private@main; workflow_call callers target @main per docs
           token: ${{ secrets.DON_PETRY_BOT_GH_PAT }}
 
       - name: Run fleet monitor
@@ -149,7 +163,7 @@ jobs:
                   'is:open',
                   `in:title`,
                   `"${title}"`,
-                ].join('+'),
+                ].join(' '),
               });
               const existing = results.items.find(i => i.title === title);
 
@@ -163,7 +177,7 @@ jobs:
                 await github.rest.issues.addLabels({
                   owner: context.repo.owner, repo: context.repo.repo,
                   issue_number: existing.number,
-                  labels: ['dev-lead', 'fleet-tracker'],
+                  labels: ['dev-lead', 'fleet-tracker', 'health-check'],
                 });
                 core.notice(`Updated issue #${existing.number}: ${existing.html_url}`);
               } else {
@@ -176,6 +190,19 @@ jobs:
                 core.notice(`Created issue #${created.data.number}: ${created.data.html_url}`);
               }
             }
+
+
+      - name: Dispatch dev-lead for critical items
+        if: env.HIGH_FAILURE_COUNT != '' && env.HIGH_FAILURE_COUNT != '0'
+        env:
+          GH_TOKEN: ${{ secrets.DON_PETRY_BOT_GH_PAT }}
+        run: |
+          # github.token events do not trigger issues:labeled workflows; use the
+          # PAT to fire repository_dispatch so Dev-Lead Agent is explicitly woken.
+          gh api "repos/${{ github.repository }}/dispatches" \
+            -X POST \
+            -f event_type=dev-lead-ci-failure \
+            -f 'client_payload={"source":"fleet-monitor","count":"${{ env.HIGH_FAILURE_COUNT }}"}'
 
       - name: Annotate clean run
         if: env.HAS_FAILURES != 'true'

--- a/.github/workflows/actions-fleet-monitor.yml
+++ b/.github/workflows/actions-fleet-monitor.yml
@@ -91,8 +91,8 @@ jobs:
         env:
           ORG: ${{ env.ORG }}
         with:
-          # Use the PAT so label creation and cross-repo context both work
-          github-token: ${{ secrets.DON_PETRY_BOT_GH_PAT }}
+          # Use GITHUB_TOKEN (has explicit issues:write) for label creation and assignment
+          github-token: ${{ github.token }}
           script: |
             const fs = require('fs');
 

--- a/.github/workflows/actions-fleet-monitor.yml
+++ b/.github/workflows/actions-fleet-monitor.yml
@@ -83,6 +83,99 @@ jobs:
             });
             core.notice(`Issue created: ${issue.data.html_url}`);
 
+
+      - name: Track high-failure workflows as Issues
+        if: hashFiles('fleet_high_failure.json') != ''
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          ORG: ${{ env.ORG }}
+        with:
+          # Use the PAT so label creation and cross-repo context both work
+          github-token: ${{ secrets.DON_PETRY_BOT_GH_PAT }}
+          script: |
+            const fs = require('fs');
+
+            const raw = fs.readFileSync('fleet_high_failure.json', 'utf8').trim();
+            const items = JSON.parse(raw || '[]');
+            if (!items.length) {
+              core.info('No workflows with >10% failure rate — nothing to track.');
+              return;
+            }
+
+            // Ensure required labels exist (422 = already exists — safe to ignore)
+            for (const [name, color, desc] of [
+              ['dev-lead',      'd93f0b', 'Requires dev-lead attention'],
+              ['fleet-tracker', '0075ca', 'Tracked by the Actions Fleet Monitor'],
+            ]) {
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  name, color, description: desc,
+                });
+              } catch (e) { if (e.status !== 422) throw e; }
+            }
+
+            const labelEmoji = { CRITICAL: '🔴', DEGRADED: '🟠', WARNING: '🟡', ERROR: '⚫' };
+            const today = new Date().toISOString().split('T')[0];
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+
+            for (const item of items) {
+              const emoji   = labelEmoji[item.label] ?? '🔴';
+              const title   = `[Fleet Monitor] ${item.repo} — ${item.workflow}`;
+              const body    = [
+                `## ${emoji} ${item.label}: \`${item.repo}\` / \`${item.workflow}\``,
+                '',
+                `| Metric | Value |`,
+                `|---|---|`,
+                `| **Failure Rate** | ${item.rate} (${item.failed} / ${item.total} runs) |`,
+                `| **Status** | ${item.label} |`,
+                `| **p50 Duration** | ${item.p50}s |`,
+                `| **p95 Duration** | ${item.p95}s |`,
+                `| **Successful Runs** | ${item.success} |`,
+                `| **Cancelled Runs** | ${item.cancelled} |`,
+                '',
+                `**Workflow:** [\`${item.workflow}\`](https://github.com/${item.repo}/actions)`,
+                '',
+                `> _Last updated by [Fleet Monitor run](${runUrl}) on ${today}._`,
+                `> _Threshold: failure rate > 10% over the monitored window._`,
+              ].join('\n');
+
+              // Search for an existing open issue with this exact title
+              const { data: results } = await github.rest.search.issuesAndPullRequests({
+                q: [
+                  `repo:${context.repo.owner}/${context.repo.repo}`,
+                  'is:issue',
+                  'is:open',
+                  `in:title`,
+                  `"${title}"`,
+                ].join('+'),
+              });
+              const existing = results.items.find(i => i.title === title);
+
+              if (existing) {
+                await github.rest.issues.update({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  issue_number: existing.number,
+                  body,
+                });
+                // Ensure dev-lead label is present (addLabels is idempotent)
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  issue_number: existing.number,
+                  labels: ['dev-lead', 'fleet-tracker'],
+                });
+                core.notice(`Updated issue #${existing.number}: ${existing.html_url}`);
+              } else {
+                const created = await github.rest.issues.create({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  title,
+                  body,
+                  labels: ['dev-lead', 'fleet-tracker', 'health-check'],
+                });
+                core.notice(`Created issue #${created.data.number}: ${created.data.html_url}`);
+              }
+            }
+
       - name: Annotate clean run
         if: env.HAS_FAILURES != 'true'
         run: |

--- a/.github/workflows/actions-fleet-monitor.yml
+++ b/.github/workflows/actions-fleet-monitor.yml
@@ -50,7 +50,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: petry-projects/.github-private
-          ref: main  # Always checkout .github-private@main; workflow_call callers target @main per docs
+          # TEST: use calling branch so feature-branch scripts are available; revert to 'main' before merge
+          ref: ${{ github.ref_name }}
           token: ${{ secrets.DON_PETRY_BOT_GH_PAT }}
 
       - name: Run fleet monitor

--- a/scripts/fleet_monitor.sh
+++ b/scripts/fleet_monitor.sh
@@ -196,6 +196,45 @@ fi
 { report_header; generate_report "$metrics_file" "$failed_file" "true"; } \
   > "$REPORT_FILE"
 
+# ---------------------------------------------------------------------------
+# 3b. Export high-failure items as JSON for per-workflow issue tracking (>10%)
+# ---------------------------------------------------------------------------
+# Reads the raw metrics TSV and produces fleet_high_failure.json — an array of
+# objects for every workflow whose failure rate exceeds 10%. The downstream
+# "Track high-failure workflows" step reads this file to find/update or create
+# a tracked GitHub Issue for each item and apply the dev-lead label.
+HIGH_FAILURE_FILE="fleet_high_failure.json"
+if [ -s "$metrics_file" ]; then
+  jq -Rsn '
+    [inputs | split("\n")[] | select(length > 0) | split("\t") |
+     select(length >= 12) |
+     {
+       sort_key:  .[0],
+       repo:      .[1],
+       workflow:  .[2],
+       total:    (.[3]  | tonumber? // 0),
+       success:  (.[4]  | tonumber? // 0),
+       failed:   (.[5]  | tonumber? // 0),
+       cancelled:(.[6]  | tonumber? // 0),
+       rate:      .[7],
+       p50:      (.[8]  | tonumber? // 0),
+       p95:      (.[9]  | tonumber? // 0),
+       label:     .[10],
+       rate_int: (.[11] | tonumber? // 0)
+     }] |
+    map(select(
+      .rate_int > 10 and
+      (.label | IN("WARNING","DEGRADED","CRITICAL","ERROR"))
+    )) |
+    sort_by(.rate_int) | reverse
+  ' < "$metrics_file" > "$HIGH_FAILURE_FILE"
+  hf_count=$(jq 'length' "$HIGH_FAILURE_FILE")
+  echo "High-failure items (>10%): ${hf_count}"
+  [ -n "${GITHUB_ENV:-}" ] && echo "HIGH_FAILURE_COUNT=${hf_count}" >> "$GITHUB_ENV"
+else
+  echo "[]" > "$HIGH_FAILURE_FILE"
+fi
+
 rm -f "$metrics_file" "$failed_file"
 
 # ---------------------------------------------------------------------------

--- a/scripts/fleet_monitor.sh
+++ b/scripts/fleet_monitor.sh
@@ -205,9 +205,8 @@ fi
 # a tracked GitHub Issue for each item and apply the dev-lead label.
 HIGH_FAILURE_FILE="fleet_high_failure.json"
 if [ -s "$metrics_file" ]; then
-  jq -Rsn '
-    [inputs | split("\n")[] | select(length > 0) | split("\t") |
-     select(length >= 12) |
+  jq -Rn '
+    [inputs | select(length > 0) | split("\t") | select(length >= 12) |
      {
        sort_key:  .[0],
        repo:      .[1],
@@ -222,11 +221,22 @@ if [ -s "$metrics_file" ]; then
        label:     .[10],
        rate_int: (.[11] | tonumber? // 0)
      }] |
+    # Apply confidence filter: CRITICAL rows with < 5 total runs become LOW-CONF
+    map(if .label == "CRITICAL" and .total < 5 then .label = "LOW-CONF" else . end) |
+    # Keep trackable items:
+    #   ERROR rows (monitor could not read runs — always noteworthy regardless of rate)
+    #   WARNING/DEGRADED/CRITICAL with exact failure rate > 10%
+    #   (uses .failed/.total directly to avoid integer-truncation false negatives)
     map(select(
-      .rate_int > 10 and
-      (.label | IN("WARNING","DEGRADED","CRITICAL","ERROR"))
+      .label == "ERROR" or
+      (
+        .label != "LOW-CONF" and
+        (.label | IN("WARNING","DEGRADED","CRITICAL")) and
+        .total > 0 and
+        (.failed * 100.0 / .total > 10)
+      )
     )) |
-    sort_by(.rate_int) | reverse
+    sort_by(.failed * 100.0 / (if .total > 0 then .total else 1 end)) | reverse
   ' < "$metrics_file" > "$HIGH_FAILURE_FILE"
   hf_count=$(jq 'length' "$HIGH_FAILURE_FILE")
   echo "High-failure items (>10%): ${hf_count}"


### PR DESCRIPTION
## Summary

Enhances the Actions Fleet Monitor to **find/update or create a dedicated GitHub Issue** for every workflow whose failure rate exceeds **10%**, and applies the `dev-lead` label automatically.

## Changes

### `scripts/fleet_monitor.sh`
- **New section 3b** runs after metrics collection (before temp-file cleanup).
- Uses `jq` to parse the raw metrics TSV and emit `fleet_high_failure.json` — an array of all workflows with `rate_int > 10` (covers WARNING ≥10%, DEGRADED ≥20%, CRITICAL ≥50%, ERROR).
- Exports `HIGH_FAILURE_COUNT` to `GITHUB_ENV` for downstream logging.

### `.github/workflows/actions-fleet-monitor.yml`
- **New step: Track high-failure workflows as Issues** (runs after `Run fleet monitor`, before `Annotate clean run`).
- Reads `fleet_high_failure.json`; no-ops if the file is absent or empty.
- Creates `dev-lead` and `fleet-tracker` labels on first run (idempotent — 422 ignored).
- For each high-failure item:
  - Searches for an existing **open** Issue titled `[Fleet Monitor] repo — workflow.yml`
  - **Updates** body + ensures `dev-lead` / `fleet-tracker` labels if found
  - **Creates** a new Issue with those labels if not found
- Emits `core.notice` annotations for every created/updated Issue URL.

## Testing
Triggered a `workflow_dispatch` run with `lookback_days=30` to surface real CRITICAL items. See linked Issue for results.

## Labels created
| Label | Color | Purpose |
|---|---|---|
| `dev-lead` | 🔴 `#d93f0b` | Requires dev-lead attention |
| `fleet-tracker` | 🔵 `#0075ca` | Tracked by the Actions Fleet Monitor |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflows exceeding failure thresholds are now automatically tracked as repository issues with deterministic titles and applied labels for easier triage.
  * Issues are created or updated with per-workflow metrics (failure counts/rates, duration percentiles) and links to runs for investigation.
  * A high-failure JSON report is produced after fleet metrics run and the high-failure count is exported for use in subsequent steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/petry-projects/.github-private/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->