### PR TITLE
feat(pr-review): replace cron schedule with event-driven triggers

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,8 +1,42 @@
 name: PR Review Agent
 
 on:
-  schedule:
-    - cron: "0 * * * *"
+  # ── Event-driven triggers ────────────────────────────────────────────────
+  # These replace the former time-based schedule. The review engine's own
+  # idempotency check (head-SHA marker) prevents duplicate reviews, so
+  # firing multiple times on the same PR is always safe.
+  #
+  # Coverage note: these events are scoped to this repo (.github-private).
+  # For org-wide event-driven triggering (broodly, markets, etc.), deploy
+  # a thin pr-review-auto-trigger.yml caller stub to each repo (Phase 2).
+
+  check_suite:
+    # Fires when a CI check suite completes on any branch in this repo.
+    # We only act when the suite succeeded (failing/pending PRs are already
+    # skipped by review-one-pr.sh's CI gate, but filtering here avoids
+    # spinning up a runner at all). Empty pull_requests arrays (e.g. pushes
+    # to main) are dropped in the job condition below.
+    types: [completed]
+
+  pull_request_review:
+    # Fires when a reviewer submits a review or dismisses one.
+    #   submitted  — covers APPROVED (green light) and CHANGES_REQUESTED
+    #                (agent will skip via its own gate, but APPROVED is the
+    #                common case that unlocks a previously-blocked PR).
+    #   dismissed  — a CHANGES_REQUESTED review was dismissed, clearing the
+    #                block so the agent can re-engage with the updated code.
+    types: [submitted, dismissed]
+
+  pull_request:
+    # ready_for_review — draft PR promoted to open (ready for first review).
+    # reopened          — closed PR is reopened (e.g. after revision).
+    # synchronize       — new commits pushed (author addressed review comments);
+    #                     CI will be pending immediately, so review-one-pr.sh
+    #                     skips cheaply — the check_suite trigger fires once CI
+    #                     settles and is the real wake signal post-push.
+    types: [ready_for_review, reopened, synchronize]
+
+  # ── Manual / programmatic triggers ──────────────────────────────────────
   workflow_dispatch:
     inputs:
       pr_url:
@@ -31,16 +65,41 @@ permissions:
   checks: read
 
 concurrency:
-  # Scheduled and manual batch runs share one slot to prevent overlap.
-  # Mention-triggered runs (repository_dispatch or workflow_dispatch with pr_url)
-  # get per-PR slots so they don't queue behind hourly batches or each other.
-  group: ${{ (inputs.pr_url || github.event.client_payload.pr_url) && format('pr-review-mention-{0}', inputs.pr_url || github.event.client_payload.pr_url) || 'pr-review-scheduled' }}
+  # Event-triggered and mention-triggered runs for a specific PR get a per-PR
+  # concurrency slot so they never queue behind unrelated PRs.
+  # Manual batch runs (workflow_dispatch without pr_url) use a shared slot.
+  group: >-
+    ${{
+      (inputs.pr_url
+       || github.event.client_payload.pr_url
+       || github.event.pull_request.html_url)
+      && format('pr-review-pr-{0}',
+           inputs.pr_url
+           || github.event.client_payload.pr_url
+           || github.event.pull_request.html_url)
+      || 'pr-review-batch'
+    }}
   cancel-in-progress: false
 
 jobs:
   review:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # Early exit conditions (avoids spinning up the runner for guaranteed no-ops):
