### PR TITLE
feat(concurrency): serialize dev-lead to one active run per repo

### DIFF
--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -23,13 +23,12 @@ permissions:
   checks: read
 
 concurrency:
-  # Per-PR slots for most events; ci-relay is ephemeral and runs immediately
+  # One active run per repo; ci-relay (check_run) keeps an ephemeral per-SHA slot
+  # so it can fire immediately without blocking or being blocked by the dispatch queue.
   group: >-
     ${{
       github.event_name == 'check_run' && format('dev-lead-ci-relay-{0}', github.event.check_run.head_sha) ||
-      github.event_name == 'repository_dispatch' && format('dev-lead-pr-{0}', github.event.client_payload.pr_number) ||
-      github.event_name == 'issues' && format('dev-lead-issue-{0}', github.event.issue.number) ||
-      format('dev-lead-pr-{0}', github.event.pull_request.number || github.event.issue.number || '0')
+      'dev-lead'
     }}
   cancel-in-progress: false
 

--- a/.github/workflows/test-dev-lead.yml
+++ b/.github/workflows/test-dev-lead.yml
@@ -61,3 +61,12 @@ jobs:
           else
             echo "Prompt coverage test not yet implemented"
           fi
+
+  concurrency-config:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Validate concurrency config (per-repo serialization)
+        run: bash tests/dev-lead/integration/test_concurrency_config.sh

--- a/tests/dev-lead/integration/test_concurrency_config.sh
+++ b/tests/dev-lead/integration/test_concurrency_config.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Validates that dev-lead workflow files use per-repo serialized concurrency
+# (a single 'dev-lead' group) rather than per-PR or per-issue groups.
+set -euo pipefail
+
+FAIL=0
+
+check_absent() {
+  local file="$1" pattern="$2" label="$3"
+  if grep -qF "$pattern" "$file"; then
+    echo "FAIL [$label]: '$pattern' found in $file (should have been removed)"
+    FAIL=$((FAIL + 1))
+  else
+    echo "PASS [$label]: '$pattern' absent"
+  fi
+}
+
+check_present() {
+  local file="$1" pattern="$2" label="$3"
+  if grep -qF "$pattern" "$file"; then
+    echo "PASS [$label]: '$pattern' present"
+  else
+    echo "FAIL [$label]: '$pattern' not found in $file"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+WORKFLOW=".github/workflows/dev-lead.yml"
+
+# Must not have per-PR or per-issue group keys (those allowed parallel runs)
+check_absent "$WORKFLOW" "dev-lead-pr-"    "no per-PR group"
+check_absent "$WORKFLOW" "dev-lead-issue-" "no per-issue group"
+
+# ci-relay must still get its own ephemeral per-SHA slot
+check_present "$WORKFLOW" "dev-lead-ci-relay-" "ci-relay per-SHA group preserved"
+
+# The fallback group must be the bare repo-scoped key
+check_present "$WORKFLOW" "'dev-lead'" "per-repo 'dev-lead' fallback group"
+
+# cancel-in-progress must be false so queued runs aren't dropped
+check_present "$WORKFLOW" "cancel-in-progress: false" "cancel-in-progress is false"
+
+echo ""
+if [ "$FAIL" -eq 0 ]; then
+  echo "All concurrency config checks passed."
+else
+  echo "$FAIL check(s) failed."
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Replaces per-PR/per-issue concurrency groups in `dev-lead.yml` with a single `'dev-lead'` group, so at most one dispatch run executes in the repo at a time — new triggers queue instead of running in parallel
- The `ci-relay` job (`check_run` events) retains its ephemeral per-SHA slot so relay dispatches fire immediately without being blocked by a running dispatch
- Adds `tests/dev-lead/integration/test_concurrency_config.sh` + a `concurrency-config` CI job to guard against regression

## Why

Previously each PR got its own concurrency slot, so N open PRs could run N simultaneous dev-lead agents, all competing for the same API rate limit. Serializing to one per repo prevents that while still allowing different repos to run in parallel.

## Test plan

- [ ] `concurrency-config` CI job passes (validates group key shape)
- [ ] Existing `validate-fixtures`, `unit`, `prompt-coverage` jobs pass
- [ ] Manual check: open two PRs and confirm the second queues behind the first

🤖 Generated with [Claude Code](https://claude.com/claude-code)