### PR TITLE
feat: implement issue #362 — dev-lead: suppress visible body on no-changes terminal comments

### DIFF
--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -370,7 +370,7 @@ case "$INTENT_TYPE" in
         post_reviews_terminal "fix-reviews" "applied" "Changes committed and pushed."
       else
         notify_coderabbit_resolve
-        post_reviews_terminal "fix-reviews" "no-changes" "No changes were needed for the open review threads."
+        post_reviews_terminal "fix-reviews" "no-changes"
       fi
       try_enable_auto_merge
     fi
@@ -388,7 +388,7 @@ case "$INTENT_TYPE" in
         post_reviews_terminal "fix-bot-comment" "applied" "Changes committed and pushed."
       else
         notify_coderabbit_resolve
-        post_reviews_terminal "fix-bot-comment" "no-changes" "Engine ran but made no changes."
+        post_reviews_terminal "fix-bot-comment" "no-changes"
       fi
       try_enable_auto_merge
     fi
@@ -405,7 +405,7 @@ case "$INTENT_TYPE" in
       if commit_and_push "human"; then
         post_reviews_terminal "human" "applied" "Changes committed and pushed."
       else
-        post_reviews_terminal "human" "no-changes" "Engine ran but made no changes."
+        post_reviews_terminal "human" "no-changes"
       fi
     fi
     exit "$rc"
@@ -436,7 +436,7 @@ case "$INTENT_TYPE" in
         post_reviews_terminal "human-pr" "applied" "Changes committed and pushed."
       else
         notify_coderabbit_resolve
-        post_reviews_terminal "human-pr" "no-changes" "No changes were needed for this PR."
+        post_reviews_terminal "human-pr" "no-changes"
       fi
       try_enable_auto_merge
     fi
@@ -464,7 +464,7 @@ case "$INTENT_TYPE" in
       if commit_and_push "rebase"; then
         post_reviews_terminal "rebase" "applied" "Rebase completed and pushed."
       else
-        post_reviews_terminal "rebase" "no-changes" "PR is already up to date."
+        post_reviews_terminal "rebase" "no-changes"
       fi
     fi
     exit "$rc"

--- a/tests/dev-lead/unit/test_fix_reviews.bats
+++ b/tests/dev-lead/unit/test_fix_reviews.bats
@@ -428,6 +428,31 @@ STUB
   [[ "$output" == *"terminal marker"* || "$output" == *"[dry-run]"* ]]
 }
 
+@test "fix-reviews: no-changes dry-run: does not post visible heading in comment body" {
+  export INTENT_TYPE="fix-reviews"
+  export DEV_LEAD_DRY_RUN="true"
+  export HEAD_SHA="ddd444eee555"
+
+  run bash "$FIX_REVIEWS_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  # no-changes posts only the invisible HTML marker — no visible ## heading
+  [[ "$output" != *"## Dev-Lead —"* ]]
+}
+
+@test "fix-reviews: no-changes dry-run human-pr: does not post visible heading" {
+  export INTENT_TYPE="human-pr"
+  export DEV_LEAD_DRY_RUN="true"
+  export HEAD_SHA="ddd444eee555"
+  export PR_TITLE="Test PR"
+  export PR_DESCRIPTION="A test pull request"
+
+  run bash "$FIX_REVIEWS_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"## Dev-Lead —"* ]]
+}
+
 # ── commit_and_push failure tests ─────────────────────────────────────────────
 
 @test "fix-reviews: commit_and_push: git commit failure exits 1 (not silently swallowed)" {


### PR DESCRIPTION
Closes #362

Implemented by dev-lead agent. Please review.