+    #   check_suite  — only proceed when CI succeeded and there's an associated PR.
+    #                  Failing suites are always skipped by review-one-pr.sh; empty
+    #                  pull_requests (e.g. direct pushes to main) have nothing to review.
+    #   pull_request_review — skip COMMENTED reviews; they don't change merge-readiness.
+    #                         CHANGES_REQUESTED reviews are also skipped because the PR
+    #                         is now blocked; review-one-pr.sh would skip it anyway.
+    if: >-
+      (github.event_name != 'check_suite' ||
+       (github.event.check_suite.conclusion == 'success' &&
+        github.event.check_suite.pull_requests[0] != null))
+      &&
+      (github.event_name != 'pull_request_review' ||
+       github.event.review.state == 'approved' ||
+       github.event.review.state == 'dismissed')
     env:
       # Auth for every gh / script call in this job. The PAT must belong to BOT_USER.
       GH_TOKEN: ${{ secrets.DON_PETRY_BOT_GH_PAT }}
@@ -62,10 +121,30 @@ jobs:
       GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
       GEMINI_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
       GEMINI_CLI_TRUST_WORKSPACE: "true"
-      # Default to dry-run. workflow_dispatch can override; repository_dispatch
-      # (mention) always runs live; vars.LIVE_MODE=true switches scheduled runs live.
+      # Event-triggered runs respect LIVE_MODE (same semantics as the former schedule).
+      # repository_dispatch (mention) always runs live.
+      # workflow_dispatch respects the dry_run input.
       DRY_RUN: ${{ github.event_name == 'repository_dispatch' && 'false' || inputs.dry_run || (vars.LIVE_MODE == 'true' && 'false' || 'true') }}
-      PR_URL_OVERRIDE: ${{ inputs.pr_url || github.event.client_payload.pr_url }}
+      # PR URL to review. Populated from inputs (workflow_dispatch), client_payload
+      # (repository_dispatch), or the PR context for event-triggered runs.
+      # check_suite events may have multiple PRs; those are handled separately via
+      # CHECK_SUITE_PRS in the "Enumerate candidate PRs" step.
+      PR_URL_OVERRIDE: >-
+        ${{
+          inputs.pr_url
+          || github.event.client_payload.pr_url
+          || (github.event_name == 'pull_request_review' && github.event.pull_request.html_url)
+          || (github.event_name == 'pull_request' && github.event.pull_request.html_url)
+          || ''
+        }}
+      # JSON array of PRs associated with a check_suite event. Empty for all
+      # other event types. Consumed by "Enumerate candidate PRs" to extract URLs.
+      CHECK_SUITE_PRS: >-
+        ${{
+          github.event_name == 'check_suite'
+          && toJSON(github.event.check_suite.pull_requests)
+          || '[]'
+        }}
       DELEGATION_ORGS: ${{ vars.DELEGATION_ORGS || vars.CLAUDE_ORGS || '' }}
       MAX_REVIEW_CYCLES: ${{ vars.MAX_REVIEW_CYCLES || '3' }}
       MAX_PRS: ${{ vars.MAX_PRS || '10' }}
@@ -74,7 +153,8 @@ jobs:
       # 'latest' caches an install indefinitely under that key — flush via the
       # Actions cache UI or bump the variable to pick up new releases.
       CLAUDE_CODE_VERSION: ${{ vars.CLAUDE_CODE_VERSION || 'latest' }}
-      # Mention-triggered reviews always force; workflow_dispatch respects the input.
+      # Mention-triggered reviews always force a re-review; all other triggers
+      # respect the idempotency check (no double-reviews on the same head SHA).
       FORCE_REVIEW: ${{ github.event_name == 'repository_dispatch' && 'true' || inputs.force_review || 'false' }}
 
     steps:
@@ -139,7 +219,18 @@ jobs:
         run: |
           set -euo pipefail
           if [ -n "${PR_URL_OVERRIDE}" ]; then
+            # Single-PR mode: workflow_dispatch with pr_url, repository_dispatch
+            # (mention), or event-triggered run with a direct PR context
+            # (pull_request_review / pull_request events).
             printf '%s\n' "${PR_URL_OVERRIDE}" > prs.txt
