### PR TITLE
feat: implement issue #365 — dev-lead: preserve session output in Actions logs and surface agent reasoning in no-changes comments

### DIFF
--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -86,6 +86,30 @@ ${summary}"
   gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$body" 2>/dev/null || true
 }
 
+read_session_summary() {
+  local log="/tmp/dev-lead-session-output.txt"
+  [ -f "$log" ] || return
+  # The agent output format is always at the end; grab last non-empty paragraph
+  tail -30 "$log" | sed '/^$/d' | tail -10
+}
+
+post_no_changes() {
+  local intent="$1"
+  local _summary
+  _summary=$(read_session_summary)
+  if [ -n "$_summary" ]; then
+    post_reviews_terminal "$intent" "no-changes" \
+      "<details><summary>Agent reasoning</summary>
+
+\`\`\`
+${_summary}
+\`\`\`
+</details>"
+  else
+    post_reviews_terminal "$intent" "no-changes"
+  fi
+}
+
 # notify_coderabbit_resolve: posts @coderabbitai resolve if coderabbitai[bot]'s
 # most recent review on the PR is CHANGES_REQUESTED. Uses --paginate so it sees
 # all reviews even on long-lived PRs, and checks only the latest review state
@@ -371,7 +395,7 @@ case "$INTENT_TYPE" in
         post_reviews_terminal "fix-reviews" "applied" "Changes committed and pushed."
       else
         notify_coderabbit_resolve
-        post_reviews_terminal "fix-reviews" "no-changes"
+        post_no_changes "fix-reviews"
       fi
       try_enable_auto_merge
     fi
@@ -389,7 +413,7 @@ case "$INTENT_TYPE" in
         post_reviews_terminal "fix-bot-comment" "applied" "Changes committed and pushed."
       else
         notify_coderabbit_resolve
-        post_reviews_terminal "fix-bot-comment" "no-changes"
+        post_no_changes "fix-bot-comment"
       fi
       try_enable_auto_merge
     fi
@@ -406,7 +430,7 @@ case "$INTENT_TYPE" in
       if commit_and_push "on-mention"; then
         post_reviews_terminal "on-mention" "applied" "Changes committed and pushed."
       else
-        post_reviews_terminal "on-mention" "no-changes" "Engine ran but made no changes."
+        post_no_changes "on-mention"
       fi
     fi
     exit "$rc"
@@ -437,7 +461,7 @@ case "$INTENT_TYPE" in
         post_reviews_terminal "review-changes" "applied" "Changes committed and pushed."
       else
         notify_coderabbit_resolve
-        post_reviews_terminal "review-changes" "no-changes" "No changes were needed for this PR."
+        post_no_changes "review-changes"
       fi
       try_enable_auto_merge
     fi
@@ -465,7 +489,7 @@ case "$INTENT_TYPE" in
       if commit_and_push "rebase"; then
         post_reviews_terminal "rebase" "applied" "Rebase completed and pushed."
       else
-        post_reviews_terminal "rebase" "no-changes"
+        post_no_changes "rebase"
       fi
     fi
     exit "$rc"

--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -90,7 +90,7 @@ read_session_summary() {
   local log="/tmp/dev-lead-session-output.txt"
   [ -f "$log" ] || return
   # The agent output format is always at the end; grab last non-empty paragraph
-  tail -30 "$log" | sed '/^$/d' | tail -10
+  tail -30 "$log" | sed '/^[[:space:]]*$/d' | tail -10
 }
 
 post_no_changes() {

--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -88,7 +88,7 @@ ${summary}"
 
 read_session_summary() {
   local log="/tmp/dev-lead-session-output.txt"
-  [ -f "$log" ] || return
+  [ -f "$log" ] || return 0
   # The agent output format is always at the end; grab last non-empty paragraph
   tail -30 "$log" | sed '/^[[:space:]]*$/d' | tail -10
 }

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -579,7 +579,14 @@ run_writer() {
   if [ "$rc" -eq 0 ]; then
     _record_engine_tokens "writer" "$REVIEW_ENGINE" "$model" "$prompt_file" "$_tmp"
   fi
-  [ -n "$_tmp" ] && rm -f "$_tmp"
+  if [ -n "$_tmp" ]; then
+    if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+      echo "## Dev-Lead session output" >> "$GITHUB_STEP_SUMMARY"
+      cat "$_tmp" >> "$GITHUB_STEP_SUMMARY"
+    fi
+    cp "$_tmp" /tmp/dev-lead-session-output.txt
+    rm -f "$_tmp"
+  fi
   return "$rc"
 }
 

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -582,7 +582,11 @@ run_writer() {
   if [ -n "$_tmp" ]; then
     if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
       echo "## Dev-Lead session output" >> "$GITHUB_STEP_SUMMARY"
+      echo "<details><summary>Click to expand session logs</summary>" >> "$GITHUB_STEP_SUMMARY"
+      echo "" >> "$GITHUB_STEP_SUMMARY"
       cat "$_tmp" >> "$GITHUB_STEP_SUMMARY"
+      echo "" >> "$GITHUB_STEP_SUMMARY"
+      echo "</details>" >> "$GITHUB_STEP_SUMMARY"
     fi
     cp "$_tmp" /tmp/dev-lead-session-output.txt
     rm -f "$_tmp"

--- a/tests/dev-lead/unit/test_engine_writer.bats
+++ b/tests/dev-lead/unit/test_engine_writer.bats
@@ -23,6 +23,7 @@ setup() {
 
 teardown() {
   rm -f "$GITHUB_ENV" "$GITHUB_OUTPUT" "$TEST_PROMPT"
+  rm -f /tmp/dev-lead-session-output.txt
   rm -rf "$STUB_BIN_DIR"
   if [ -n "${TEST_OWNED_TOKEN_LOG:-}" ] && [ "${TOKEN_LOG_FILE:-}" = "$TEST_OWNED_TOKEN_LOG" ]; then
     rm -f "$TEST_OWNED_TOKEN_LOG"
@@ -467,4 +468,83 @@ STUB
   [ "$status" -eq 2 ]
   # Rate-limited → no successful completion → token log must be empty
   [ ! -s "$log" ]
+}
+
+# ── session output persistence tests ─────────────────────────────────────────
+
+@test "session: run_writer copies output to /tmp/dev-lead-session-output.txt on success" {
+  _source_engine "claude"
+  export STUB_ENGINE_EXIT=0
+  export STUB_ENGINE_RESPONSE="PR: #42 - feat: do thing
+Human review threads addressed: 0
+Files changed: none"
+  export DEV_LEAD_DRY_RUN=false
+  rm -f /tmp/dev-lead-session-output.txt
+
+  run run_writer "$TEST_PROMPT"
+
+  [ "$status" -eq 0 ]
+  [ -f /tmp/dev-lead-session-output.txt ]
+  grep -q "Files changed: none" /tmp/dev-lead-session-output.txt
+}
+
+@test "session: run_writer appends to GITHUB_STEP_SUMMARY when set" {
+  _source_engine "claude"
+  export STUB_ENGINE_EXIT=0
+  export STUB_ENGINE_RESPONSE="Issues addressed: 0"
+  export DEV_LEAD_DRY_RUN=false
+  local summary_file
+  summary_file=$(mktemp)
+  export GITHUB_STEP_SUMMARY="$summary_file"
+  rm -f /tmp/dev-lead-session-output.txt
+
+  run run_writer "$TEST_PROMPT"
+
+  [ "$status" -eq 0 ]
+  grep -q "## Dev-Lead session output" "$summary_file"
+  grep -q "Issues addressed: 0" "$summary_file"
+  rm -f "$summary_file"
+}
+
+@test "session: run_writer does not write to GITHUB_STEP_SUMMARY when unset" {
+  _source_engine "claude"
+  export STUB_ENGINE_EXIT=0
+  export STUB_ENGINE_RESPONSE="Issues addressed: 0"
+  export DEV_LEAD_DRY_RUN=false
+  unset GITHUB_STEP_SUMMARY
+  rm -f /tmp/dev-lead-session-output.txt
+
+  run run_writer "$TEST_PROMPT"
+
+  [ "$status" -eq 0 ]
+  # No summary file should be created (we just verify the run succeeded without error)
+  [ -f /tmp/dev-lead-session-output.txt ]
+}
+
+@test "session: run_writer does not write session file when rate-limited" {
+  _source_engine "claude"
+  export DEV_LEAD_DRY_RUN=false
+  rm -f /tmp/dev-lead-session-output.txt
+  cat > "$STUB_BIN_DIR/claude" << 'STUB'
+#!/usr/bin/env bash
+echo "You've hit your limit · resets 11:20pm (UTC)"
+exit 1
+STUB
+  chmod +x "$STUB_BIN_DIR/claude"
+
+  run run_writer "$TEST_PROMPT"
+
+  [ "$status" -eq 2 ]
+  [ ! -f /tmp/dev-lead-session-output.txt ]
+}
+
+@test "session: run_writer dry-run does not write session file" {
+  _source_engine "claude"
+  export DEV_LEAD_DRY_RUN=true
+  rm -f /tmp/dev-lead-session-output.txt
+
+  run run_writer "$TEST_PROMPT"
+
+  [ "$status" -eq 0 ]
+  [ ! -f /tmp/dev-lead-session-output.txt ]
 }

--- a/tests/dev-lead/unit/test_fix_reviews.bats
+++ b/tests/dev-lead/unit/test_fix_reviews.bats
@@ -9,6 +9,7 @@ GH_STUBS_DIR="$SCRIPT_DIR/tests/dev-lead/fixtures/stubs"
 setup() {
   export GITHUB_ENV="$(mktemp)"
   export GITHUB_OUTPUT="$(mktemp)"
+  rm -f /tmp/dev-lead-session-output.txt
 
   STUB_BIN_DIR="$(mktemp -d)"
   cp "$STUB_ENGINES_DIR/stub-claude" "$STUB_BIN_DIR/claude"
@@ -53,6 +54,7 @@ GHEOF
 
 teardown() {
   rm -f "$GITHUB_ENV" "$GITHUB_OUTPUT"
+  rm -f /tmp/dev-lead-session-output.txt
   rm -rf "$STUB_BIN_DIR"
 }
 
@@ -572,4 +574,47 @@ GITEOF
     ! grep -q "status=applied" "$comment_file"
   fi
   rm -f "$comment_file"
+}
+
+# ── read_session_summary / post_no_changes tests ──────────────────────────────
+
+@test "fix-reviews: no-changes dry-run: includes details block when session output exists" {
+  export INTENT_TYPE="fix-reviews"
+  export DEV_LEAD_DRY_RUN="true"
+  export HEAD_SHA="ddd444eee555"
+  printf 'Issues addressed: 0\nSkipped: 3\n' > /tmp/dev-lead-session-output.txt
+
+  run bash "$FIX_REVIEWS_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Agent reasoning"* ]]
+  [[ "$output" == *"Issues addressed: 0"* ]]
+}
+
+@test "fix-reviews: no-changes dry-run: no details block when session output absent" {
+  export INTENT_TYPE="fix-reviews"
+  export DEV_LEAD_DRY_RUN="true"
+  export HEAD_SHA="ddd444eee555"
+  rm -f /tmp/dev-lead-session-output.txt
+
+  run bash "$FIX_REVIEWS_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Agent reasoning"* ]]
+}
+
+@test "fix-reviews: no-changes dry-run human-pr: includes details block when session output exists" {
+  export INTENT_TYPE="human-pr"
+  export DEV_LEAD_DRY_RUN="true"
+  export HEAD_SHA="ddd444eee555"
+  export PR_TITLE="Test PR"
+  export PR_DESCRIPTION="A test pull request"
+  printf 'PR: #54 - feat: thing\nHuman review threads addressed: 0\nFiles changed: none\n' \
+    > /tmp/dev-lead-session-output.txt
+
+  run bash "$FIX_REVIEWS_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Agent reasoning"* ]]
+  [[ "$output" == *"Files changed: none"* ]]
 }


### PR DESCRIPTION
Closes #365

Implemented by dev-lead agent. Please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Session reasoning is now captured and displayed in "no changes" outcomes within a collapsible "Agent reasoning" section
  * Session output is preserved for enhanced visibility and debugging purposes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/petry-projects/.github-private/pull/366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->