### PR TITLE
fix(dev-lead): add chatgpt-codex-connector[bot] to TRUSTED_BOTS + fix pre-existing test failures

### DIFF
--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -34,7 +34,7 @@ concurrency:
 
 env:
   BOT_USER: ${{ vars.BOT_USER || 'donpetry-bot' }}
-  TRUSTED_BOTS: ${{ vars.TRUSTED_BOTS || 'copilot-pull-request-reviewer[bot],gemini-code-assist[bot],sonarqubecloud[bot],coderabbitai[bot]' }}
+  TRUSTED_BOTS: ${{ vars.TRUSTED_BOTS || 'copilot-pull-request-reviewer[bot],gemini-code-assist[bot],sonarqubecloud[bot],coderabbitai[bot],chatgpt-codex-connector[bot]' }}
   TRIGGER_PHRASES: ${{ vars.TRIGGER_PHRASES || '@dev-lead' }}
   DEV_LEAD_ENGINE: ${{ vars.DEV_LEAD_ENGINE || 'claude' }}
   DEV_LEAD_DRY_RUN: ${{ vars.DEV_LEAD_DRY_RUN || 'false' }}

--- a/tests/dev-lead/fixtures/events/issue_comment_human_trigger.json
+++ b/tests/dev-lead/fixtures/events/issue_comment_human_trigger.json
@@ -16,7 +16,8 @@
     "user": {
       "login": "donpetry",
       "type": "User"
-    }
+    },
+    "author_association": "OWNER"
   },
   "repository": { "full_name": "petry-projects/.github-private" },
   "sender": { "login": "donpetry", "type": "User" }

--- a/tests/dev-lead/fixtures/events/pr_review_codex_commented.json
+++ b/tests/dev-lead/fixtures/events/pr_review_codex_commented.json
@@ -1,0 +1,30 @@
+{
+  "_test_expected_intent": "fix-reviews",
+  "action": "submitted",
+  "review": {
+    "id": 3050,
+    "state": "COMMENTED",
+    "body": "Please address the naming inconsistencies noted inline.",
+    "user": {
+      "login": "chatgpt-codex-connector[bot]",
+      "type": "Bot"
+    }
+  },
+  "pull_request": {
+    "number": 284,
+    "title": "feat: implement issue #232",
+    "state": "open",
+    "author_association": "OWNER",
+    "head": {
+      "sha": "aaa111bbb222",
+      "ref": "feat/issue-232",
+      "repo": { "full_name": "petry-projects/.github-private" }
+    },
+    "base": {
+      "ref": "main",
+      "repo": { "full_name": "petry-projects/.github-private" }
+    }
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "chatgpt-codex-connector[bot]", "type": "Bot" }
+}

--- a/tests/dev-lead/fixtures/events/pr_review_comment_codex.json
+++ b/tests/dev-lead/fixtures/events/pr_review_comment_codex.json
@@ -1,0 +1,31 @@
+{
+  "_test_expected_intent": "fix-reviews",
+  "action": "created",
+  "comment": {
+    "id": 2050,
+    "body": "This logic has a potential off-by-one error on line 17.",
+    "path": "src/index.js",
+    "line": 17,
+    "user": {
+      "login": "chatgpt-codex-connector[bot]",
+      "type": "Bot"
+    }
+  },
+  "pull_request": {
+    "number": 284,
+    "title": "feat: implement issue #232",
+    "state": "open",
+    "author_association": "OWNER",
+    "head": {
+      "sha": "aaa111bbb222",
+      "ref": "feat/issue-232",
+      "repo": { "full_name": "petry-projects/.github-private" }
+    },
+    "base": {
+      "ref": "main",
+      "repo": { "full_name": "petry-projects/.github-private" }
+    }
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "chatgpt-codex-connector[bot]", "type": "Bot" }
+}

