### PR TITLE
test(dev-lead): runtime-build PEM markers in writer redaction test

### DIFF
--- a/tests/dev-lead/unit/test_engine_writer.bats
+++ b/tests/dev-lead/unit/test_engine_writer.bats
@@ -576,12 +576,19 @@ STUB
 @test "writer: PEM private key block fully redacted in /tmp persistence" {
   _source_engine "claude"
   export DEV_LEAD_DRY_RUN=false
-  cat > "$STUB_BIN_DIR/claude" << 'STUB'
+  # Build PEM markers at runtime so the literal "-----BEGIN/END RSA PRIVATE
+  # KEY-----" never appears in this source file (avoids tripping gitleaks on
+  # a test fixture). Same pattern as the post_no_changes PEM tests in
+  # test_fix_reviews.bats.
+  local dashes="-----"
+  local begin="${dashes}BEGIN RSA PRIVATE KEY${dashes}"
+  local end="${dashes}END RSA PRIVATE KEY${dashes}"
+  cat > "$STUB_BIN_DIR/claude" << STUB
 #!/usr/bin/env bash
-echo "-----BEGIN RSA PRIVATE KEY-----"
+echo "$begin"
 echo "MIIEowIBAAKCAQEAuVERYSENSITIVEKEYBODYWITHTONSOFCHARSANDMOREDATAHERE"
 echo "ENDOFBODYDATAGOESHEREMOREMOREMOREMOREMOREMORE"
-echo "-----END RSA PRIVATE KEY-----"
+echo "$end"
 echo "after-key"
 STUB
   chmod +x "$STUB_BIN_DIR/claude"
@@ -591,9 +598,9 @@ STUB
 
   [ "$status" -eq 0 ]
   # Neither header, body, nor footer of the PEM block may survive
-  ! grep -F "BEGIN RSA PRIVATE KEY" /tmp/dev-lead-session-output.txt
+  ! grep -F "$begin" /tmp/dev-lead-session-output.txt
   ! grep -F "uVERYSENSITIVEKEYBODY" /tmp/dev-lead-session-output.txt
-  ! grep -F "END RSA PRIVATE KEY" /tmp/dev-lead-session-output.txt
+  ! grep -F "$end" /tmp/dev-lead-session-output.txt
   grep -F "***REDACTED-PRIVATE-KEY***" /tmp/dev-lead-session-output.txt
   # Content outside the PEM block survives
   grep -F "after-key" /tmp/dev-lead-session-output.txt

--- a/tests/dev-lead/unit/test_engine_writer.bats
+++ b/tests/dev-lead/unit/test_engine_writer.bats
@@ -597,10 +597,14 @@ STUB
   run run_writer "$TEST_PROMPT"
 
   [ "$status" -eq 0 ]
-  # Neither header, body, nor footer of the PEM block may survive
-  ! grep -F "$begin" /tmp/dev-lead-session-output.txt
+  # Neither header, body, nor footer of the PEM block may survive. Substring
+  # match (without the surrounding dashes) so a partial leak that trims the
+  # delimiters still fails the assertion. Safe vs. gitleaks: the substring
+  # alone does not satisfy the private-key rule's `-----BEGIN ... -----`
+  # regex.
+  ! grep -F "BEGIN RSA PRIVATE KEY" /tmp/dev-lead-session-output.txt
   ! grep -F "uVERYSENSITIVEKEYBODY" /tmp/dev-lead-session-output.txt
-  ! grep -F "$end" /tmp/dev-lead-session-output.txt
+  ! grep -F "END RSA PRIVATE KEY" /tmp/dev-lead-session-output.txt
   grep -F "***REDACTED-PRIVATE-KEY***" /tmp/dev-lead-session-output.txt
   # Content outside the PEM block survives
   grep -F "after-key" /tmp/dev-lead-session-output.txt


### PR DESCRIPTION
## Summary

- Replaces the literal `-----BEGIN/END RSA PRIVATE KEY-----` strings inside the stub-claude heredoc with markers built from a `dashes="-----"` variable.
- The same pattern is already used by the `post_no_changes` PEM tests in `tests/dev-lead/unit/test_fix_reviews.bats` — this brings the engine writer test in line.
- Fixes the gitleaks `private-key` rule trip that landed on main as a side effect of #371's bypass-merge (gitleaks isn't a required check, so it slipped through). Any future PR re-touching the surrounding lines would otherwise be flagged.

No behaviour change — only the source representation of the markers changes; runtime expansion produces the same `-----BEGIN/END RSA PRIVATE KEY-----` strings the redactor needs to match.

## Test plan

- [x] `bats tests/dev-lead/unit/test_engine_writer.bats` — 33/33 pass (PEM test still asserts header/body/footer redaction)
- [x] No literal `-----BEGIN ... PRIVATE KEY-----` remains in `tests/dev-lead/unit/test_engine_writer.bats`
- [ ] Gitleaks check on this PR is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved unit test reliability and maintainability for sensitive data redaction verification during session output persistence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/petry-projects/.github-private/pull/377?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->