### PR TITLE
fix(dev-lead): relay check_run id, verify engine CLI, improve SonarCloud guidance

### DIFF
--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -157,6 +157,7 @@ jobs:
             claude)  claude --version ;;
             gemini)  gemini --version ;;
             copilot) gh copilot --version ;;
+            *) echo "::error::Unknown DEV_LEAD_ENGINE value: '${DEV_LEAD_ENGINE}'. Must be one of: claude, gemini, copilot"; exit 1 ;;
           esac
 
       # ── fix-ci ────────────────────────────────────────────────────────────

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -148,6 +148,17 @@ jobs:
             gh extension install github/gh-copilot || true
           fi
 
+      - name: Verify primary engine CLI
+        if: env.INTENT_TYPE != 'skip' && env.INTENT_TYPE != 'enable-auto-merge'
+        run: |
+          # Fail fast if the primary engine binary is missing — a silent exit 127
+          # later would waste tokens and incorrectly count toward PR exhaustion.
+          case "${DEV_LEAD_ENGINE:-claude}" in
+            claude)  claude --version ;;
+            gemini)  gemini --version ;;
+            copilot) gh copilot --version ;;
+          esac
+
       # ── fix-ci ────────────────────────────────────────────────────────────
       - name: Run fix-ci
         if: env.INTENT_TYPE == 'fix-ci'
@@ -268,6 +279,7 @@ jobs:
           RELAY_HEAD_SHA: ${{ github.event.check_run.head_sha }}
           RELAY_REPO: ${{ github.repository }}
           RELAY_CHECK_NAME: ${{ github.event.check_run.name }}
+          RELAY_CHECK_ID: ${{ github.event.check_run.id }}
           RELAY_CONCLUSION: ${{ github.event.check_run.conclusion }}
           RELAY_DETAILS_URL: ${{ github.event.check_run.details_url }}
           RELAY_APP_SLUG: ${{ github.event.check_run.app.slug }}
@@ -279,6 +291,7 @@ jobs:
             --arg head_sha "$RELAY_HEAD_SHA" \
             --arg repo "$RELAY_REPO" \
             --arg name "$RELAY_CHECK_NAME" \
+            --argjson check_id "$RELAY_CHECK_ID" \
             --arg conclusion "$RELAY_CONCLUSION" \
             --arg details_url "$RELAY_DETAILS_URL" \
             --arg app_slug "$RELAY_APP_SLUG" \
@@ -288,7 +301,7 @@ jobs:
                 pr_number: $pr_number,
                 head_sha: $head_sha,
                 repo: $repo,
-                checks: [{name: $name, conclusion: $conclusion, details_url: $details_url, app_slug: $app_slug}]
+                checks: [{id: $check_id, name: $name, conclusion: $conclusion, details_url: $details_url, app_slug: $app_slug}]
               }
             }')
           echo "$payload" | gh api \

--- a/prompts/dev-lead/fix-ci.md
+++ b/prompts/dev-lead/fix-ci.md
@@ -49,10 +49,10 @@ Common SonarCloud Security Hotspot patterns to look for in changed files:
 | Hardcoded credentials / API keys | Move to secrets / env vars |
 | `eval` / `exec` with dynamic input | Remove dynamic execution or sanitize input |
 | HTTP (non-HTTPS) download URLs | Change to `https://` |
-| `npm install` without `--ignore-scripts` | Add `--ignore-scripts` if install scripts are not required; otherwise document why they are needed |
+| `npm install` without `--ignore-scripts` | Add `--ignore-scripts` if install scripts are not required; otherwise, this may require manual acknowledgment in the SonarCloud UI |
 | `npm install pkg@variable` or `@latest` | Pin to an exact version number (e.g. `pkg@1.2.3`), or exclude the file in `sonar-project.properties` if version is intentionally managed via a CI variable |
 
-Fix each identified issue and commit.
+- Fix each identified issue.
 
 ## Constraints
 

--- a/prompts/dev-lead/fix-ci.md
+++ b/prompts/dev-lead/fix-ci.md
@@ -37,14 +37,22 @@ Analyze the CI failure logs and annotations above, then fix the root cause(s). Y
 
 If **Failure Logs** begins with `# External quality gate`, this check is not a GitHub Actions workflow — it is an external service that reported a quality gate failure. In this case:
 
