### PR TITLE
fix(dev-lead): centralize git identity; apply to fix-ci & fix-reviews

### DIFF
--- a/scripts/dev-lead-fix-ci.sh
+++ b/scripts/dev-lead-fix-ci.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 # Optional: MAX_FAIL_ATTEMPTS — consecutive engine failures before exhaustion (default: 2)
 
 source "$(dirname "$0")/engine.sh"
+source "$(dirname "$0")/lib/git-identity.sh"
 
 PR_NUMBER="${PR_NUMBER:-}"
 HEAD_SHA="${HEAD_SHA:-}"
@@ -254,6 +255,9 @@ main() {
     fi
 
     if $has_uncommitted; then
+      # GitHub-hosted runners have no default git identity; configure it
+      # before committing or commit fails with "fatal: empty ident name".
+      setup_git_identity
       git add -A
       git commit -m "fix(ci): auto-fix for $(echo "$CHECKS_JSON" | jq -r '.[0].name // "CI failure"') [skip ci-relay]"
     fi

--- a/scripts/dev-lead-fix-issue.sh
+++ b/scripts/dev-lead-fix-issue.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 # Optional: PROMPTS_DIR (defaults to prompts/dev-lead relative to CWD)
 
 source "$(dirname "$0")/engine.sh"
+source "$(dirname "$0")/lib/git-identity.sh"
 
 ISSUE_NUMBER="${ISSUE_NUMBER:-}"
 REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
@@ -15,18 +16,6 @@ check_existing_pr() {
   existing=$(gh api "repos/${REPO}/pulls?state=open" \
     --jq "[.[] | select(.head.ref | startswith(\"dev-lead/issue-${ISSUE_NUMBER}\"))] | length" 2>/dev/null || echo "0")
   [ "$existing" -gt 0 ]
-}
-
-setup_git_identity() {
-  local bot="${BOT_USER:-donpetry-bot}"
-  local bot_id
-  bot_id=$(gh api "users/${bot}" --jq '.id' 2>/dev/null || echo "")
-  if [ -n "$bot_id" ]; then
-    git config user.email "${bot_id}+${bot}@users.noreply.github.com"
-  else
-    git config user.email "${bot}@users.noreply.github.com"
-  fi
-  git config user.name "$bot"
 }
 
 main() {

--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 # Optional: PROMPTS_DIR (defaults to prompts/dev-lead relative to CWD)
 
 source "$(dirname "$0")/engine.sh"
+source "$(dirname "$0")/lib/git-identity.sh"
 
 INTENT_TYPE="${INTENT_TYPE:-fix-reviews}"
 PR_NUMBER="${PR_NUMBER:-}"
@@ -370,6 +371,9 @@ commit_and_push() {
     fi
   else
     if $has_uncommitted; then
+      # GitHub-hosted runners have no default git identity; configure it
+      # before committing or commit fails with "fatal: empty ident name".
+      setup_git_identity
       git add -A
       # Explicit exit on failure: set -e is suspended when commit_and_push is called from
       # an if-statement condition, so git commit failures would be silently swallowed

--- a/scripts/lib/git-identity.sh
+++ b/scripts/lib/git-identity.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# git-identity.sh — shared helper for dev-lead scripts.
+#
+# All dev-lead entry points (fix-issue, fix-ci, fix-reviews) must call
+# setup_git_identity before any git commit. Without it, the runner has
+# no user.name/user.email and `git commit` aborts with:
+#   fatal: empty ident name (for <(null)>) not allowed
+#
+# Background: prior to centralizing this helper, only dev-lead-fix-issue.sh
+# called the local setup_git_identity defined inline. fix-ci and fix-reviews
+# silently committed under runner-default identity, which on GitHub-hosted
+# runners is unset — causing the commit step to error and the agent run to
+# fail. See bmad-bgreat-suite PR #203 dev-lead failures (2026-05-23) for the
+# observed symptom.
+
+# setup_git_identity — configure git user.name/user.email for the bot user.
+#
+# BOT_USER env var (default: donpetry-bot) determines the identity. The
+# canonical noreply form (<id>+<login>@users.noreply.github.com) is preferred
+# because it links commits to the bot's GitHub profile; fall back to the
+# legacy form when the GitHub user API is unreachable.
+setup_git_identity() {
+  local bot="${BOT_USER:-donpetry-bot}"
+  local bot_id
+  bot_id=$(gh api "users/${bot}" --jq '.id' 2>/dev/null || echo "")
+  if [ -n "$bot_id" ]; then
+    git config user.email "${bot_id}+${bot}@users.noreply.github.com"
+  else
+    git config user.email "${bot}@users.noreply.github.com"
+  fi
+  git config user.name "$bot"
+}


### PR DESCRIPTION
## Summary

Move the `setup_git_identity` helper to a shared lib and call it from all three dev-lead entry-point scripts. Previously, only `dev-lead-fix-issue.sh` configured git before committing, so review and CI intents failed on GitHub-hosted runners with `fatal: empty ident name`.

## Observed failure

`bmad-bgreat-suite#203`, triggered by `pull_request_review` (handled by `dev-lead-fix-reviews.sh`):

```
##[error]git commit failed — check git identity configuration on the runner
##[error]Process completed with exit code 1.
```

`dev-lead-fix-reviews.sh` and `dev-lead-fix-ci.sh` both call `git commit` but neither configured `user.name`/`user.email`. The earlier fix in PR #326 only patched the issue intent.

## Changes

- **New:** `scripts/lib/git-identity.sh` — shared `setup_git_identity` helper.
- **Refactor:** `dev-lead-fix-issue.sh` drops the inline duplicate; sources the shared lib.
- **Fix:** `dev-lead-fix-ci.sh` sources the shared lib; calls `setup_git_identity` before `git commit`.
- **Fix:** `dev-lead-fix-reviews.sh` sources the shared lib; calls `setup_git_identity` before `git commit`.

## Test plan

- [ ] Merge.
- [ ] Trigger a dev-lead fix-reviews intent (e.g., re-request review on an existing PR) and confirm the commit step succeeds.
- [ ] Trigger a dev-lead fix-ci intent (e.g., push a commit that fails CI) and confirm the commit step succeeds.
- [ ] No regression on fix-issue (already worked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)