### PR TITLE
fix(dev-lead): resolve review threads after fixing + notify CodeRabbit on CHANGES_REQUESTED

### DIFF
--- a/prompts/dev-lead/fix-bot-comment.md
+++ b/prompts/dev-lead/fix-bot-comment.md
@@ -22,7 +22,41 @@ Analyze the bot's findings and address each actionable issue:
 1. Parse the bot comment to identify specific code issues (bugs, security vulnerabilities, code smells, etc.)
 2. Locate the referenced files and line numbers using Read/Grep/Glob tools
 3. Apply targeted fixes using Edit/Write tools
-4. Verify that the fixes are complete and do not introduce regressions
+4. **Resolve any open review threads** from this bot that are now fixed or outdated (see below)
+
+### Resolving threads from this bot
+
+After fixing an issue, resolve the corresponding review thread so the bot gets a clean slate to re-review:
+
+```bash
+# List open threads from this bot
+gh api graphql -f query='
+  query($owner: String!, $repo: String!, $pr: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 50) {
+          nodes {
+            id isResolved isOutdated
+            comments(first: 1) { nodes { author { login } body } }
+          }
+        }
+      }
+    }
+  }' -F owner="${REPO%%/*}" -F repo="${REPO##*/}" -F pr=${PR_NUMBER} \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes
+        | map(select(.isResolved == false
+              and (.comments.nodes[0].author.login == "${ACTOR}" or .isOutdated == true)))'
+
+# Resolve a thread
+gh api graphql -f query='
+  mutation($id: ID!) {
+    resolveReviewThread(input: {threadId: $id}) {
+      thread { isResolved }
+    }
+  }' -F id="<threadId>"
+```
+
+Resolve every thread you fixed and every thread marked `isOutdated: true` from this bot.
 
 ## SonarQube / SonarCloud comments
 
@@ -52,7 +86,8 @@ After applying fixes, output a summary:
 ```
 Bot: ${ACTOR}
 Issues addressed: N
-- <issue description>: <fix applied>
+- <issue description>: <fix applied> [thread resolved]
+- <issue description>: outdated thread resolved
 Files changed: <list of files>
 Skipped (informational): <count>
 ```

--- a/prompts/dev-lead/fix-bot-comment.md
+++ b/prompts/dev-lead/fix-bot-comment.md
@@ -22,14 +22,14 @@ Analyze the bot's findings and address each actionable issue:
 1. Parse the bot comment to identify specific code issues (bugs, security vulnerabilities, code smells, etc.)
 2. Locate the referenced files and line numbers using Read/Grep/Glob tools
 3. Apply targeted fixes using Edit/Write tools
-4. **Resolve any open review threads** from this bot that are now fixed or outdated (see below)
+4. **Resolve open review threads** from this bot that are now fixed or outdated (see below)
 
 ### Resolving threads from this bot
 
-After fixing an issue, resolve the corresponding review thread so the bot gets a clean slate to re-review:
+After fixing an issue, resolve the corresponding review thread so the bot gets a clean slate to re-review. First, find open threads from this bot:
 
 ```bash
-# List open threads from this bot (pass ACTOR as --arg so it expands in jq)
+# Pipe through jq --arg to safely pass the bot login as a variable
 gh api graphql -f query='
   query($owner: String!, $repo: String!, $pr: Int!) {
     repository(owner: $owner, name: $repo) {
@@ -43,22 +43,18 @@ gh api graphql -f query='
       }
     }
   }' -F owner="${REPO%%/*}" -F repo="${REPO##*/}" -F pr=${PR_NUMBER} \
-  --jq --arg actor "${ACTOR}" \
-  '.data.repository.pullRequest.reviewThreads.nodes
-   | map(select(.isResolved == false
-         and (.comments.nodes[0].author.login == $actor or
-              (.isOutdated == true and .comments.nodes[0].author.login == $actor))))'
-
-# Resolve a thread
-gh api graphql -f query='
-  mutation($id: ID!) {
-    resolveReviewThread(input: {threadId: $id}) {
-      thread { isResolved }
-    }
-  }' -F id="<threadId>"
+  | jq --arg actor "${ACTOR}" '
+      .data.repository.pullRequest.reviewThreads.nodes
+      | map(select(.isResolved == false
+            and .comments.nodes[0].author.login == $actor))'
 ```
 