--- a/tests/dev-lead/fixtures/events/pr_review_comment_human_trigger.json
+++ b/tests/dev-lead/fixtures/events/pr_review_comment_human_trigger.json
@@ -9,7 +9,8 @@
     "user": {
       "login": "donpetry",
       "type": "User"
-    }
+    },
+    "author_association": "OWNER"
   },
   "pull_request": {
     "number": 59,

--- a/tests/dev-lead/unit/test_engine_fallback.bats
+++ b/tests/dev-lead/unit/test_engine_fallback.bats
@@ -92,16 +92,19 @@ STUBEOF
 }
 
 @test "fallback: all rate-limited → returns 2" {
-  # All engines exit 2
+  # All engines exit 2 (rate-limited)
   _make_stub "claude" 2
   _make_stub "gemini" 2
-  # copilot falls back to claude internally, so we only need claude and gemini
-  # Create a copilot stub that also fails with 2
-  cat > "$STUB_BIN_DIR/copilot" <<'STUBEOF'
+  # copilot uses `gh copilot`; provide token + gh stub returning rate-limit text
+  export COPILOT_GITHUB_TOKEN="stub-token"
+  cat > "$STUB_BIN_DIR/gh" <<'GHEOF'
 #!/usr/bin/env bash
-exit 2
-STUBEOF
-  chmod +x "$STUB_BIN_DIR/copilot"
+case "$*" in
+  *"copilot"*) echo "rate limit exceeded"; exit 1 ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN_DIR/gh"
   _source_engine "claude"
 
   run run_writer_with_fallback "$TEST_PROMPT"

--- a/tests/dev-lead/unit/test_engine_writer.bats
+++ b/tests/dev-lead/unit/test_engine_writer.bats
@@ -91,14 +91,21 @@ _source_engine() {
 }
 
 @test "writer: copilot falls back to claude in run_writer (internal)" {
-  # When REVIEW_ENGINE=copilot, run_writer internally falls back to claude
+  # When REVIEW_ENGINE=copilot, run_writer calls copilot_chat → gh copilot
   _source_engine "copilot"
-  export STUB_ENGINE_EXIT=0
   export DEV_LEAD_DRY_RUN=false
+  export COPILOT_GITHUB_TOKEN="stub-token"
+  cat > "$STUB_BIN_DIR/gh" <<'GHEOF'
+#!/usr/bin/env bash
+case "$*" in
+  *"copilot"*) exit 0 ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN_DIR/gh"
 
   run run_writer "$TEST_PROMPT"
 
-  # Should succeed because the internal claude stub is present
   [ "$status" -eq 0 ]
 }
 
@@ -187,8 +194,16 @@ exit 1
 STUB
     chmod +x "$STUB_BIN_DIR/$engine"
   done
-  # Add copilot stub (falls back to claude internally)
-  cp "$STUB_BIN_DIR/claude" "$STUB_BIN_DIR/copilot"
+  # copilot uses `gh copilot`; provide token + gh stub returning rate-limit text
+  export COPILOT_GITHUB_TOKEN="stub-token"
+  cat > "$STUB_BIN_DIR/gh" << 'GHEOF'
+#!/usr/bin/env bash
+case "$*" in
+  *"copilot"*) echo "rate limit exceeded"; exit 1 ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN_DIR/gh"
 
   run run_writer_with_fallback "$TEST_PROMPT"
 

--- a/tests/dev-lead/unit/test_fix_ci.bats
+++ b/tests/dev-lead/unit/test_fix_ci.bats
@@ -300,6 +300,7 @@ STUB
     chmod +x "$STUB_BIN_DIR/$engine"
   done
 
+  export COPILOT_GITHUB_TOKEN="stub-token"
   cat > "$STUB_BIN_DIR/gh" << 'GHEOF'
 #!/usr/bin/env bash
 case "$*" in
@@ -307,6 +308,7 @@ case "$*" in
   *"pr checkout"*) exit 0 ;;
   *"pr comment"*) echo "COMMENT_POSTED: $*"; exit 0 ;;
   *"run view"*) echo "log output" ;;
+  *"copilot"*) echo "rate limit exceeded"; exit 1 ;;
   *) echo "{}" ;;
 esac
 GHEOF
