### PR TITLE
fix(dev-lead): detect engine-committed changes; remove commit instructions from prompts

### DIFF
--- a/prompts/dev-lead/fix-bot-comment.md
+++ b/prompts/dev-lead/fix-bot-comment.md
@@ -23,7 +23,6 @@ Analyze the bot's findings and address each actionable issue:
 2. Locate the referenced files and line numbers using Read/Grep/Glob tools
 3. Apply targeted fixes using Edit/Write tools
 4. Verify that the fixes are complete and do not introduce regressions
-5. Commit changes with a message: `fix(bot): address ${ACTOR} findings on PR #${PR_NUMBER}`
 
 ## Constraints
 
@@ -32,7 +31,7 @@ Analyze the bot's findings and address each actionable issue:
 - Do not suppress bot rules without a documented reason
 - Do not modify the bot's configuration files
 - Stay within the scope of the pull request's changed files where possible
-- Do not push to remote — the CI workflow will handle that
+- Do not commit or push — the CI workflow handles git operations after you finish
 
 ## Output Format
 

--- a/prompts/dev-lead/fix-ci.md
+++ b/prompts/dev-lead/fix-ci.md
@@ -32,7 +32,6 @@ Analyze the CI failure logs and annotations above, then fix the root cause(s). Y
 2. Locate the relevant source files using Read/Grep/Glob tools
 3. Apply targeted fixes using the Edit/Write tools
 4. Verify your fixes are consistent with the rest of the codebase
-5. Commit the changes with a descriptive message: `fix(ci): resolve ${CHECK_NAME} failures`
 
 ## Constraints
 
@@ -40,7 +39,7 @@ Analyze the CI failure logs and annotations above, then fix the root cause(s). Y
 - Do not modify test expectations to make tests pass artificially
 - Do not suppress linting rules unless absolutely necessary (add a comment explaining why)
 - Stay within the scope of the failing check: `${CHECK_NAME}`
-- Do not push to remote — the CI workflow will handle that
+- Do not commit or push — the CI workflow handles git operations after you finish
 
 ## Output Format
 
@@ -48,5 +47,4 @@ After applying fixes, output a brief summary:
 ```
 Fixed: <description of what was fixed>
 Files changed: <list of files>
-Commit: <commit SHA or "pending">
 ```

--- a/prompts/dev-lead/fix-issue.md
+++ b/prompts/dev-lead/fix-issue.md
@@ -20,20 +20,16 @@ Implement the feature or fix described in the issue:
 
 1. Analyze the issue description to understand the full scope of work
 2. Explore the codebase using Read/Grep/Glob tools to understand the relevant patterns
-3. Create a new branch (if not already on one): `git checkout -b fix/${ISSUE_NUMBER}-brief-slug` or `feat/${ISSUE_NUMBER}-brief-slug`
-4. Implement the changes using Edit/Write/Bash tools
-5. Write or update tests as needed
-6. Commit with a message referencing the issue: `feat: implement ${ISSUE_TITLE} (closes #${ISSUE_NUMBER})`
-7. Open a pull request referencing the issue
+3. Implement the changes using Edit/Write/Bash tools
+4. Write or update tests as needed
 
 ## Constraints
 
 - Follow the org standards in `${ORG_STANDARDS_HINT}` — check AGENTS.md and any referenced standards docs
 - Do not implement more than what the issue requests
 - Add tests for new functionality
-- Keep commits atomic and well-described
 - Do not modify unrelated files
-- Do not push to remote without creating a PR — use `gh pr create` to open a draft PR when ready
+- Do not commit, push, or open PRs — the CI workflow handles all git operations after you finish
 
 ## Output Format
 

--- a/prompts/dev-lead/fix-reviews.md
+++ b/prompts/dev-lead/fix-reviews.md
@@ -26,16 +26,15 @@ For each open review thread, address the feedback by:
 4. Ensuring the fix aligns with existing code patterns and style
 
 After addressing all threads:
-- Commit all changes with a message like: `fix(reviews): address PR #${PR_NUMBER} review feedback`
 - Do not resolve the threads yourself — they will be resolved automatically when the conversation is updated
 
 ## Constraints
 