-Resolve every thread you fixed and every thread marked `isOutdated: true` from this bot.
+Then resolve each thread you addressed (and any from this bot marked `isOutdated: true`):
+
+```bash
+# Replace THREAD_NODE_ID with the id value from the query above
+gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "THREAD_NODE_ID"}) { thread { isResolved } } }'
+```
 
 ## SonarQube / SonarCloud comments
 
@@ -79,6 +75,7 @@ If `${ACTOR}` is `sonarqubecloud[bot]` and the comment reports security hotspots
 - Do not fix issues marked as "informational" or "suggestion" unless they indicate a real bug
 - Do not suppress bot rules without a documented reason
 - Do not modify the bot's configuration files
+- Only resolve threads from `${ACTOR}` — do not resolve threads from other reviewers
 - Stay within the scope of the pull request's changed files where possible
 - Do not commit or push — the CI workflow handles git operations after you finish
 

--- a/prompts/dev-lead/fix-bot-comment.md
+++ b/prompts/dev-lead/fix-bot-comment.md
@@ -29,7 +29,7 @@ Analyze the bot's findings and address each actionable issue:
 After fixing an issue, resolve the corresponding review thread so the bot gets a clean slate to re-review:
 
 ```bash
-# List open threads from this bot
+# List open threads from this bot (pass ACTOR as --arg so it expands in jq)
 gh api graphql -f query='
   query($owner: String!, $repo: String!, $pr: Int!) {
     repository(owner: $owner, name: $repo) {
@@ -43,9 +43,11 @@ gh api graphql -f query='
       }
     }
   }' -F owner="${REPO%%/*}" -F repo="${REPO##*/}" -F pr=${PR_NUMBER} \
-  --jq '.data.repository.pullRequest.reviewThreads.nodes
-        | map(select(.isResolved == false
-              and (.comments.nodes[0].author.login == "${ACTOR}" or .isOutdated == true)))'
+  --jq --arg actor "${ACTOR}" \
+  '.data.repository.pullRequest.reviewThreads.nodes
+   | map(select(.isResolved == false
+         and (.comments.nodes[0].author.login == $actor or
+              (.isOutdated == true and .comments.nodes[0].author.login == $actor))))'
 
 # Resolve a thread
 gh api graphql -f query='

--- a/prompts/dev-lead/fix-reviews.md
+++ b/prompts/dev-lead/fix-reviews.md
@@ -23,27 +23,24 @@ For each open review thread:
 1. Read the relevant file(s) using Read/Grep/Glob tools
 2. Understand the reviewer's concern
 3. Apply the appropriate fix using Edit/Write tools
-4. **Resolve the thread** using the GraphQL mutation below — do this for every thread you fix *and* for any thread that is `isOutdated: true` (the code it referenced no longer exists)
+4. **Resolve the thread** — do this for every thread you fix *and* for every thread with `isOutdated: true` (the code it referenced no longer exists)
 
 ### Resolving a thread
 
-After fixing (or confirming outdated), resolve it immediately:
+After fixing (or confirming outdated), resolve it using the thread `id` from the JSON above. Only resolve threads from the reviewer who triggered this run — do not resolve threads from other reviewers.
 
 ```bash
