### PR TITLE
fix(dev-lead): add visible body to applied status comments

### DIFF
--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -301,7 +301,7 @@ case "$INTENT_TYPE" in
     if [ "$rc" -eq 0 ]; then
       if commit_and_push "fix-reviews"; then
         notify_coderabbit_resolve
-        post_reviews_terminal "fix-reviews" "applied"
+        post_reviews_terminal "fix-reviews" "applied" "Changes committed and pushed."
       else
         post_reviews_terminal "fix-reviews" "no-changes" "No changes were needed for the open review threads."
       fi
@@ -363,7 +363,7 @@ case "$INTENT_TYPE" in
     if [ "$rc" -eq 0 ]; then
       if commit_and_push "human-pr"; then
         notify_coderabbit_resolve
-        post_reviews_terminal "human-pr" "applied"
+        post_reviews_terminal "human-pr" "applied" "Changes committed and pushed."
       else
         post_reviews_terminal "human-pr" "no-changes" "No changes were needed for this PR."
       fi
@@ -390,7 +390,7 @@ case "$INTENT_TYPE" in
     [ "$rc" -eq 2 ] && handle_rate_limit "rebase"
     if [ "$rc" -eq 0 ]; then
       if commit_and_push "rebase"; then
-        post_reviews_terminal "rebase" "applied"
+        post_reviews_terminal "rebase" "applied" "Rebase completed and pushed."
       else
         post_reviews_terminal "rebase" "no-changes" "PR is already up to date."
       fi


### PR DESCRIPTION
## Summary

- `post_reviews_terminal` builds the comment body from marker + optional summary. When `summary` is empty, the body is a bare HTML comment — GitHub renders it as invisible, making the comment appear empty.
- `fix-reviews`, `human-pr`, and `rebase` applied-status calls were missing the summary argument; `fix-bot-comment` and `human` already had one.

## Test plan

- [x] All 17 unit tests in `test_fix_reviews.bats` pass
- [ ] Verify next `fix-reviews applied` / `human-pr applied` / `rebase applied` run produces a visible comment body

🤖 Generated with [Claude Code](https://claude.com/claude-code)