@@ -322,6 +324,7 @@ GHEOF
 
 @test "fix-ci: rate-limited: does not count toward exhaustion threshold" {
   # PR already has rate-limited markers but zero status=failed markers
+  export COPILOT_GITHUB_TOKEN="stub-token"
   cat > "$STUB_BIN_DIR/gh" << 'GHEOF'
 #!/usr/bin/env bash
 case "$*" in
@@ -332,13 +335,14 @@ case "$*" in
   *"pr checkout"*) exit 0 ;;
   *"pr comment"*) echo "COMMENT_POSTED"; exit 0 ;;
   *"run view"*) echo "log output" ;;
+  *"copilot"*) echo "rate limit exceeded"; exit 1 ;;
   *) echo "{}" ;;
 esac
 GHEOF
   chmod +x "$STUB_BIN_DIR/gh"
 
   # Engine also rate-limits on this run
-  for engine in claude gemini copilot; do
+  for engine in claude gemini; do
     cat > "$STUB_BIN_DIR/$engine" << 'STUB'
 #!/usr/bin/env bash
 echo "rate limit exceeded"
@@ -406,6 +410,7 @@ GHEOF
 
 @test "fix-ci: rate-limited dedup: existing rate-limited marker for same SHA skips duplicate post" {
   # Simulate an existing rate-limited marker for HEAD_SHA (same sha)
+  export COPILOT_GITHUB_TOKEN="stub-token"
   cat > "$STUB_BIN_DIR/gh" << 'GHEOF'
 #!/usr/bin/env bash
 case "$*" in
@@ -415,12 +420,13 @@ case "$*" in
   *"pr checkout"*) exit 0 ;;
   *"pr comment"*) echo "COMMENT_POSTED"; exit 0 ;;
   *"run view"*) echo "log output" ;;
+  *"copilot"*) echo "rate limit exceeded"; exit 1 ;;
   *) echo "{}" ;;
 esac
 GHEOF
   chmod +x "$STUB_BIN_DIR/gh"
 
-  for engine in claude gemini copilot; do
+  for engine in claude gemini; do
     cat > "$STUB_BIN_DIR/$engine" << 'STUB'
 #!/usr/bin/env bash
 echo "rate limit exceeded"

--- a/tests/dev-lead/unit/test_fix_reviews.bats
+++ b/tests/dev-lead/unit/test_fix_reviews.bats
@@ -173,16 +173,18 @@ STUB
 
   cat > "$STUB_BIN_DIR/gh" << 'GHEOF'
 #!/usr/bin/env bash
+# copilot must be checked first — its -p prompt text may contain "graphql"
+case "$1" in
+  copilot) echo "rate limit exceeded"; exit 1 ;;
+esac
 ARGS="$*"
 case "$ARGS" in
-  *"api"*"graphql"*)
+  *"graphql"*)
     echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}' ;;
   *"api"*"repos/"*"issues/"*)
     echo "[]" ;;
   *"pr comment"*)
     echo "COMMENT_POSTED: $ARGS"; exit 0 ;;
-  *"copilot"*)
-    echo "rate limit exceeded"; exit 1 ;;
   *) echo "{}" ;;
 esac
 GHEOF
@@ -263,9 +265,13 @@ STUB
 
   cat > "$STUB_BIN_DIR/gh" << GHEOF
 #!/usr/bin/env bash
+# copilot must be checked first — its -p prompt text may contain "graphql"
+case "\$1" in
+  copilot) echo "quota exceeded"; exit 1 ;;
+esac
 ARGS="\$*"
 case "\$ARGS" in
-  *"api"*"graphql"*)
+  *"graphql"*)
     echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}' ;;
   *"api"*"repos/"*"issues/"*)
     echo "[]" ;;
@@ -273,8 +279,6 @@ case "\$ARGS" in
     count=\$(cat "${comment_count_file}")
     echo \$((count + 1)) > "${comment_count_file}"
     echo "COMMENT_POSTED #\$((count + 1))"; exit 0 ;;
-  *"copilot"*)
-    echo "quota exceeded"; exit 1 ;;
   *) echo "{}" ;;
 esac
 GHEOF