-gh api graphql -f query='
-  mutation($id: ID!) {
-    resolveReviewThread(input: {threadId: $id}) {
-      thread { isResolved }
-    }
-  }' -F id="<threadId>"
+# Replace THREAD_NODE_ID with the id value from the thread JSON
+gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "THREAD_NODE_ID"}) { thread { isResolved } } }'
 ```
 
-Resolving a thread signals to the reviewer (human or bot) that the issue is handled and gives them a clean slate to re-review if anything remains.
+Resolving signals to the reviewer that the issue is handled and gives them a clean slate to re-review if anything remains.
 
 ## Constraints
 
 - Address each open thread individually
-- Resolve every thread you fix; resolve outdated threads without a corresponding fix
+- Resolve every thread you fix; resolve outdated threads without a corresponding code change
+- Only resolve threads from the reviewer who triggered this run — leave other reviewers' threads open
 - Do not resolve threads you are skipping due to ambiguity — leave those open and note them in your output
 - Do not make changes beyond what the review threads request
 - If a review thread is ambiguous, apply the most conservative interpretation

--- a/prompts/dev-lead/fix-reviews.md
+++ b/prompts/dev-lead/fix-reviews.md
@@ -10,7 +10,7 @@ You are the dev-lead agent for the `${REPO}` repository. Your task is to address
 
 ## Open Review Threads
 
-The following review threads are unresolved and require attention:
+The following review threads are unresolved and require attention. Each thread includes an `id` field used to resolve it after you address it.
 
 ```json
 ${OPEN_THREADS_JSON}
@@ -18,22 +18,35 @@ ${OPEN_THREADS_JSON}
 
 ## Task
 
-For each open review thread, address the feedback by:
+For each open review thread:
 
-1. Reading the relevant file(s) using the Read/Grep/Glob tools
-2. Understanding the reviewer's concern
-3. Applying the appropriate fix using Edit/Write tools
-4. Ensuring the fix aligns with existing code patterns and style
+1. Read the relevant file(s) using Read/Grep/Glob tools
+2. Understand the reviewer's concern
+3. Apply the appropriate fix using Edit/Write tools
+4. **Resolve the thread** using the GraphQL mutation below — do this for every thread you fix *and* for any thread that is `isOutdated: true` (the code it referenced no longer exists)
 
-After addressing all threads:
-- Do not resolve the threads yourself — they will be resolved automatically when the conversation is updated
+### Resolving a thread
+
+After fixing (or confirming outdated), resolve it immediately:
+
+```bash
+gh api graphql -f query='
+  mutation($id: ID!) {
+    resolveReviewThread(input: {threadId: $id}) {
+      thread { isResolved }
+    }
+  }' -F id="<threadId>"
+```
+
+Resolving a thread signals to the reviewer (human or bot) that the issue is handled and gives them a clean slate to re-review if anything remains.
 
 ## Constraints
 
 - Address each open thread individually
+- Resolve every thread you fix; resolve outdated threads without a corresponding fix
+- Do not resolve threads you are skipping due to ambiguity — leave those open and note them in your output
 - Do not make changes beyond what the review threads request
 - If a review thread is ambiguous, apply the most conservative interpretation
-- Do not modify files that are not referenced in the review threads
 - Do not commit or push — the CI workflow handles git operations after you finish
 
 ## Output Format
@@ -41,7 +54,8 @@ After addressing all threads:
 After applying fixes, output a summary:
 ```
 Addressed N threads:
-- Thread <id>: <brief description of fix>
-- Thread <id>: <brief description of fix>
+- Thread <id>: <brief description of fix> [resolved]
+- Thread <id>: outdated — resolved without change
+- Thread <id>: skipped — <reason> [left open]
 Files changed: <list of files>
 ```

--- a/prompts/dev-lead/human-pr.md
+++ b/prompts/dev-lead/human-pr.md
@@ -16,7 +16,7 @@ ${PR_DESCRIPTION}
 
 ## Open Review Threads
 