-- Address each open thread individually — do not batch unrelated changes into one commit
+- Address each open thread individually
 - Do not make changes beyond what the review threads request
 - If a review thread is ambiguous, apply the most conservative interpretation
 - Do not modify files that are not referenced in the review threads
-- Do not push to remote — the CI workflow will handle that
+- Do not commit or push — the CI workflow handles git operations after you finish
 
 ## Output Format
 

--- a/prompts/dev-lead/human-pr.md
+++ b/prompts/dev-lead/human-pr.md
@@ -30,7 +30,6 @@ Address every open review thread from the human reviewers:
 2. Use Read/Grep/Glob tools to examine the referenced code and surrounding context
 3. Apply the requested changes using Edit/Write tools
 4. Ensure your changes align with the PR's overall purpose and do not break existing functionality
-5. Commit the changes with: `fix(pr): address review feedback on PR #${PR_NUMBER}`
 
 ## Constraints
 
@@ -39,7 +38,7 @@ Address every open review thread from the human reviewers:
 - Do not dismiss or skip any thread without a documented reason
 - Maintain the existing code style and patterns
 - Run any available test commands to verify fixes where possible
-- Do not push to remote — the CI workflow will handle that
+- Do not commit or push — the CI workflow handles git operations after you finish
 
 ## Output Format
 

--- a/prompts/dev-lead/human.md
+++ b/prompts/dev-lead/human.md
@@ -27,15 +27,15 @@ Carry out the instruction exactly as requested by `${ACTOR}`:
 1. Read the instruction carefully and identify the specific action required
 2. Use Read/Grep/Glob tools to understand the relevant code
 3. Apply the requested changes using Edit/Write/Bash tools as needed
-4. Commit the changes with an appropriate message that references the instruction
-5. If the instruction is ambiguous, apply the most reasonable interpretation and note it in your output
+4. If the instruction is ambiguous, apply the most reasonable interpretation and note it in your output
 
 ## Constraints
 
 - Execute the instruction faithfully — do not substitute your own judgment for the requester's intent
 - If the instruction would break tests or CI, still apply it but note the potential issue in your output
 - Do not make unrelated improvements
-- Do not push to remote — the CI workflow will handle that
+- Do not commit or push — the CI workflow handles git operations after you finish
+- If the instruction is unsafe (e.g., deletes critical security checks, exposes secrets), decline and explain why
 - If the instruction is unsafe (e.g., deletes critical security checks, exposes secrets), decline and explain why
 
 ## Output Format

--- a/prompts/dev-lead/human.md
+++ b/prompts/dev-lead/human.md
@@ -36,7 +36,6 @@ Carry out the instruction exactly as requested by `${ACTOR}`:
 - Do not make unrelated improvements
 - Do not commit or push — the CI workflow handles git operations after you finish
 - If the instruction is unsafe (e.g., deletes critical security checks, exposes secrets), decline and explain why
-- If the instruction is unsafe (e.g., deletes critical security checks, exposes secrets), decline and explain why
 
 ## Output Format
 