@@ -337,16 +341,18 @@ GHEOF
   # Returns existing rate-limited marker for this sha+intent
   cat > "$STUB_BIN_DIR/gh" << 'GHEOF'
 #!/usr/bin/env bash
+# copilot must be checked first — its -p prompt text may contain "graphql"
+case "$1" in
+  copilot) echo "rate limit exceeded"; exit 1 ;;
+esac
 ARGS="$*"
 case "$ARGS" in
-  *"api"*"graphql"*)
+  *"graphql"*)
     echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}' ;;
   *"api"*"repos/"*"issues/"*)
     echo '[{"body":"<!-- dev-lead-fix-reviews pr=54 sha=ddd444eee555 intent=fix-reviews status=rate-limited -->"}]' ;;
   *"pr comment"*)
     echo "COMMENT_POSTED"; exit 0 ;;
-  *"copilot"*)
-    echo "rate limit exceeded"; exit 1 ;;
   *) echo "{}" ;;
 esac
 GHEOF

--- a/tests/dev-lead/unit/test_fix_reviews.bats
+++ b/tests/dev-lead/unit/test_fix_reviews.bats
@@ -175,7 +175,7 @@ STUB
 #!/usr/bin/env bash
 ARGS="$*"
 case "$ARGS" in
-  *"graphql"*)
+  *"api"*"graphql"*)
     echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}' ;;
   *"api"*"repos/"*"issues/"*)
     echo "[]" ;;
@@ -265,7 +265,7 @@ STUB
 #!/usr/bin/env bash
 ARGS="\$*"
 case "\$ARGS" in
-  *"graphql"*)
+  *"api"*"graphql"*)
     echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}' ;;
   *"api"*"repos/"*"issues/"*)
     echo "[]" ;;
@@ -339,7 +339,7 @@ GHEOF
 #!/usr/bin/env bash
 ARGS="$*"
 case "$ARGS" in
-  *"graphql"*)
+  *"api"*"graphql"*)
     echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}' ;;
   *"api"*"repos/"*"issues/"*)
     echo '[{"body":"<!-- dev-lead-fix-reviews pr=54 sha=ddd444eee555 intent=fix-reviews status=rate-limited -->"}]' ;;

--- a/tests/dev-lead/unit/test_fix_reviews.bats
+++ b/tests/dev-lead/unit/test_fix_reviews.bats
@@ -159,9 +159,10 @@ teardown() {
   export INTENT_TYPE="fix-reviews"
   export DEV_LEAD_DRY_RUN="false"
   export HEAD_SHA="ddd444eee555"
+  export COPILOT_GITHUB_TOKEN="stub-token"
 
-  # All engines rate-limited
-  for engine in claude gemini copilot; do
+  # claude and gemini engines rate-limited
+  for engine in claude gemini; do
     cat > "$STUB_BIN_DIR/$engine" << 'STUB'
 #!/usr/bin/env bash
 echo "rate limit exceeded"
@@ -180,6 +181,8 @@ case "$ARGS" in
     echo "[]" ;;
   *"pr comment"*)
     echo "COMMENT_POSTED: $ARGS"; exit 0 ;;
+  *"copilot"*)
+    echo "rate limit exceeded"; exit 1 ;;
   *) echo "{}" ;;
 esac
 GHEOF
@@ -198,9 +201,10 @@ GHEOF
   export HEAD_SHA="ddd444eee555"
   export ACTOR="donpetry"
   export USER_INSTRUCTION="Please fix the failing tests"
+  export COPILOT_GITHUB_TOKEN="stub-token"
 
-  # All engines rate-limited
-  for engine in claude gemini copilot; do
+  # claude and gemini engines rate-limited
+  for engine in claude gemini; do
     cat > "$STUB_BIN_DIR/$engine" << 'STUB'
 #!/usr/bin/env bash
 echo "hit your limit"
@@ -219,6 +223,8 @@ case "$ARGS" in
     echo "COMMENT_POSTED: $ARGS"; exit 0 ;;
   *"pulls/"*)
     echo '{"head":{"sha":"ddd444eee555"}}' ;;
