### PR TITLE
fix(dev-lead): configure git user identity in fix-issue script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,4 +132,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
-

--- a/scripts/dev-lead-fix-issue.sh
+++ b/scripts/dev-lead-fix-issue.sh
@@ -17,6 +17,18 @@ check_existing_pr() {
   [ "$existing" -gt 0 ]
 }
 
+setup_git_identity() {
+  local bot="${BOT_USER:-donpetry-bot}"
+  local bot_id
+  bot_id=$(gh api "users/${bot}" --jq '.id' 2>/dev/null || echo "")
+  if [ -n "$bot_id" ]; then
+    git config user.email "${bot_id}+${bot}@users.noreply.github.com"
+  else
+    git config user.email "${bot}@users.noreply.github.com"
+  fi
+  git config user.name "$bot"
+}
+
 main() {
   if [ -z "$ISSUE_NUMBER" ]; then
     echo "::error::ISSUE_NUMBER is required"
@@ -46,6 +58,10 @@ main() {
     rm -f "$prompt_file"
     exit 0
   fi
+
+  # Configure git identity so the post-engine commit does not fail.
+  # BOT_USER is set as a job-level env var in dev-lead-reusable.yml.
+  setup_git_identity
 
   # Create feature branch
   local branch


### PR DESCRIPTION
## Problem

The `dev-lead-fix-issue.sh` script commits on behalf of the agent after Claude finishes (the fix-issue prompt says \"Do not commit or push\"). However, git requires `user.name` and `user.email` to be configured before committing, and neither the workflow nor the script sets these.

This caused every `issue` intent run to fail with:
```
fatal: empty ident name (for <runner@...>) not allowed
```

All 29 open `compliance-audit` issues across the org were blocked by this bug.

## Fix

Added `setup_git_identity()` which:
1. Looks up the bot user's GitHub ID via API
2. Sets `git config user.email <id>+<BOT_USER>@users.noreply.github.com`
3. Sets `git config user.name <BOT_USER>`

Called once before the feature branch is created.

## Testing

Re-trigger any compliance issue by cycling its `claude` label after merge.

Closes the unblocking issue for the 2026-05-15 compliance audit backlog.