### PR TITLE
fix(ci-analyst): pin reusable ref to post-merge main SHA

### DIFF
--- a/.github/workflows/ci-failure-analyst.lock.yml
+++ b/.github/workflows/ci-failure-analyst.lock.yml
@@ -30,6 +30,6 @@ jobs:
     if: >-
       github.event.check_run.conclusion == 'failure' &&
       !startsWith(github.event.check_run.name, 'CI Failure Analyst')
-    uses: petry-projects/.github-private/.github/workflows/ci-failure-analyst-reusable.yml@69e9774818d45846f3a850ca13f31c7e9d6345cc # main
+    uses: petry-projects/.github-private/.github/workflows/ci-failure-analyst-reusable.yml@121bee881bd13715706d30230b2d5a8d2d78b0b1 # main
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/docs/aw/ci-failure-analyst.md
+++ b/docs/aw/ci-failure-analyst.md
@@ -22,7 +22,7 @@ The workflow uses the **reusable workflow** (`workflow_call`) pattern — the sa
 ```
 repo-x (check_run: failure)
   └─ .github/workflows/ci-failure-analyst.yml   ← ~20-line stub (no logic)
-      └─ uses: petry-projects/.github-private/.github/workflows/ci-failure-analyst-reusable.yml@69e9774818d45846f3a850ca13f31c7e9d6345cc # main
+      └─ uses: petry-projects/.github-private/.github/workflows/ci-failure-analyst-reusable.yml@121bee881bd13715706d30230b2d5a8d2d78b0b1 # main
           ├─ resolves PR (non-fork only)
           ├─ idempotency check (<!-- ci-analyst sha=... -->)
           ├─ installs Claude Code

--- a/templates/ci-failure-analyst.yml
+++ b/templates/ci-failure-analyst.yml
@@ -41,6 +41,6 @@ jobs:
     if: >-
       github.event.check_run.conclusion == 'failure' &&
       !startsWith(github.event.check_run.name, 'CI Failure Analyst')
-    uses: petry-projects/.github-private/.github/workflows/ci-failure-analyst-reusable.yml@69e9774818d45846f3a850ca13f31c7e9d6345cc # main
+    uses: petry-projects/.github-private/.github/workflows/ci-failure-analyst-reusable.yml@121bee881bd13715706d30230b2d5a8d2d78b0b1 # main
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

Addresses a P1 issue raised during review of #367: the SHA pinned in the
template and lock stub (`69e9774`) predated the PR and did not include
`ci-failure-analyst-reusable.yml`. Any repo copying the template would fail
to resolve the `uses:` target.

This PR updates all three affected files to reference the merge commit of
#367 (`121bee881bd13715706d30230b2d5a8d2d78b0b1`), which is the first commit
on main that contains the reusable workflow.

**Files changed:**
- `templates/ci-failure-analyst.yml` — SHA updated
- `.github/workflows/ci-failure-analyst.lock.yml` — SHA updated
- `docs/aw/ci-failure-analyst.md` — architecture diagram SHA updated

## Test plan

- [ ] Verify the pinned SHA resolves correctly: `gh api repos/petry-projects/.github-private/contents/.github/workflows/ci-failure-analyst-reusable.yml?ref=121bee881bd13715706d30230b2d5a8d2d78b0b1`
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)