-- **Failure Logs** contains the PR diff instead of log output; **Annotations** will be empty
-- Use the PR diff to identify what the gate likely flagged
-- For **SonarQube / SonarCloud Security Hotspots**, scan changed files for:
-  - `curl … | bash` / `wget … | sh` — script injection hotspot (replace with a pinned install or `gh extension install`)
-  - Hardcoded credentials, tokens, or API keys
-  - `eval` / `exec` with dynamic input
-  - HTTP (non-HTTPS) URLs for script or package downloads
-- Fix each identified hotspot and commit
+- **Annotations** contains the specific lines and rule messages flagged by the gate — read it carefully
+- If **Annotations** is empty, **Failure Logs** contains the PR diff to identify what the gate likely flagged
+- For **SonarQube / SonarCloud**, note: `# NOSONAR` suppresses Bugs/Code Smells but **not Security Hotspots** — hotspots require code changes or UI acknowledgment in SonarCloud
+
+Common SonarCloud Security Hotspot patterns to look for in changed files:
+
+| Pattern | Typical fix |
+|---|---|
+| `curl … \| bash` / `wget … \| sh` | Replace with pinned download + verify checksum, or `gh extension install` |
+| Hardcoded credentials / API keys | Move to secrets / env vars |
+| `eval` / `exec` with dynamic input | Remove dynamic execution or sanitize input |
+| HTTP (non-HTTPS) download URLs | Change to `https://` |
+| `npm install` without `--ignore-scripts` | Add `--ignore-scripts` if install scripts are not required; otherwise document why they are needed |
+| `npm install pkg@variable` or `@latest` | Pin to an exact version number (e.g. `pkg@1.2.3`), or exclude the file in `sonar-project.properties` if version is intentionally managed via a CI variable |
+
+Fix each identified issue and commit.
 
 ## Constraints
 


### PR DESCRIPTION
## Root Cause

Diagnosed from PR #175's SonarCloud failure where dev-lead ran fix-ci three times with `status=no-changes`, then timed out, then crashed with exit 127, ultimately exhausting the PR.

Three bugs identified:

### 1. Relay payload missing `check_run.id` → ANNOTATIONS always empty

The `ci-relay` dispatch payload did not include `github.event.check_run.id`. In `dev-lead-fix-ci.sh::build_prompt()`:

```bash
ANNOTATIONS=$(gh api "repos/${REPO}/check-runs/$(echo "$CHECKS_JSON" | jq -r '.[0].id // empty')/annotations..." ...)
```

`.[0].id // empty` returned `""` → API called with an empty path segment → `ANNOTATIONS=[]`. External quality gates like SonarCloud do post annotations (PR #175 had 2), but the agent never saw them. Flying blind, it found no issues and reported `no-changes` three times.

### 2. Silent exit 127 (command not found) counted toward exhaustion

One of the fix-ci runs produced exit 127 (engine binary not in PATH). This was treated as a real engine failure and posted `status=failed`, counting toward the exhaustion threshold. A silent infrastructure failure exhausted the PR rather than failing fast with a visible error.

### 3. Fix-ci SonarCloud prompt missing key npm hotspot patterns

The prompt listed `curl|bash`, hardcoded credentials, `eval`, and HTTP URLs — but not the patterns that actually fired on PR #175:
- `npm install` without `--ignore-scripts`  
- Variable/`@latest` package version (`@${CLAUDE_CODE_VERSION}`)

Also: the prompt implied `# NOSONAR` works for hotspots — it doesn't. SonarCloud security hotspots require code fixes or UI acknowledgment.

## Changes

### `dev-lead.yml`
- Add `RELAY_CHECK_ID: ${{ github.event.check_run.id }}` to relay env vars
- Pass `--argjson check_id "$RELAY_CHECK_ID"` and add `id: $check_id` to the checks array in the dispatch payload
- Add **"Verify primary engine CLI"** step after install — fails the workflow immediately with a clear error if the engine binary is missing, before any agent work begins

### `prompts/dev-lead/fix-ci.md`
- Reorder to prioritize Annotations (now populated) over PR diff fallback
- Document that `# NOSONAR` does **not** suppress Security Hotspots
- Add npm-specific patterns to the hotspot lookup table (`--ignore-scripts`, pinned versions)

## Test plan
- [x] All 25 unit tests pass locally (`bats tests/dev-lead/unit/test_fix_ci.bats tests/dev-lead/unit/test_ci_relay.bats`)
- [ ] CI passes on this PR (lint, shellcheck, bats, SonarCloud)
- [ ] On next SonarCloud failure in any PR: verify `ANNOTATIONS` is non-empty in fix-ci run

🤖 Generated with [Claude Code](https://claude.com/claude-code)