### PR TITLE
fix(dev-lead): set git identity before commit in commit_and_push

### DIFF
--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -15,18 +15,6 @@ export PROMPTS_DIR="${PROMPTS_DIR:-prompts/dev-lead}"
 
 REVIEWS_MARKER_PREFIX="<!-- dev-lead-fix-reviews pr="
 
-setup_git_identity() {
-  local bot="${BOT_USER:-donpetry-bot}"
-  local bot_id
-  bot_id=$(gh api "users/${bot}" --jq '.id' 2>/dev/null || echo "")
-  if [ -n "$bot_id" ]; then
-    git config user.email "${bot_id}+${bot}@users.noreply.github.com"
-  else
-    git config user.email "${bot}@users.noreply.github.com"
-  fi
-  git config user.name "$bot"
-}
-
 if [ -z "$PR_NUMBER" ] && [ "$INTENT_TYPE" != "rebase" ]; then
   echo "::error::PR_NUMBER is required"
   exit 1

--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -14,6 +14,18 @@ export PROMPTS_DIR="${PROMPTS_DIR:-prompts/dev-lead}"
 
 REVIEWS_MARKER_PREFIX="<!-- dev-lead-fix-reviews pr="
 
+setup_git_identity() {
+  local bot="${BOT_USER:-donpetry-bot}"
+  local bot_id
+  bot_id=$(gh api "users/${bot}" --jq '.id' 2>/dev/null || echo "")
+  if [ -n "$bot_id" ]; then
+    git config user.email "${bot_id}+${bot}@users.noreply.github.com"
+  else
+    git config user.email "${bot}@users.noreply.github.com"
+  fi
+  git config user.name "$bot"
+}
+
 if [ -z "$PR_NUMBER" ] && [ "$INTENT_TYPE" != "rebase" ]; then
   echo "::error::PR_NUMBER is required"
   exit 1
@@ -29,6 +41,7 @@ fi
 # Checkout the PR branch for modification (Requirement 1)
 if [ "${DEV_LEAD_DRY_RUN:-false}" = "false" ] && [ -n "${PR_NUMBER:-}" ]; then
   gh pr checkout "$PR_NUMBER" --repo "$REPO"
+  setup_git_identity
 fi
 
 build_and_run() {
@@ -220,8 +233,7 @@ commit_and_push() {
       git add -A
       # Ensure git identity is set — actions/checkout only sets local config for the
       # repo it checks out (.github-private), not for target repos cloned separately.
-      git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-      git config user.name "github-actions[bot]"
+      setup_git_identity
       # Explicit exit on failure: set -e is suspended when commit_and_push is called from
       # an if-statement condition, so git commit failures would be silently swallowed
       # otherwise. Using exit (not return) ensures CI fails visibly instead of posting a

--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -218,6 +218,10 @@ commit_and_push() {
   else
     if $has_uncommitted; then
       git add -A
+      # Ensure git identity is set — actions/checkout only sets local config for the
+      # repo it checks out (.github-private), not for target repos cloned separately.
+      git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      git config user.name "github-actions[bot]"
       # Explicit exit on failure: set -e is suspended when commit_and_push is called from
       # an if-statement condition, so git commit failures would be silently swallowed
       # otherwise. Using exit (not return) ensures CI fails visibly instead of posting a

--- a/scripts/lib/git-identity.sh
+++ b/scripts/lib/git-identity.sh
@@ -15,6 +15,9 @@
 
 # setup_git_identity — configure git user.name/user.email for the bot user.
 #
+# GitHub-hosted runners lack git identity by default; this helper ensures
+# commits succeed whether we're committing to the primary repo or secondary checkouts.
+#
 # BOT_USER env var (default: donpetry-bot) determines the identity. The
 # canonical noreply form (<id>+<login>@users.noreply.github.com) is preferred
 # because it links commits to the bot's GitHub profile; fall back to the
@@ -23,7 +26,7 @@ setup_git_identity() {
   local bot="${BOT_USER:-donpetry-bot}"
   local bot_id
   bot_id=$(gh api "users/${bot}" --jq '.id' 2>/dev/null || echo "")
-  if [ -n "$bot_id" ]; then
+  if [[ -n $bot_id ]]; then
     git config user.email "${bot_id}+${bot}@users.noreply.github.com"
   else
     git config user.email "${bot}@users.noreply.github.com"


### PR DESCRIPTION
## Summary

- Sets `git config user.email` and `git config user.name` before `git commit` in `commit_and_push()`
- Fixes the `git commit failed — check git identity configuration on the runner` error that blocks the dev-lead from committing to any repo other than `.github-private`

## Root cause

`actions/checkout` sets local git identity only for the repo it checks out (`.github-private`). When the script clones a target repo (TalkTerm, broodly, etc.) into a separate workspace directory, that identity doesn't carry over and `git commit` fails.

## Impact

Without this fix, the `human`, `fix-reviews`, and `fix-bot-comment` intents all fail at the commit step for every repo except `.github-private` itself. All 5 rollout PRs (TalkTerm #203, broodly #241, markets #204, ContentTwin #181, bmad-bgreat-suite #199) were affected.

Fixes #368

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Git author identity configuration in automated workflows to prevent missing author information in commits across repository checkouts.

* **Documentation**
  * Improved documentation for Git identity setup procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/petry-projects/.github-private/pull/369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->