### PR TITLE
fix(dev-lead): post Add enable-auto-merge intent for bot approvals resolve on no-changes + enable auto-merge on approval

### DIFF
--- a/.github/workflows/dev-lead-reusable.yml
+++ b/.github/workflows/dev-lead-reusable.yml
@@ -101,7 +101,7 @@ jobs:
           echo "::notice::Skipping event: $INTENT_REASON"
 
       - name: Pre-flight checks
-        if: env.INTENT_TYPE != 'skip'
+        if: env.INTENT_TYPE != 'skip' && env.INTENT_TYPE != 'enable-auto-merge'
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GH_PAT_WORKFLOWS: ${{ secrets.GH_PAT_WORKFLOWS }}
@@ -111,14 +111,14 @@ jobs:
 
       # ── Install engine CLIs ───────────────────────────────────────────────
       - name: Cache claude-code CLI
-        if: env.INTENT_TYPE != 'skip'
+        if: env.INTENT_TYPE != 'skip' && env.INTENT_TYPE != 'enable-auto-merge'
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.npm-global
           key: claude-code-${{ vars.CLAUDE_CODE_VERSION || 'latest' }}-${{ runner.os }}
 
       - name: Install engine CLIs
-        if: env.INTENT_TYPE != 'skip'
+        if: env.INTENT_TYPE != 'skip' && env.INTENT_TYPE != 'enable-auto-merge'
         env:
           CLAUDE_CODE_VERSION: ${{ vars.CLAUDE_CODE_VERSION || 'latest' }}
         run: |
@@ -242,6 +242,17 @@ jobs:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           COPILOT_GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           PROMPTS_DIR: .dev-lead/prompts/dev-lead
+        run: bash .dev-lead/scripts/dev-lead-fix-reviews.sh
+
+      # ── enable-auto-merge ─────────────────────────────────────────────────
+      # Triggered when a trusted bot approves a PR. Skips engine install and
+      # pre-flight — just checks reviewDecision and enables auto-merge if APPROVED.
+      - name: Enable auto-merge on bot approval
+        if: env.INTENT_TYPE == 'enable-auto-merge'
+        env:
+          PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}
+          HEAD_SHA: ${{ env.INTENT_HEAD_SHA }}
+          REPO: ${{ github.repository }}
         run: bash .dev-lead/scripts/dev-lead-fix-reviews.sh
 
   # ── ci-relay ──────────────────────────────────────────────────────────────────

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -102,25 +102,25 @@ jobs:
           echo "::notice::Skipping event: $INTENT_REASON"
 
       - name: Pre-flight checks
-        if: env.INTENT_TYPE != 'skip'
+        if: env.INTENT_TYPE != 'skip' && env.INTENT_TYPE != 'enable-auto-merge'
         run: bash scripts/dev-lead-preflight.sh
 
       - name: Configure git identity
-        if: env.INTENT_TYPE != 'skip'
+        if: env.INTENT_TYPE != 'skip' && env.INTENT_TYPE != 'enable-auto-merge'
         run: |
           git config --global user.email "donpetry-bot@users.noreply.github.com"
           git config --global user.name "donpetry-bot"
 
       # ── Install engine CLIs ───────────────────────────────────────────────
       - name: Cache claude-code CLI
-        if: env.INTENT_TYPE != 'skip'
+        if: env.INTENT_TYPE != 'skip' && env.INTENT_TYPE != 'enable-auto-merge'
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.npm-global
           key: claude-code-${{ vars.CLAUDE_CODE_VERSION || 'latest' }}-${{ runner.os }}
 
       - name: Install engine CLIs
-        if: env.INTENT_TYPE != 'skip'
+        if: env.INTENT_TYPE != 'skip' && env.INTENT_TYPE != 'enable-auto-merge'
         env:
           CLAUDE_CODE_VERSION: ${{ vars.CLAUDE_CODE_VERSION || 'latest' }}
           # Pass keys during install if needed for extension setup
@@ -220,6 +220,38 @@ jobs:
           REPO: ${{ github.repository }}
           REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
         run: bash scripts/dev-lead-fix-reviews.sh