-The following threads from human reviewers require your attention:
+The following threads from human reviewers require your attention. Each thread includes an `id` field used to resolve it after you address it.
 
 ```json
 ${OPEN_THREADS_JSON}
@@ -29,13 +29,27 @@ Address every open review thread from the human reviewers:
 1. Read each thread carefully to understand the reviewer's intent
 2. Use Read/Grep/Glob tools to examine the referenced code and surrounding context
 3. Apply the requested changes using Edit/Write tools
-4. Ensure your changes align with the PR's overall purpose and do not break existing functionality
+4. **Resolve the thread** after fixing it, or if it is `isOutdated: true`
+
+### Resolving a thread
+
+```bash
+gh api graphql -f query='
+  mutation($id: ID!) {
+    resolveReviewThread(input: {threadId: $id}) {
+      thread { isResolved }
+    }
+  }' -F id="<threadId>"
+```
+
+Resolving signals to the reviewer that the issue is handled and gives them a chance to re-review if anything remains.
 
 ## Constraints
 
 - Treat human reviewer feedback with high priority — implement exactly what is asked
+- Resolve every thread you fix; resolve outdated threads without a corresponding code change
+- Do not resolve threads you are intentionally skipping — leave those open and explain why
 - If multiple threads conflict, prioritize in this order: security > correctness > style
-- Do not dismiss or skip any thread without a documented reason
 - Maintain the existing code style and patterns
 - Run any available test commands to verify fixes where possible
 - Do not commit or push — the CI workflow handles git operations after you finish
@@ -46,7 +60,8 @@ After applying fixes, output a summary:
 ```
 PR: #${PR_NUMBER} - ${PR_TITLE}
 Human review threads addressed: N
-- Thread <author>: <brief description of change>
+- Thread <author>: <brief description of change> [resolved]
+- Thread <author>: outdated — resolved without change
+- Thread <author>: skipped — <reason> [left open]
 Files changed: <list of files>
-Remaining (if any): <explanation>
 ```

--- a/prompts/dev-lead/human-pr.md
+++ b/prompts/dev-lead/human-pr.md
@@ -33,13 +33,11 @@ Address every open review thread from the human reviewers:
 
 ### Resolving a thread
 
+After fixing (or confirming outdated), resolve the thread using the `id` from the JSON above. Only resolve threads from human reviewers — do not resolve threads posted by bots.
+
 ```bash