+          elif [ "${CHECK_SUITE_PRS}" != "[]" ] && [ -n "${CHECK_SUITE_PRS}" ]; then
+            # check_suite event: one or more PRs share the completed suite.
+            # The payload carries API URLs (https://api.github.com/repos/…/pulls/N);
+            # convert them to HTML URLs (https://github.com/…/pull/N) for review-one-pr.sh.
+            echo "${CHECK_SUITE_PRS}" \
+              | jq -r '.[].url' \
+              | sed 's|https://api\.github\.com/repos/|https://github.com/|; s|/pulls/|/pull/|' \
+              > prs.txt
           else
             bash scripts/list-prs.sh > prs.txt
           fi


### PR DESCRIPTION
## Summary

Replaces the time-based `schedule:` trigger with three event-driven triggers that fire when a PR's review-readiness actually changes, rather than on a fixed clock interval.

### New triggers

| Event | Types | Fires when |
|---|---|---|
| `check_suite` | `completed` | CI finishes — the primary signal that a PR moved from pending to ready |
| `pull_request_review` | `submitted`, `dismissed` | Reviewer approves, or a `CHANGES_REQUESTED` block is dismissed |
| `pull_request` | `ready_for_review`, `reopened`, `synchronize` | Draft promoted, PR reopened, or author pushes new commits |

### Noise-reduction: job `if:` conditions

Drops guaranteed no-ops **before a runner is even allocated**:
- `check_suite` with failing/cancelled conclusion → skip
- `check_suite` with no associated PRs (e.g. push to `main`) → skip
- `pull_request_review` with state `commented` or `changes_requested` → skip (agent's own CI gate would skip anyway, but this avoids spinning up a runner)

### Key implementation details

- **`PR_URL_OVERRIDE`** is now populated from `github.event.pull_request.html_url` for `pull_request_review` and `pull_request` events — same single-PR fast path as mention-triggered reviews.
- **`CHECK_SUITE_PRS`** new env var carries `toJSON(github.event.check_suite.pull_requests)` for the case where a suite has multiple associated PRs. The enumerate step converts GitHub API URLs (`api.github.com/repos/…/pulls/N`) to HTML URLs (`github.com/…/pull/N`) via `sed`.
- **`concurrency.group`** updated from `pr-review-mention-{url}` / `pr-review-scheduled` → `pr-review-pr-{url}` / `pr-review-batch` to reflect the broader trigger scope.
- **`FORCE_REVIEW`** unchanged — only `repository_dispatch` (mention) forces re-review; all event-triggered runs respect the idempotency check.
- **`DRY_RUN`** unchanged — event-triggered runs behave like the former schedule, respecting `vars.LIVE_MODE` (currently `true`).

### What "comments resolved" means in practice

GitHub fires **no webhook** for the "resolve conversation" UI action. The closest proxy events captured here are:
- `pull_request_review: dismissed` — reviewer dismisses their `CHANGES_REQUESTED`, unblocking the PR
- `pull_request: synchronize` — author pushes new commits after addressing feedback (CI then settles → `check_suite` fires)

### Scope limitation (Phase 2)

These triggers are scoped to `.github-private`. PRs in `broodly`, `markets`, `ContentTwin`, etc. still require mention-triggering. Phase 2 would deploy a `pr-review-auto-trigger.yml` thin caller stub (same pattern as `pr-review-mention.yml`) to each repo in the org.

## Test plan

- [ ] Push a commit to an open PR in `.github-private` — verify `check_suite: completed` fires the review workflow once CI settles (not on the push itself)
- [ ] Approve a PR in `.github-private` — verify `pull_request_review: submitted` fires
- [ ] Dismiss a `CHANGES_REQUESTED` review — verify `pull_request_review: dismissed` fires
- [ ] Verify a `pull_request_review` with state `commented` does **not** start a runner (job `if:` filters it)
- [ ] Verify a `check_suite` on a `main`-branch push does **not** start a runner (no associated PRs)
- [ ] Manually trigger via `workflow_dispatch` — still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)