+  *"copilot"*)
+    echo "hit your limit"; exit 1 ;;
   *) echo "{}" ;;
 esac
 GHEOF
@@ -245,7 +251,8 @@ GHEOF
   comment_count_file=$(mktemp)
   echo "0" > "$comment_count_file"
 
-  for engine in claude gemini copilot; do
+  export COPILOT_GITHUB_TOKEN="stub-token"
+  for engine in claude gemini; do
     cat > "$STUB_BIN_DIR/$engine" << 'STUB'
 #!/usr/bin/env bash
 echo "quota exceeded"
@@ -266,6 +273,8 @@ case "\$ARGS" in
     count=\$(cat "${comment_count_file}")
     echo \$((count + 1)) > "${comment_count_file}"
     echo "COMMENT_POSTED #\$((count + 1))"; exit 0 ;;
+  *"copilot"*)
+    echo "quota exceeded"; exit 1 ;;
   *) echo "{}" ;;
 esac
 GHEOF
@@ -287,8 +296,9 @@ GHEOF
   export DEV_LEAD_DRY_RUN="false"
   export HEAD_SHA="ddd444eee555"
   export COMMENT_BODY="SonarQube found issues"
+  export COPILOT_GITHUB_TOKEN="stub-token"
 
-  for engine in claude gemini copilot; do
+  for engine in claude gemini; do
     cat > "$STUB_BIN_DIR/$engine" << 'STUB'
 #!/usr/bin/env bash
 echo "rate limit exceeded"
@@ -305,6 +315,8 @@ case "$ARGS" in
     echo "[]" ;;
   *"pr comment"*)
     echo "COMMENT_POSTED"; exit 0 ;;
+  *"copilot"*)
+    echo "rate limit exceeded"; exit 1 ;;
   *) echo "{}" ;;
 esac
 GHEOF
@@ -320,6 +332,7 @@ GHEOF
   export INTENT_TYPE="fix-reviews"
   export DEV_LEAD_DRY_RUN="false"
   export HEAD_SHA="ddd444eee555"
+  export COPILOT_GITHUB_TOKEN="stub-token"
 
   # Returns existing rate-limited marker for this sha+intent
   cat > "$STUB_BIN_DIR/gh" << 'GHEOF'
@@ -332,12 +345,14 @@ case "$ARGS" in
     echo '[{"body":"<!-- dev-lead-fix-reviews pr=54 sha=ddd444eee555 intent=fix-reviews status=rate-limited -->"}]' ;;
   *"pr comment"*)
     echo "COMMENT_POSTED"; exit 0 ;;
+  *"copilot"*)
+    echo "rate limit exceeded"; exit 1 ;;
   *) echo "{}" ;;
 esac
 GHEOF
   chmod +x "$STUB_BIN_DIR/gh"
 
-  for engine in claude gemini copilot; do
+  for engine in claude gemini; do
     cat > "$STUB_BIN_DIR/$engine" << 'STUB'
 #!/usr/bin/env bash
 echo "rate limit exceeded"