-gh api graphql -f query='
-  mutation($id: ID!) {
-    resolveReviewThread(input: {threadId: $id}) {
-      thread { isResolved }
-    }
-  }' -F id="<threadId>"
+# Replace THREAD_NODE_ID with the id value from the thread JSON
+gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "THREAD_NODE_ID"}) { thread { isResolved } } }'
 ```
 
 Resolving signals to the reviewer that the issue is handled and gives them a chance to re-review if anything remains.
@@ -48,6 +46,7 @@ Resolving signals to the reviewer that the issue is handled and gives them a cha
 
 - Treat human reviewer feedback with high priority — implement exactly what is asked
 - Resolve every thread you fix; resolve outdated threads without a corresponding code change
+- Only resolve threads from human reviewers — do not resolve bot review threads
 - Do not resolve threads you are intentionally skipping — leave those open and explain why
 - If multiple threads conflict, prioritize in this order: security > correctness > style
 - Maintain the existing code style and patterns

--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -74,21 +74,22 @@ ${summary}"
   gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$body" 2>/dev/null || true
 }
 
-# notify_coderabbit_resolve: posts @coderabbitai resolve if coderabbitai[bot]
-# has an outstanding CHANGES_REQUESTED review on the PR. This triggers CodeRabbit
-# to mark all its comment threads as resolved and post an APPROVED review when
-# request_changes_workflow is enabled.
+# notify_coderabbit_resolve: posts @coderabbitai resolve if coderabbitai[bot]'s
+# most recent review on the PR is CHANGES_REQUESTED. Uses --paginate so it sees
+# all reviews even on long-lived PRs, and checks only the latest review state
+# (not any historical one) to avoid noisy re-posts after a prior approval or dismissal.
 notify_coderabbit_resolve() {
   if [ "${DEV_LEAD_DRY_RUN:-false}" = "true" ]; then
     echo "[dry-run] would check for coderabbitai CHANGES_REQUESTED and post @coderabbitai resolve"
     return 0
   fi
-  local has_cr_changes_requested
-  has_cr_changes_requested=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
-    --jq '[.[] | select(.user.login == "coderabbitai[bot]" and .state == "CHANGES_REQUESTED")] | length' \
-    2>/dev/null || echo "0")
-  if [ "${has_cr_changes_requested:-0}" -gt 0 ]; then
-    echo "::notice::coderabbitai has CHANGES_REQUESTED — posting @coderabbitai resolve"
+  # Emit one state per CodeRabbit review in chronological order; tail -1 = latest.
+  local latest_cr_state
+  latest_cr_state=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+    --jq '.[] | select(.user.login == "coderabbitai[bot]") | .state' \
+    2>/dev/null | tail -1)
+  if [ "${latest_cr_state:-}" = "CHANGES_REQUESTED" ]; then
+    echo "::notice::coderabbitai[bot] latest review is CHANGES_REQUESTED — posting @coderabbitai resolve"
     gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@coderabbitai resolve" 2>/dev/null || true
   fi
 }

--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -74,6 +74,25 @@ ${summary}"
   gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$body" 2>/dev/null || true
 }
 
+# notify_coderabbit_resolve: posts @coderabbitai resolve if coderabbitai[bot]
+# has an outstanding CHANGES_REQUESTED review on the PR. This triggers CodeRabbit
+# to mark all its comment threads as resolved and post an APPROVED review when
+# request_changes_workflow is enabled.
+notify_coderabbit_resolve() {
+  if [ "${DEV_LEAD_DRY_RUN:-false}" = "true" ]; then
+    echo "[dry-run] would check for coderabbitai CHANGES_REQUESTED and post @coderabbitai resolve"
+    return 0
+  fi
+  local has_cr_changes_requested
+  has_cr_changes_requested=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+    --jq '[.[] | select(.user.login == "coderabbitai[bot]" and .state == "CHANGES_REQUESTED")] | length' \
+    2>/dev/null || echo "0")
+  if [ "${has_cr_changes_requested:-0}" -gt 0 ]; then
+    echo "::notice::coderabbitai has CHANGES_REQUESTED — posting @coderabbitai resolve"
+    gh pr comment "$PR_NUMBER" --repo "$REPO" --body "@coderabbitai resolve" 2>/dev/null || true
+  fi
+}
+
 # commit_and_push: stages any uncommitted changes (including untracked files),
 # commits if needed, and pushes. Returns 0 if changes were pushed, 1 if nothing to push.
 # Handles two cases:
@@ -255,7 +274,7 @@ case "$INTENT_TYPE" in
         repository(owner:$owner, name:$repo) {
           pullRequest(number:$pr) {
             reviewThreads(first:50) {
-              nodes { isResolved line path comments(first:5) { nodes { body author { login } } } }
+              nodes { id isResolved isOutdated line path comments(first:5) { nodes { body author { login } } } }
             }
           }
         }
@@ -268,6 +287,7 @@ case "$INTENT_TYPE" in
     [ "$rc" -eq 2 ] && handle_rate_limit "fix-reviews"
     if [ "$rc" -eq 0 ]; then
       if commit_and_push "fix-reviews"; then
+        notify_coderabbit_resolve
         post_reviews_terminal "fix-reviews" "applied"
       else
         post_reviews_terminal "fix-reviews" "no-changes" "No changes were needed for the open review threads."
@@ -283,6 +303,7 @@ case "$INTENT_TYPE" in
     [ "$rc" -eq 2 ] && handle_rate_limit "fix-bot-comment"
     if [ "$rc" -eq 0 ]; then
       if commit_and_push "fix-bot-comment"; then
+        notify_coderabbit_resolve
         post_reviews_terminal "fix-bot-comment" "applied" "Changes committed and pushed."
       else
         post_reviews_terminal "fix-bot-comment" "no-changes" "Engine ran but made no changes."
@@ -315,7 +336,7 @@ case "$INTENT_TYPE" in
         repository(owner:$owner, name:$repo) {
           pullRequest(number:$pr) {
             reviewThreads(first:50) {
-              nodes { isResolved line path comments(first:5) { nodes { body author { login } } } }
+              nodes { id isResolved isOutdated line path comments(first:5) { nodes { body author { login } } } }
             }
           }
         }
@@ -328,6 +349,7 @@ case "$INTENT_TYPE" in
     [ "$rc" -eq 2 ] && handle_rate_limit "human-pr"
     if [ "$rc" -eq 0 ]; then
       if commit_and_push "human-pr"; then
+        notify_coderabbit_resolve
         post_reviews_terminal "human-pr" "applied"
       else
         post_reviews_terminal "human-pr" "no-changes" "No changes were needed for this PR."

--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -34,8 +34,20 @@ fi
 build_and_run() {
   local template_name="$1"
   local prompt_file="/tmp/dev-lead-${template_name}-prompt-$$.md"
-  # Export required vars then envsubst
-  envsubst < "${PROMPTS_DIR}/${template_name}.md" > "$prompt_file"
+  local template_path="${PROMPTS_DIR}/${template_name}.md"
+  # Scope envsubst to only the variables declared in the <!-- VARIABLES: --> header.
+  # This prevents GraphQL $variables, $() subshells, and other $ patterns in the
+  # prompt from being silently clobbered before the agent ever sees them.
+  local vars_spec
+  vars_spec=$(grep -m1 '<!-- VARIABLES:' "$template_path" 2>/dev/null \
+    | sed 's/<!-- VARIABLES: //; s/ -->//' \
+    | tr ',' '\n' \
+    | awk '{gsub(/^ +| +$/, ""); if (length) printf "${%s}", $0}' || true)
+  if [ -n "$vars_spec" ]; then
+    envsubst "$vars_spec" < "$template_path" > "$prompt_file"
+  else
+    envsubst < "$template_path" > "$prompt_file"
+  fi
 
   if [ "$DEV_LEAD_DRY_RUN" = "true" ]; then
     echo "[dry-run] would run engine with prompt: $prompt_file ($(wc -l < "$prompt_file") lines)"


### PR DESCRIPTION
## Problem

The dev-lead prompts said **"Do not resolve the threads yourself"** — this was wrong in two ways:

1. It prevented the agent from resolving threads it had just fixed, leaving stale CHANGES_REQUESTED state on every PR it touched
2. The rationale ("they will be resolved automatically") is false for bot reviewers — CodeRabbit, Copilot, and Gemini do NOT auto-resolve when new commits are pushed

Additionally, the script never posted \`@coderabbitai resolve\` after a successful push, so CodeRabbit's \`request_changes_workflow\` CHANGES_REQUESTED review never cleared to APPROVED even when all findings were addressed.

## Changes

**\`scripts/dev-lead-fix-reviews.sh\`**
- Added \`notify_coderabbit_resolve()\`: after a successful \`commit_and_push\`, checks if \`coderabbitai[bot]\` has an outstanding CHANGES_REQUESTED review and posts \`@coderabbitai resolve\`, which triggers CodeRabbit to mark all threads resolved and post APPROVED
- Both \`reviewThreads\` GraphQL queries now fetch \`id\` and \`isOutdated\` so the agent can resolve threads
- \`notify_coderabbit_resolve\` called in \`fix-reviews\`, \`fix-bot-comment\`, and \`human-pr\` intents after successful push

**\`prompts/dev-lead/fix-reviews.md\`**
- Removed the wrong "do not resolve" instruction
- Added: resolve each thread after fixing it via \`resolveReviewThread\` GraphQL mutation
- Added: resolve threads marked \`isOutdated: true\` without a code change

**\`prompts/dev-lead/fix-bot-comment.md\`**
- Same thread-resolution instructions with bot-specific thread query

**\`prompts/dev-lead/human-pr.md\`**
- Same thread-resolution instructions for human review threads

## Correct lifecycle after this fix

1. Agent fixes the code issue → resolves the thread → reviewer sees clean slate
2. Bot gets a chance to re-review the new commit and flag anything remaining
3. If CodeRabbit had CHANGES_REQUESTED → script posts \`@coderabbitai resolve\` → CodeRabbit posts APPROVED

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic resolution of review threads when code fixes are applied
  * Enhanced status tracking with clear indicators for resolved, outdated, or skipped review threads
  * Notification system to manage outstanding bot-generated reviews

* **Documentation**
  * Updated review workflow templates for improved clarity on thread resolution and handling processes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/petry-projects/.github-private/pull/285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->