--- a/scripts/dev-lead-fix-ci.sh
+++ b/scripts/dev-lead-fix-ci.sh
@@ -229,15 +229,29 @@ main() {
       exit 1
     fi
 
-    # Check if there are changes to commit
-    if git diff --quiet && git diff --cached --quiet; then
+    # Check if there are changes to push.
+    # git status --porcelain catches untracked files that git diff misses.
+    # Also detect engine-committed-but-not-pushed changes via upstream comparison.
+    local has_uncommitted=false has_unpushed=false
+    [ -n "$(git status --porcelain)" ] && has_uncommitted=true
+    local upstream
+    upstream=$(git rev-parse --abbrev-ref --symbolic-full-name "@{u}" 2>/dev/null || true)
+    if [ -n "$upstream" ]; then
+      git log "${upstream}..HEAD" --oneline 2>/dev/null | grep -q . && has_unpushed=true
+    elif [ -n "${HEAD_SHA:-}" ]; then
+      git log "${HEAD_SHA}..HEAD" --oneline 2>/dev/null | grep -q . && has_unpushed=true
+    fi
+
+    if ! $has_uncommitted && ! $has_unpushed; then
       echo "  [fix-ci] no changes made by engine"
       post_summary "no-changes" "Engine ran but made no changes."
       exit 0
     fi
 
-    git add -A
-    git commit -m "fix(ci): auto-fix for $(echo "$CHECKS_JSON" | jq -r '.[0].name // "CI failure"') [skip ci-relay]"
+    if $has_uncommitted; then
+      git add -A
+      git commit -m "fix(ci): auto-fix for $(echo "$CHECKS_JSON" | jq -r '.[0].name // "CI failure"') [skip ci-relay]"
+    fi
     git push
 
     post_summary "applied" "Fix committed and pushed. Waiting for CI."

--- a/scripts/dev-lead-fix-issue.sh
+++ b/scripts/dev-lead-fix-issue.sh
@@ -51,6 +51,8 @@ main() {
   local branch
   branch="dev-lead/issue-${ISSUE_NUMBER}-$(date +%Y%m%d-%H%M)"
   git checkout -b "$branch"
+  local pre_engine_sha
+  pre_engine_sha=$(git rev-parse HEAD)
 
   if ! run_writer_with_fallback "$prompt_file"; then
     echo "::error::Engine failed to implement issue #${ISSUE_NUMBER}"
@@ -58,14 +60,22 @@ main() {
     exit 1
   fi
 
-  if git diff --quiet && git diff --cached --quiet; then
+  # git status --porcelain catches untracked files that git diff misses.
+  # Compare HEAD to pre-engine SHA to detect commits the engine made via Bash.
+  local has_uncommitted=false has_unpushed=false
+  [ -n "$(git status --porcelain)" ] && has_uncommitted=true
+  [ "$(git rev-parse HEAD)" != "$pre_engine_sha" ] && has_unpushed=true
+
+  if ! $has_uncommitted && ! $has_unpushed; then
     echo "::notice::No changes made for issue #${ISSUE_NUMBER}"
     rm -f "$prompt_file"
     exit 0
   fi
 
-  git add -A
-  git commit -m "feat: implement issue #${ISSUE_NUMBER} — ${ISSUE_TITLE}"
+  if $has_uncommitted; then
+    git add -A
+    git commit -m "feat: implement issue #${ISSUE_NUMBER} — ${ISSUE_TITLE}"
+  fi
   git push --set-upstream origin "$branch"
 
   gh pr create \

--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -74,18 +74,28 @@ ${summary}"
   gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$body" 2>/dev/null || true
 }
 
-# commit_and_push: stages any uncommitted changes, commits if needed, and pushes.
-# Returns 0 if changes were pushed, 1 if nothing to push.
+# commit_and_push: stages any uncommitted changes (including untracked files),
+# commits if needed, and pushes. Returns 0 if changes were pushed, 1 if nothing to push.
 # Handles two cases:
-#   (a) Engine left uncommitted working-tree changes — stage, commit, push.
-#   (b) Engine committed via Bash but didn't push — detected via git log @{u}..HEAD
+#   (a) Engine left uncommitted/untracked working-tree changes — stage, commit, push.
+#   (b) Engine committed via Bash but didn't push — detected via upstream comparison
 #       so changes are not silently dropped when the ephemeral runner exits.
 commit_and_push() {
   local intent="$1"
   local has_uncommitted=false has_unpushed=false
 
-  git diff --quiet && git diff --cached --quiet || has_uncommitted=true
-  git log "@{u}..HEAD" --oneline 2>/dev/null | grep -q . && has_unpushed=true
+  # git status --porcelain covers untracked files that git diff misses
+  [ -n "$(git status --porcelain)" ] && has_uncommitted=true
+
+  # Detect engine-committed but not pushed: prefer @{u} if upstream is configured,
+  # fall back to HEAD_SHA (resolved from PR API at script startup) for fork checkouts.
+  local upstream
+  upstream=$(git rev-parse --abbrev-ref --symbolic-full-name "@{u}" 2>/dev/null || true)
+  if [ -n "$upstream" ]; then
+    git log "${upstream}..HEAD" --oneline 2>/dev/null | grep -q . && has_unpushed=true
+  elif [ -n "${HEAD_SHA:-}" ]; then
+    git log "${HEAD_SHA}..HEAD" --oneline 2>/dev/null | grep -q . && has_unpushed=true
+  fi
 
   if ! $has_uncommitted && ! $has_unpushed; then
     echo "::notice::No changes to commit for intent=${intent}"
@@ -102,8 +112,11 @@ commit_and_push() {
   esac
 
   if [ "$DEV_LEAD_DRY_RUN" = "true" ]; then
-    echo "[dry-run] would git add, commit with '${commit_msg}', and push"
-    $has_unpushed && echo "[dry-run] note: engine already committed — would push existing commit(s)"
+    if $has_uncommitted; then
+      echo "[dry-run] would git add -A, commit '${commit_msg}', and push"
+    else
+      echo "[dry-run] engine already committed — would push existing commit(s) without re-committing"
+    fi
   else
     if $has_uncommitted; then
       git add -A

--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -74,12 +74,20 @@ ${summary}"
   gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$body" 2>/dev/null || true
 }
 
-# commit_and_push: adds all changes, commits with an intent-specific message,
-# and pushes to the PR branch. Returns 0 if changes were made and pushed,
-# 1 if no changes were found.
+# commit_and_push: stages any uncommitted changes, commits if needed, and pushes.
+# Returns 0 if changes were pushed, 1 if nothing to push.
+# Handles two cases:
+#   (a) Engine left uncommitted working-tree changes — stage, commit, push.
+#   (b) Engine committed via Bash but didn't push — detected via git log @{u}..HEAD
+#       so changes are not silently dropped when the ephemeral runner exits.
 commit_and_push() {
   local intent="$1"
-  if git diff --quiet && git diff --cached --quiet; then
+  local has_uncommitted=false has_unpushed=false
+
+  git diff --quiet && git diff --cached --quiet || has_uncommitted=true
+  git log "@{u}..HEAD" --oneline 2>/dev/null | grep -q . && has_unpushed=true
+
+  if ! $has_uncommitted && ! $has_unpushed; then
     echo "::notice::No changes to commit for intent=${intent}"
     return 1
   fi
@@ -95,9 +103,12 @@ commit_and_push() {
 
   if [ "$DEV_LEAD_DRY_RUN" = "true" ]; then
     echo "[dry-run] would git add, commit with '${commit_msg}', and push"
+    $has_unpushed && echo "[dry-run] note: engine already committed — would push existing commit(s)"
   else
-    git add -A
-    git commit -m "$commit_msg"
+    if $has_uncommitted; then
+      git add -A
+      git commit -m "$commit_msg"
+    fi
     git push
   fi
   return 0


### PR DESCRIPTION
## Summary

- **Bug**: `commit_and_push` only checked `git diff` (uncommitted working-tree changes). When the engine followed prompt instructions to run `git commit` via Bash, the working tree became clean and `commit_and_push` returned early with `status=no-changes` — silently dropping the committed changes when the ephemeral runner exited. This is what caused PRs #175 and #204 to show `no-changes` despite the engine claiming to have applied fixes.
- **Fix 1 (`commit_and_push`)**: Also check for unpushed commits via `git log "@{u}..HEAD"`. If the engine already committed, skip the `add + commit` step and push the existing commit(s).
- **Fix 2 (prompts)**: Remove "Commit the changes with..." task steps from `human.md`, `human-pr.md`, `fix-bot-comment.md`, and `fix-reviews.md`. Replace with an explicit "Do not commit or push" constraint so the engine leaves all git operations to the script.

## Test plan

- [ ] Trigger `@dev-lead` on a PR with unresolved review comments and confirm the engine's file changes are pushed (not `no-changes`)
- [ ] Confirm dry-run mode (`DEV_LEAD_DRY_RUN=true`) still logs correctly for both the uncommitted-changes path and the engine-already-committed path
- [ ] Confirm `fix-reviews`, `fix-bot-comment`, `human-pr` intents behave the same (all affected prompts updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)