--- a/tests/dev-lead/unit/test_intent_ci.bats
+++ b/tests/dev-lead/unit/test_intent_ci.bats
@@ -20,6 +20,15 @@ teardown() {
 
 _get_env() {
   local key="$1"
+  # Handle multiline heredoc format: KEY<<DELIM\nvalue\nDELIM
+  local delim_line delimiter
+  delim_line=$(grep "^${key}<<" "$GITHUB_ENV" 2>/dev/null | head -1)
+  if [ -n "$delim_line" ]; then
+    delimiter="${delim_line#*<<}"
+    awk -v start="${key}<<${delimiter}" -v end="${delimiter}" \
+      'found && $0==end{exit} found{print} $0==start{found=1}' "$GITHUB_ENV"
+    return
+  fi
   grep "^${key}=" "$GITHUB_ENV" | cut -d= -f2- | head -1
 }
 

--- a/tests/dev-lead/unit/test_intent_issue.bats
+++ b/tests/dev-lead/unit/test_intent_issue.bats
@@ -20,6 +20,15 @@ teardown() {
 
 _get_env() {
   local key="$1"
+  # Handle multiline heredoc format: KEY<<DELIM\nvalue\nDELIM
+  local delim_line delimiter
+  delim_line=$(grep "^${key}<<" "$GITHUB_ENV" 2>/dev/null | head -1)
+  if [ -n "$delim_line" ]; then
+    delimiter="${delim_line#*<<}"
+    awk -v start="${key}<<${delimiter}" -v end="${delimiter}" \
+      'found && $0==end{exit} found{print} $0==start{found=1}' "$GITHUB_ENV"
+    return
+  fi
   grep "^${key}=" "$GITHUB_ENV" | cut -d= -f2- | head -1
 }
 

--- a/tests/dev-lead/unit/test_intent_reviews.bats
+++ b/tests/dev-lead/unit/test_intent_reviews.bats
@@ -9,7 +9,7 @@ setup() {
   export GITHUB_ENV="$(mktemp)"
   export GITHUB_OUTPUT="$(mktemp)"
   export BOT_USER="donpetry-bot"
-  export TRUSTED_BOTS="copilot-pull-request-reviewer[bot],gemini-code-assist[bot],sonarqubecloud[bot],coderabbitai[bot]"
+  export TRUSTED_BOTS="copilot-pull-request-reviewer[bot],gemini-code-assist[bot],sonarqubecloud[bot],coderabbitai[bot],chatgpt-codex-connector[bot]"
   export TRIGGER_PHRASES="@dev-lead"
   export GITHUB_REPOSITORY="petry-projects/.github-private"
 }
@@ -160,7 +160,27 @@ EOF
   rm -f "$tmp_event"
 }
 
+@test "reviews: pull_request_review codex COMMENTED → fix-reviews" {
+  export GITHUB_EVENT_NAME="pull_request_review"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/pr_review_codex_commented.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "fix-reviews" ]
+}
+
 # ── pull_request_review_comment tests ────────────────────────────────────────
+
+@test "reviews: pull_request_review_comment codex → fix-reviews" {
+  export GITHUB_EVENT_NAME="pull_request_review_comment"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/pr_review_comment_codex.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "fix-reviews" ]
+}
 
 @test "reviews: pull_request_review_comment copilot → fix-reviews" {
   export GITHUB_EVENT_NAME="pull_request_review_comment"


### PR DESCRIPTION
Fixes #290

## Summary

- **Root cause**: `chatgpt-codex-connector[bot]` was not in the `TRUSTED_BOTS` default list, so `dev-lead-intent.sh` was classifying its `pull_request_review_comment` events as `skip/no-trigger-or-untrusted` instead of `fix-reviews`
- Adds `chatgpt-codex-connector[bot]` to the `TRUSTED_BOTS` default in `dev-lead.yml`
- Adds test fixtures and test cases for codex bot review and review-comment events
- Fixes 3 pre-existing test fixture bugs (missing `author_association` on comment objects causing human-trigger tests to fail)
- Fixes pre-existing `_get_env` helper bug in `test_intent_ci.bats` and `test_intent_issue.bats` — `INTENT_CONTEXT` is written in GitHub Actions multiline heredoc format (`KEY<<DELIM`) but the helper only parsed `KEY=value` format
- Fixes pre-existing copilot rate-limit test failures: tests were creating standalone `copilot` stubs but the engine uses `gh copilot`; updated to set `COPILOT_GITHUB_TOKEN` and stub `gh copilot` calls correctly; use `case "$1"` to guard copilot dispatch before pattern-matching on full args (prompt text may contain "graphql")

All 116 unit tests now pass (was 18 failing before this PR).

## Test plan

- [x] All 116 bats unit tests pass locally
- [x] New tests: `pull_request_review codex COMMENTED → fix-reviews` and `pull_request_review_comment codex → fix-reviews`
- [x] Verified codex bot login: `chatgpt-codex-connector[bot]` (confirmed from PR #284 review API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)