+
+      # ── enable-auto-merge ─────────────────────────────────────────────────
+      # Triggered when a trusted bot approves a PR. Skips engine install and
+      # pre-flight — just checks reviewDecision and enables auto-merge if APPROVED.
+      - name: Enable auto-merge on bot approval
+        if: env.INTENT_TYPE == 'enable-auto-merge'
+        env:
+          PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          auto_merge=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" \
+            --jq '.auto_merge // empty' 2>/dev/null || true)
+          if [ -n "$auto_merge" ]; then
+            echo "::notice::PR #${PR_NUMBER} auto-merge already enabled"
+            exit 0
+          fi
+          review_decision=$(gh api graphql -f query='
+            query($owner:String!,$repo:String!,$pr:Int!){
+              repository(owner:$owner,name:$repo){
+                pullRequest(number:$pr){reviewDecision}
+              }
+            }' \
+            -F owner="${REPO%%/*}" -F repo="${REPO##*/}" -F pr="${PR_NUMBER}" \
+            --jq '.data.repository.pullRequest.reviewDecision' 2>/dev/null || true)
+          if [ "${review_decision:-}" = "APPROVED" ]; then
+            echo "::notice::PR #${PR_NUMBER} is APPROVED — enabling auto-merge (squash)"
+            gh pr merge "${PR_NUMBER}" --repo "${REPO}" --auto --squash || \
+              echo "::warning::auto-merge could not be enabled — check repository settings and token permissions"
+          else
+            echo "::notice::PR #${PR_NUMBER} reviewDecision=${review_decision:-unknown} — not yet eligible for auto-merge"
+          fi
 
   # ── ci-relay ────────────────────────────────────────────────────────────────
   # Handles check_run completed events only.

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -229,6 +229,7 @@ jobs:
         env:
           INTENT_TYPE: enable-auto-merge
           PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}
+          HEAD_SHA: ${{ env.INTENT_HEAD_SHA }}
           REPO: ${{ github.repository }}
         run: bash scripts/dev-lead-fix-reviews.sh
 

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -227,31 +227,10 @@ jobs:
       - name: Enable auto-merge on bot approval
         if: env.INTENT_TYPE == 'enable-auto-merge'
         env:
+          INTENT_TYPE: enable-auto-merge
           PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}
           REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          auto_merge=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" \
-            --jq '.auto_merge // empty' 2>/dev/null || true)
-          if [ -n "$auto_merge" ]; then
-            echo "::notice::PR #${PR_NUMBER} auto-merge already enabled"
-            exit 0
-          fi
-          review_decision=$(gh api graphql -f query='
-            query($owner:String!,$repo:String!,$pr:Int!){
-              repository(owner:$owner,name:$repo){
-                pullRequest(number:$pr){reviewDecision}
-              }
-            }' \
-            -F owner="${REPO%%/*}" -F repo="${REPO##*/}" -F pr="${PR_NUMBER}" \
-            --jq '.data.repository.pullRequest.reviewDecision' 2>/dev/null || true)
-          if [ "${review_decision:-}" = "APPROVED" ]; then
-            echo "::notice::PR #${PR_NUMBER} is APPROVED — enabling auto-merge (squash)"
-            gh pr merge "${PR_NUMBER}" --repo "${REPO}" --auto --squash || \
-              echo "::warning::auto-merge could not be enabled — check repository settings and token permissions"
-          else
-            echo "::notice::PR #${PR_NUMBER} reviewDecision=${review_decision:-unknown} — not yet eligible for auto-merge"
-          fi
+        run: bash scripts/dev-lead-fix-reviews.sh
 
   # ── ci-relay ────────────────────────────────────────────────────────────────
   # Handles check_run completed events only.

--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -109,31 +109,58 @@ notify_coderabbit_resolve() {
 # try_enable_auto_merge: enables auto-merge (squash) on the PR if reviewDecision is
 # APPROVED and auto-merge is not already set. Safe to call speculatively — checks
 # eligibility first and is idempotent if auto-merge is already on.
+# Pass "true" as first arg for strict mode: API errors propagate and a merge failure
+# exits non-zero rather than emitting a warning (use for the enable-auto-merge intent).
 try_enable_auto_merge() {
+  local strict="${1:-false}"
   if [ "${DEV_LEAD_DRY_RUN:-false}" = "true" ]; then
     echo "[dry-run] would enable auto-merge if PR #${PR_NUMBER} is APPROVED"
     return 0
   fi
-  local auto_merge_state
-  auto_merge_state=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" \
-    --jq '.auto_merge // empty' 2>/dev/null || true)
-  if [ -n "$auto_merge_state" ]; then
-    echo "::notice::PR #${PR_NUMBER} auto-merge already enabled"
-    return 0
+
+  local auto_merge_state review_decision
+
+  if [ "$strict" = "true" ]; then
+    auto_merge_state=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.auto_merge // empty')
+    if [ -n "$auto_merge_state" ]; then
+      echo "::notice::PR #${PR_NUMBER} auto-merge already enabled"
+      return 0
+    fi
+    review_decision=$(gh api graphql -f query='
+      query($owner:String!,$repo:String!,$pr:Int!){
+        repository(owner:$owner,name:$repo){
+          pullRequest(number:$pr){reviewDecision}
+        }
+      }' \
+      -F owner="${REPO%%/*}" -F repo="${REPO##*/}" -F pr="$PR_NUMBER" \
+      --jq '.data.repository.pullRequest.reviewDecision')
+  else
+    auto_merge_state=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" \
+      --jq '.auto_merge // empty' 2>/dev/null || true)
+    if [ -n "$auto_merge_state" ]; then
+      echo "::notice::PR #${PR_NUMBER} auto-merge already enabled"
+      return 0
+    fi
+    review_decision=$(gh api graphql -f query='
+      query($owner:String!,$repo:String!,$pr:Int!){
+        repository(owner:$owner,name:$repo){
+          pullRequest(number:$pr){reviewDecision}
+        }
+      }' \
+      -F owner="${REPO%%/*}" -F repo="${REPO##*/}" -F pr="$PR_NUMBER" \
+      --jq '.data.repository.pullRequest.reviewDecision' 2>/dev/null || true)
   fi
-  local review_decision
-  review_decision=$(gh api graphql -f query='
-    query($owner:String!,$repo:String!,$pr:Int!){
-      repository(owner:$owner,name:$repo){
-        pullRequest(number:$pr){reviewDecision}
-      }
-    }' \
-    -F owner="${REPO%%/*}" -F repo="${REPO##*/}" -F pr="$PR_NUMBER" \
-    --jq '.data.repository.pullRequest.reviewDecision' 2>/dev/null || true)
+
   if [ "${review_decision:-}" = "APPROVED" ]; then
     echo "::notice::PR #${PR_NUMBER} is APPROVED — enabling auto-merge (squash)"
-    gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --squash 2>/dev/null || \
-      echo "::warning::auto-merge could not be enabled on PR #${PR_NUMBER} — check repository settings and token permissions"
+    local merge_args=(--auto --squash)
+    [ -n "${HEAD_SHA:-}" ] && merge_args+=(--match-head-commit "$HEAD_SHA")
+    if [ "$strict" = "true" ]; then
+      gh pr merge "$PR_NUMBER" --repo "$REPO" "${merge_args[@]}"
+    else
+      gh pr merge "$PR_NUMBER" --repo "$REPO" "${merge_args[@]}" 2>/dev/null || \
+        echo "::warning::auto-merge could not be enabled on PR #${PR_NUMBER} — check repository settings and token permissions"
+    fi
   else
     echo "::notice::PR #${PR_NUMBER} reviewDecision=${review_decision:-unknown} — not yet eligible for auto-merge"
   fi
@@ -441,7 +468,7 @@ case "$INTENT_TYPE" in
       echo "::error::PR_NUMBER is required for enable-auto-merge"
       exit 1
     fi
-    try_enable_auto_merge
+    try_enable_auto_merge "true"
     ;;
   *)
     echo "::error::Unknown intent type: $INTENT_TYPE"

--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -436,6 +436,13 @@ case "$INTENT_TYPE" in
     fi
     exit "$rc"
     ;;
+  enable-auto-merge)
+    if [ -z "$PR_NUMBER" ]; then
+      echo "::error::PR_NUMBER is required for enable-auto-merge"
+      exit 1
+    fi
+    try_enable_auto_merge
+    ;;
   *)
     echo "::error::Unknown intent type: $INTENT_TYPE"
     exit 1

--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -117,6 +117,12 @@ try_enable_auto_merge() {
     echo "[dry-run] would enable auto-merge if PR #${PR_NUMBER} is APPROVED"
     return 0
   fi
+  # Refresh HEAD_SHA to the commit that is now the PR head. commit_and_push may
+  # have created a new commit after HEAD_SHA was resolved at script startup, so
+  # --match-head-commit would fail with the stale value.
+  local current_head
+  current_head=$(git rev-parse HEAD 2>/dev/null || true)
+  [ -n "$current_head" ] && HEAD_SHA="$current_head"
 
   local auto_merge_state review_decision
 
@@ -153,12 +159,12 @@ try_enable_auto_merge() {
 
   if [ "${review_decision:-}" = "APPROVED" ]; then
     echo "::notice::PR #${PR_NUMBER} is APPROVED — enabling auto-merge (squash)"
-    local merge_args=(--auto --squash)
-    [ -n "${HEAD_SHA:-}" ] && merge_args+=(--match-head-commit "$HEAD_SHA")
+    set -- --auto --squash
+    [ -n "${HEAD_SHA:-}" ] && set -- "$@" --match-head-commit "$HEAD_SHA"
     if [ "$strict" = "true" ]; then
-      gh pr merge "$PR_NUMBER" --repo "$REPO" "${merge_args[@]}"
+      gh pr merge "$PR_NUMBER" --repo "$REPO" "$@"
     else
-      gh pr merge "$PR_NUMBER" --repo "$REPO" "${merge_args[@]}" 2>/dev/null || \
+      gh pr merge "$PR_NUMBER" --repo "$REPO" "$@" 2>/dev/null || \
         echo "::warning::auto-merge could not be enabled on PR #${PR_NUMBER} — check repository settings and token permissions"
     fi
   else

--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -106,6 +106,39 @@ notify_coderabbit_resolve() {
   fi
 }
 
+# try_enable_auto_merge: enables auto-merge (squash) on the PR if reviewDecision is
+# APPROVED and auto-merge is not already set. Safe to call speculatively — checks
+# eligibility first and is idempotent if auto-merge is already on.
+try_enable_auto_merge() {
+  if [ "${DEV_LEAD_DRY_RUN:-false}" = "true" ]; then
+    echo "[dry-run] would enable auto-merge if PR #${PR_NUMBER} is APPROVED"
+    return 0
+  fi
+  local auto_merge_state
+  auto_merge_state=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" \
+    --jq '.auto_merge // empty' 2>/dev/null || true)
+  if [ -n "$auto_merge_state" ]; then
+    echo "::notice::PR #${PR_NUMBER} auto-merge already enabled"
+    return 0
+  fi
+  local review_decision
+  review_decision=$(gh api graphql -f query='
+    query($owner:String!,$repo:String!,$pr:Int!){
+      repository(owner:$owner,name:$repo){
+        pullRequest(number:$pr){reviewDecision}
+      }
+    }' \
+    -F owner="${REPO%%/*}" -F repo="${REPO##*/}" -F pr="$PR_NUMBER" \
+    --jq '.data.repository.pullRequest.reviewDecision' 2>/dev/null || true)
+  if [ "${review_decision:-}" = "APPROVED" ]; then
+    echo "::notice::PR #${PR_NUMBER} is APPROVED — enabling auto-merge (squash)"
+    gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --squash 2>/dev/null || \
+      echo "::warning::auto-merge could not be enabled on PR #${PR_NUMBER} — check repository settings and token permissions"
+  else
+    echo "::notice::PR #${PR_NUMBER} reviewDecision=${review_decision:-unknown} — not yet eligible for auto-merge"
+  fi
+}
+
 # commit_and_push: stages any uncommitted changes (including untracked files),
 # commits if needed, and pushes. Returns 0 if changes were pushed, 1 if nothing to push.
 # Handles two cases:
@@ -303,8 +336,10 @@ case "$INTENT_TYPE" in
         notify_coderabbit_resolve
         post_reviews_terminal "fix-reviews" "applied" "Changes committed and pushed."
       else
+        notify_coderabbit_resolve
         post_reviews_terminal "fix-reviews" "no-changes" "No changes were needed for the open review threads."
       fi
+      try_enable_auto_merge
     fi
     exit "$rc"
     ;;
@@ -319,8 +354,10 @@ case "$INTENT_TYPE" in
         notify_coderabbit_resolve
         post_reviews_terminal "fix-bot-comment" "applied" "Changes committed and pushed."
       else
+        notify_coderabbit_resolve
         post_reviews_terminal "fix-bot-comment" "no-changes" "Engine ran but made no changes."
       fi
+      try_enable_auto_merge
     fi
     exit "$rc"
     ;;
@@ -365,8 +402,10 @@ case "$INTENT_TYPE" in
         notify_coderabbit_resolve
         post_reviews_terminal "human-pr" "applied" "Changes committed and pushed."
       else
+        notify_coderabbit_resolve
         post_reviews_terminal "human-pr" "no-changes" "No changes were needed for this PR."
       fi
+      try_enable_auto_merge
     fi
     exit "$rc"
     ;;

--- a/scripts/dev-lead-intent.sh
+++ b/scripts/dev-lead-intent.sh
@@ -219,9 +219,8 @@ case "$EVENT_NAME" in
       '{"pr_number":$pr_number,"head_sha":$head_sha,"actor":$actor,"body":$body}')
 
     if is_trusted_bot "$reviewer"; then
-      # Bot review: only route non-APPROVED states
       if [ "$review_state" = "APPROVED" ]; then
-        emit_skip "bot-approved"
+        emit_intent "enable-auto-merge" "bot-approved" "$context"
       else
         emit_intent "fix-reviews" "bot-review-${review_state}" "$context"
       fi

--- a/scripts/dev-lead-intent.sh
+++ b/scripts/dev-lead-intent.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 #   human-pr        — Human review changes-requested
 #   issue           — Issue labeled dev-lead/claude
 #   rebase          — Rebase conflict sentinel
+#   enable-auto-merge — Bot approval: enable auto-merge if PR is APPROVED
 #   ci-relay        — check_run relay (handled by ci-relay job, not this script)
 #   skip            — Event should be ignored
 

--- a/tests/dev-lead/fixtures/events/pr_review_coderabbit_approved.json
+++ b/tests/dev-lead/fixtures/events/pr_review_coderabbit_approved.json
@@ -1,0 +1,30 @@
+{
+  "_test_expected_intent": "enable-auto-merge",
+  "action": "submitted",
+  "review": {
+    "id": 1010,
+    "state": "APPROVED",
+    "body": "All comments resolved. LGTM!",
+    "user": {
+      "login": "coderabbitai[bot]",
+      "type": "Bot"
+    }
+  },
+  "pull_request": {
+    "number": 80,
+    "title": "ci: add required ci.yml workflow",
+    "state": "open",
+    "author_association": "OWNER",
+    "head": {
+      "sha": "03b4349fda588edd13a7a78b823d9a7a9973f5e2",
+      "ref": "claude/issue-46-20260508-1409",
+      "repo": { "full_name": "petry-projects/.github-private" }
+    },
+    "base": {
+      "ref": "main",
+      "repo": { "full_name": "petry-projects/.github-private" }
+    }
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "coderabbitai[bot]", "type": "Bot" }
+}

--- a/tests/dev-lead/unit/test_fix_reviews.bats
+++ b/tests/dev-lead/unit/test_fix_reviews.bats
@@ -380,7 +380,7 @@ STUB
   run bash "$FIX_REVIEWS_SCRIPT"
 
   [ "$status" -eq 0 ]
-  [[ "$output" == *"coderabbitai"* || "$output" == *"resolve"* || "$output" == *"[dry-run]"* ]]
+  [[ "$output" == *"would check for coderabbitai CHANGES_REQUESTED"* ]]
 }
 
 @test "fix-reviews: try_enable_auto_merge dry-run output present for fix-reviews" {
@@ -390,7 +390,7 @@ STUB
   run bash "$FIX_REVIEWS_SCRIPT"
 
   [ "$status" -eq 0 ]
-  [[ "$output" == *"auto-merge"* || "$output" == *"[dry-run]"* ]]
+  [[ "$output" == *"would enable auto-merge"* ]]
 }
 
 @test "fix-reviews: try_enable_auto_merge dry-run output present for fix-bot-comment" {
@@ -401,7 +401,7 @@ STUB
   run bash "$FIX_REVIEWS_SCRIPT"
 
   [ "$status" -eq 0 ]
-  [[ "$output" == *"auto-merge"* || "$output" == *"[dry-run]"* ]]
+  [[ "$output" == *"would enable auto-merge"* ]]
 }
 
 @test "fix-reviews: try_enable_auto_merge dry-run output present for human-pr" {
@@ -413,7 +413,7 @@ STUB
   run bash "$FIX_REVIEWS_SCRIPT"
 
   [ "$status" -eq 0 ]
-  [[ "$output" == *"auto-merge"* || "$output" == *"[dry-run]"* ]]
+  [[ "$output" == *"would enable auto-merge"* ]]
 }
 
 @test "fix-reviews: terminal marker written after successful fix-reviews run" {

--- a/tests/dev-lead/unit/test_fix_reviews.bats
+++ b/tests/dev-lead/unit/test_fix_reviews.bats
@@ -373,6 +373,49 @@ STUB
   [[ "$output" == *"skipping duplicate"* ]]
 }
 
+@test "fix-reviews: no-changes path also calls notify_coderabbit_resolve (dry-run)" {
+  export INTENT_TYPE="fix-reviews"
+  export DEV_LEAD_DRY_RUN="true"
+
+  run bash "$FIX_REVIEWS_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"coderabbitai"* || "$output" == *"resolve"* || "$output" == *"[dry-run]"* ]]
+}
+
+@test "fix-reviews: try_enable_auto_merge dry-run output present for fix-reviews" {
+  export INTENT_TYPE="fix-reviews"
+  export DEV_LEAD_DRY_RUN="true"
+
+  run bash "$FIX_REVIEWS_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"auto-merge"* || "$output" == *"[dry-run]"* ]]
+}
+
+@test "fix-reviews: try_enable_auto_merge dry-run output present for fix-bot-comment" {
+  export INTENT_TYPE="fix-bot-comment"
+  export DEV_LEAD_DRY_RUN="true"
+  export COMMENT_BODY="SonarQube found issues"
+
+  run bash "$FIX_REVIEWS_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"auto-merge"* || "$output" == *"[dry-run]"* ]]
+}
+
+@test "fix-reviews: try_enable_auto_merge dry-run output present for human-pr" {
+  export INTENT_TYPE="human-pr"
+  export DEV_LEAD_DRY_RUN="true"
+  export PR_TITLE="Test PR"
+  export PR_DESCRIPTION="A test pull request"
+
+  run bash "$FIX_REVIEWS_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"auto-merge"* || "$output" == *"[dry-run]"* ]]
+}
+
 @test "fix-reviews: terminal marker written after successful fix-reviews run" {
   export INTENT_TYPE="fix-reviews"
   export DEV_LEAD_DRY_RUN="true"

--- a/tests/dev-lead/unit/test_intent_ci.bats
+++ b/tests/dev-lead/unit/test_intent_ci.bats
@@ -129,7 +129,7 @@ EOF
   [ "$(_get_env INTENT_TYPE)" = "fix-reviews" ]
 }
 
-@test "ci: pull_request review from copilot APPROVED → skip" {
+@test "ci: pull_request review from copilot APPROVED → enable-auto-merge" {
   export GITHUB_EVENT_NAME="pull_request_review"
   export GITHUB_EVENT_PATH="$FIXTURES_DIR/pr_review_copilot_approved.json"
   export TRUSTED_BOTS="copilot-pull-request-reviewer[bot],gemini-code-assist[bot],sonarqubecloud[bot],coderabbitai[bot]"
@@ -137,7 +137,7 @@ EOF
   run bash "$INTENT_SCRIPT"
 
   [ "$status" -eq 0 ]
-  [ "$(_get_env INTENT_TYPE)" = "skip" ]
+  [ "$(_get_env INTENT_TYPE)" = "enable-auto-merge" ]
 }
 
 @test "ci: issues labeled dev-lead → issue" {

--- a/tests/dev-lead/unit/test_intent_reviews.bats
+++ b/tests/dev-lead/unit/test_intent_reviews.bats
@@ -35,14 +35,24 @@ _get_env() {
   [ "$(_get_env INTENT_TYPE)" = "fix-reviews" ]
 }
 
-@test "reviews: pull_request_review copilot APPROVED → skip" {
+@test "reviews: pull_request_review copilot APPROVED → enable-auto-merge" {
   export GITHUB_EVENT_NAME="pull_request_review"
   export GITHUB_EVENT_PATH="$FIXTURES_DIR/pr_review_copilot_approved.json"
 
   run bash "$INTENT_SCRIPT"
 
   [ "$status" -eq 0 ]
-  [ "$(_get_env INTENT_TYPE)" = "skip" ]
+  [ "$(_get_env INTENT_TYPE)" = "enable-auto-merge" ]
+}
+
+@test "reviews: pull_request_review coderabbit APPROVED → enable-auto-merge" {
+  export GITHUB_EVENT_NAME="pull_request_review"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/pr_review_coderabbit_approved.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "enable-auto-merge" ]
 }
 
 @test "reviews: pull_request_review gemini CHANGES_REQUESTED → fix-reviews" {


### PR DESCRIPTION
## Summary

- **`@coderabbitai resolve` in no-changes path**: `notify_coderabbit_resolve` was only called when the agent pushed code changes. When the agent made no changes (e.g. CodeRabbit flagged a file outside the PR diff), CodeRabbit's CHANGES_REQUESTED persisted indefinitely. Now called in both branches for `fix-reviews`, `fix-bot-comment`, and `human-pr`.
- **Auto-merge on approval**: Added `try_enable_auto_merge()` called at the end of all three intent completion paths. Added a new `enable-auto-merge` intent emitted when any trusted bot approves — this lightweight path skips engine install (uses only the `gh` CLI, no LLM) and enables auto-merge if the PR's `reviewDecision` is `APPROVED`.
- **Root cause of PR #80**: CodeRabbit's CHANGES_REQUESTED on 2026-05-17 was on `claude.yml`, a file outside the PR diff. The fix-reviews run found no open threads to address, made no changes, and never posted `@coderabbitai resolve` — leaving the PR in CHANGES_REQUESTED for 3 days until unrelated activity triggered CodeRabbit to re-review.

## Files changed

| File | Change |
| --- | --- |
| `scripts/dev-lead-intent.sh` | `bot-approved` skip → `enable-auto-merge` intent |
| `scripts/dev-lead-fix-reviews.sh` | Add `try_enable_auto_merge()`; call `notify_coderabbit_resolve` in no-changes branches |
| `.github/workflows/dev-lead.yml` | Add `enable-auto-merge` step; skip pre-flight/engine install for that intent |
| `tests/dev-lead/unit/test_intent_reviews.bats` | Update copilot APPROVED test; add coderabbit APPROVED test |
| `tests/dev-lead/unit/test_intent_ci.bats` | Update copilot APPROVED test |
| `tests/dev-lead/unit/test_fix_reviews.bats` | Add 4 new tests for no-changes resolve and auto-merge dry-run |
| `tests/dev-lead/fixtures/events/pr_review_coderabbit_approved.json` | New fixture |

## Test plan

- [x] All 121 unit tests pass locally
- [ ] CI passes
- [ ] Verify: on next CodeRabbit CHANGES_REQUESTED + no-changes agent run, `@coderabbitai resolve` is posted
- [ ] Verify: on next bot APPROVED event for a fully-approved PR, auto-merge is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated pull request auto-merge when approved by designated bot reviewers, streamlining code review workflows and eliminating manual merge steps to improve development velocity.

* **Chores**
  * Optimized workflows to skip unnecessary pre-flight checks and dependency installation steps when auto-merge is being enabled, improving overall efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/petry-projects/.github-private/pull/297?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->