### PR TITLE
feat(engine): in-Claude model fallback before cross-provider switch

### DIFF
--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -260,8 +260,17 @@ jobs:
       # ── enable-auto-merge ─────────────────────────────────────────────────
       # Triggered when a trusted bot approves a PR. Skips engine install and
       # pre-flight — just checks reviewDecision and enables auto-merge if APPROVED.
+      #
+      # Gate on the step output of `intent` (not env.INTENT_TYPE): a step's own
+      # env block is in scope when evaluating its `if:`, so the literal
+      # `INTENT_TYPE: enable-auto-merge` we set below would make env.INTENT_TYPE
+      # always equal 'enable-auto-merge' at gate-evaluation time, defeating the
+      # check. Step outputs are not shadowed. Also require a non-empty PR number
+      # to mirror the guard already present in dev-lead-reusable.yml.
       - name: Enable auto-merge on bot approval
-        if: env.INTENT_TYPE == 'enable-auto-merge'
+        if: >-
+          steps.intent.outputs.intent_type == 'enable-auto-merge'
+          && env.INTENT_PR_NUMBER != ''
         env:
           INTENT_TYPE: enable-auto-merge
           PR_NUMBER: ${{ env.INTENT_PR_NUMBER }}

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -141,8 +141,12 @@ _TOKEN_LIB="$(dirname "${BASH_SOURCE[0]}")/lib/token-metrics.sh"
 unset _TOKEN_LIB
 
 # _rate_limit_pattern
-# Emits the (ERE) pattern that classifies a provider usage/rate-limit block.
-# Shared by is_rate_limited and is_rate_limited_files so both stay in sync.
+# Single source of truth for the rate-limit regex used by both is_rate_limited
+# (text) and is_rate_limited_files (paths). Patterns intentionally excluded to
+# prevent false positives:
+#   - bare "exhausted" (too broad: matches "retry attempts exhausted", OS errors, etc.)
+#     Retained as "token.*exhaust" / "out of.*token" for the specific token-depletion case.
+#   - CLI syntax errors ("Invalid command format", "unknown flag", etc.) — see is_cli_error.
 _rate_limit_pattern() {
   local _pat
   _pat="hit your limit|rate[ -]?limit|resets [0-9]+(am|pm)|reached.*limit" # soft cap / throttle
@@ -155,7 +159,7 @@ _rate_limit_pattern() {
   _pat="$_pat|plan.*limit|subscription.*limit|billing.*limit|daily.*limit|monthly.*limit|weekly.*limit"
   _pat="$_pat|([^0-9]|^)402([^0-9]|$)"                               # HTTP 402 (payment)
   _pat="$_pat|tokens_limit_reached|body too large|([^0-9]|^)413([^0-9]|$)" # Context / Request size
-  printf '(%s)' "$_pat"
+  printf '%s' "($_pat)"
 }
 
 # is_rate_limited <text>
@@ -164,21 +168,26 @@ _rate_limit_pattern() {
 # or service overload acting as a hard block (529).
 # review-one-pr.sh exits with code 2 when this fires so the caller can switch engines.
 #
-# Patterns intentionally excluded to prevent false positives:
-#   - bare "exhausted" (too broad: matches "retry attempts exhausted", OS errors, etc.)
-#     Retained as "token.*exhaust" / "out of.*token" for the specific token-depletion case.
-#   - CLI syntax errors ("Invalid command format", "unknown flag", etc.) — see is_cli_error.
+# Prefer is_rate_limited_files for large LLM-output captures — it scans files
+# directly with grep instead of materializing the contents in a shell variable,
+# which avoids OOM and shell-substitution length limits on big payloads.
 is_rate_limited() {
   local text="$1"
   printf '%s\n' "$text" | grep -qiE "$(_rate_limit_pattern)"
 }
 
-# is_rate_limited_files <file...>
-# File-aware variant of is_rate_limited that greps the files directly rather
-# than loading them into a shell variable. Use when output may be large enough
-# to risk ARG_MAX / OOM via $(cat file).
+# is_rate_limited_files <file>...
+# File-aware variant of is_rate_limited. Returns 0 if any of the given files
+# matches the rate-limit pattern. Empty paths are skipped silently so callers
+# can pass optional tmp files without pre-checks.
 is_rate_limited_files() {
-  grep -qiE "$(_rate_limit_pattern)" "$@" 2>/dev/null
+  local files=()
+  local f
+  for f in "$@"; do
+    [ -n "$f" ] && [ -f "$f" ] && files+=("$f")
+  done
+  [ "${#files[@]}" -eq 0 ] && return 1
+  grep -qiE "$(_rate_limit_pattern)" "${files[@]}"
 }
 
 # is_cli_error <text>
@@ -287,11 +296,12 @@ _claude_chain_invoke() {
       timeout "$timeout_sec" claude --print --model "$model" "${extra_args[@]}" \
         < "$prompt_file" > "$stdout_tmp" 2> "$stderr_tmp" || rc=$?
     else
-      # mktemp failure — clean up any partial temp file, then degrade to direct
-      # stdout/stderr passthrough (no chain). Without this, a half-successful
-      # mktemp pair would leak the surviving file into /tmp.
+      # mktemp failure (one or both) — clean up the partial tmp before degrading
+      # to direct stdout/stderr passthrough so we don't leak a half-allocated fd.
       [ -n "$stdout_tmp" ] && rm -f "$stdout_tmp"
       [ -n "$stderr_tmp" ] && rm -f "$stderr_tmp"
+      [ -n "$final_stdout" ] && rm -f "$final_stdout"
+      [ -n "$final_stderr" ] && rm -f "$final_stderr"
       timeout "$timeout_sec" claude --print --model "$model" "${extra_args[@]}" \
         < "$prompt_file" || rc=$?
       _CLAUDE_CHAIN_MODEL_USED="$model"
@@ -311,6 +321,8 @@ _claude_chain_invoke() {
       all_rl=0
       break
     fi
+    # File-based rate-limit detection — avoids loading large agent output into
+    # a shell variable via $(cat ...) (OOM risk on big captures).
     if ! is_rate_limited_files "$stdout_tmp" "$stderr_tmp"; then
       # Non-rate-limit failure — propagate immediately, do not try next model.
       final_rc="$rc"
@@ -323,7 +335,7 @@ _claude_chain_invoke() {
 
   # If every attempt was rate-limited, parse the last reset time and return 2.
   if [ "$all_rl" -eq 1 ] && [ "$attempted" -gt 0 ]; then
-    parse_reset_time_files "${final_stdout:-/dev/null}" "${final_stderr:-/dev/null}"
+    parse_reset_time_files "$final_stdout" "$final_stderr"
     final_rc=2
   fi
 
@@ -634,21 +646,19 @@ run_duck() {
   return "$rc"
 }
 
-# _write_reset_time <hhmm>
-# Converts an H:MM(am|pm) string to ISO-8601 UTC and writes it to
-# /tmp/dev-lead-rate-limit-reset. Empty input → empty file (unknown).
-_write_reset_time() {
+# _emit_reset_iso <hhmm_with_meridiem>
+# Shared helper: converts e.g. "11:20pm" into an ISO-8601 UTC timestamp
+# (writing to /tmp/dev-lead-rate-limit-reset), advancing to tomorrow if the
+# computed time is already in the past for today.
+_emit_reset_iso() {
   local hhmm="$1"
   if [ -z "$hhmm" ]; then
     printf '' > /tmp/dev-lead-rate-limit-reset
     return 0
   fi
-  # Convert to ISO-8601 UTC using today's date (rate limits reset within 24h)
-  local today
+  local today iso
   today=$(date -u +%Y-%m-%d)
-  local iso
   iso=$(date -u -d "${today} ${hhmm} UTC" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)
-  # If reset time is in the past (already reset today), it means tomorrow
   if [ -n "$iso" ] && [ "$(date -u +%s)" -gt "$(date -u -d "$iso" +%s 2>/dev/null || echo 0)" ]; then
     local tomorrow
     tomorrow=$(date -u -d "tomorrow" +%Y-%m-%d)
@@ -663,26 +673,48 @@ _write_reset_time() {
 # status=rate-limited markers. Pattern: "resets H:MMam/pm (UTC)" or
 # "resets H:MM(am|pm) UTC".
 # Writes empty string if no reset time is found (caller treats as unknown).
+#
+# Prefer parse_reset_time_files for large captures — same OOM rationale as
+# is_rate_limited / is_rate_limited_files above.
 parse_reset_time() {
   local text="$1"
   # Match "resets 11:20pm (UTC)" or "resets 11:20pm UTC"
   local time_str
   time_str=$(printf '%s\n' "$text" | grep -oiE 'resets [0-9]{1,2}:[0-9]{2}(am|pm)' | head -1 || true)
+  if [ -z "$time_str" ]; then
+    printf '' > /tmp/dev-lead-rate-limit-reset
+    return 0
+  fi
+  # Extract H:MM(am|pm) part
   local hhmm
   hhmm=$(printf '%s' "$time_str" | grep -oiE '[0-9]{1,2}:[0-9]{2}(am|pm)$' || true)
-  _write_reset_time "$hhmm"
+  _emit_reset_iso "$hhmm"
 }
 
-# parse_reset_time_files <file...>
-# File-aware variant of parse_reset_time that greps the files directly rather
-# than loading them into a shell variable. Use when output may be large enough
-# to risk ARG_MAX / OOM via $(cat file).
+# parse_reset_time_files <file>...
+# File-aware variant of parse_reset_time. Scans each non-empty existing file
+# for the first "resets H:MMam/pm" match and writes the ISO timestamp via
+# _emit_reset_iso. Uses grep directly on files to avoid loading large LLM
+# outputs into a shell variable.
 parse_reset_time_files() {
+  local files=()
+  local f
+  for f in "$@"; do
+    [ -n "$f" ] && [ -f "$f" ] && files+=("$f")
+  done
+  if [ "${#files[@]}" -eq 0 ]; then
+    printf '' > /tmp/dev-lead-rate-limit-reset
+    return 0
+  fi
   local time_str
-  time_str=$(grep -hoiE 'resets [0-9]{1,2}:[0-9]{2}(am|pm)' "$@" 2>/dev/null | head -1 || true)
+  time_str=$(grep -hoiE 'resets [0-9]{1,2}:[0-9]{2}(am|pm)' "${files[@]}" 2>/dev/null | head -1 || true)
+  if [ -z "$time_str" ]; then
+    printf '' > /tmp/dev-lead-rate-limit-reset
+    return 0
+  fi
   local hhmm
   hhmm=$(printf '%s' "$time_str" | grep -oiE '[0-9]{1,2}:[0-9]{2}(am|pm)$' || true)
-  _write_reset_time "$hhmm"
+  _emit_reset_iso "$hhmm"
 }
 
 # run_writer <prompt_file> [model]
@@ -747,9 +779,10 @@ run_writer() {
       ;;
   esac
 
-  # Map rate-limit to exit code 2 for caller to detect; parse reset time for marker embedding
-  if [ "$rc" -ne 0 ] && [ -n "$_tmp" ] && is_rate_limited "$(cat "$_tmp")"; then
-    parse_reset_time "$(cat "$_tmp")"
+  # Map rate-limit to exit code 2 for caller to detect; parse reset time for
+  # marker embedding. Use the file-based helpers to avoid OOM on large captures.
+  if [ "$rc" -ne 0 ] && [ -n "$_tmp" ] && is_rate_limited_files "$_tmp"; then
+    parse_reset_time_files "$_tmp"
     [ -n "$_tmp" ] && rm -f "$_tmp"
     return 2
   fi

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -140,6 +140,24 @@ _TOKEN_LIB="$(dirname "${BASH_SOURCE[0]}")/lib/token-metrics.sh"
 [ -f "$_TOKEN_LIB" ] && source "$_TOKEN_LIB" 2>/dev/null || true
 unset _TOKEN_LIB
 
+# _rate_limit_pattern
+# Emits the (ERE) pattern that classifies a provider usage/rate-limit block.
+# Shared by is_rate_limited and is_rate_limited_files so both stay in sync.
+_rate_limit_pattern() {
+  local _pat
+  _pat="hit your limit|rate[ -]?limit|resets [0-9]+(am|pm)|reached.*limit" # soft cap / throttle
+  _pat="$_pat|usage limit|quota exceeded|too many requests|exceeded.*quota"
+  _pat="$_pat|([^0-9]|^)429([^0-9]|$)"                               # HTTP 429
+  _pat="$_pat|out of.*token|token.*exhaust"                            # token depletion
+  _pat="$_pat|overloaded_error|service.*overload|overload.*error"      # service overload
+  _pat="$_pat|([^0-9]|^)529([^0-9]|$)"                               # HTTP 529
+  _pat="$_pat|claude.*usage|usage.*claude"                             # Claude-specific cap
+  _pat="$_pat|plan.*limit|subscription.*limit|billing.*limit|daily.*limit|monthly.*limit|weekly.*limit"
+  _pat="$_pat|([^0-9]|^)402([^0-9]|$)"                               # HTTP 402 (payment)
+  _pat="$_pat|tokens_limit_reached|body too large|([^0-9]|^)413([^0-9]|$)" # Context / Request size
+  printf '(%s)' "$_pat"
+}
+
 # is_rate_limited <text>
 # Returns 0 (true) if the text looks like a provider usage/rate-limit block —
 # API-level (429), subscription/billing caps (plan limit, out of tokens, HTTP 402),
@@ -152,19 +170,15 @@ unset _TOKEN_LIB
 #   - CLI syntax errors ("Invalid command format", "unknown flag", etc.) — see is_cli_error.
 is_rate_limited() {
   local text="$1"
-  # Build pattern in segments for readability — one category per line.
-  local _pat
-  _pat="hit your limit|rate[ -]?limit|resets [0-9]+(am|pm)|reached.*limit" # soft cap / throttle
-  _pat="$_pat|usage limit|quota exceeded|too many requests|exceeded.*quota"
-  _pat="$_pat|([^0-9]|^)429([^0-9]|$)"                               # HTTP 429
-  _pat="$_pat|out of.*token|token.*exhaust"                            # token depletion
-  _pat="$_pat|overloaded_error|service.*overload|overload.*error"      # service overload
-  _pat="$_pat|([^0-9]|^)529([^0-9]|$)"                               # HTTP 529
-  _pat="$_pat|claude.*usage|usage.*claude"                             # Claude-specific cap
-  _pat="$_pat|plan.*limit|subscription.*limit|billing.*limit|daily.*limit|monthly.*limit|weekly.*limit"
-  _pat="$_pat|([^0-9]|^)402([^0-9]|$)"                               # HTTP 402 (payment)
-  _pat="$_pat|tokens_limit_reached|body too large|([^0-9]|^)413([^0-9]|$)" # Context / Request size
-  printf '%s\n' "$text" | grep -qiE "($_pat)"
+  printf '%s\n' "$text" | grep -qiE "$(_rate_limit_pattern)"
+}
+
+# is_rate_limited_files <file...>
+# File-aware variant of is_rate_limited that greps the files directly rather
+# than loading them into a shell variable. Use when output may be large enough
+# to risk ARG_MAX / OOM via $(cat file).
+is_rate_limited_files() {
+  grep -qiE "$(_rate_limit_pattern)" "$@" 2>/dev/null
 }
 
 # is_cli_error <text>
@@ -273,7 +287,11 @@ _claude_chain_invoke() {
       timeout "$timeout_sec" claude --print --model "$model" "${extra_args[@]}" \
         < "$prompt_file" > "$stdout_tmp" 2> "$stderr_tmp" || rc=$?
     else
-      # mktemp failure — degrade to direct stdout/stderr passthrough, no chain
+      # mktemp failure — clean up any partial temp file, then degrade to direct
+      # stdout/stderr passthrough (no chain). Without this, a half-successful
+      # mktemp pair would leak the surviving file into /tmp.
+      [ -n "$stdout_tmp" ] && rm -f "$stdout_tmp"
+      [ -n "$stderr_tmp" ] && rm -f "$stderr_tmp"
       timeout "$timeout_sec" claude --print --model "$model" "${extra_args[@]}" \
         < "$prompt_file" || rc=$?
       _CLAUDE_CHAIN_MODEL_USED="$model"
@@ -293,7 +311,7 @@ _claude_chain_invoke() {
       all_rl=0
       break
     fi
-    if ! is_rate_limited "$(cat "$stdout_tmp" "$stderr_tmp" 2>/dev/null)"; then
+    if ! is_rate_limited_files "$stdout_tmp" "$stderr_tmp"; then
       # Non-rate-limit failure — propagate immediately, do not try next model.
       final_rc="$rc"
       all_rl=0
@@ -305,7 +323,7 @@ _claude_chain_invoke() {
 
   # If every attempt was rate-limited, parse the last reset time and return 2.
   if [ "$all_rl" -eq 1 ] && [ "$attempted" -gt 0 ]; then
-    parse_reset_time "$(cat "${final_stdout:-/dev/null}" "${final_stderr:-/dev/null}" 2>/dev/null)"
+    parse_reset_time_files "${final_stdout:-/dev/null}" "${final_stderr:-/dev/null}"
     final_rc=2
   fi
 
@@ -616,24 +634,11 @@ run_duck() {
   return "$rc"
 }
 
-# parse_reset_time <text>
-# Extracts the rate-limit reset time from engine output and writes an ISO-8601
-# UTC timestamp to /tmp/dev-lead-rate-limit-reset for callers to embed in
-# status=rate-limited markers. Pattern: "resets H:MMam/pm (UTC)" or
-# "resets H:MM(am|pm) UTC".
-# Writes empty string if no reset time is found (caller treats as unknown).
-parse_reset_time() {
-  local text="$1"
-  # Match "resets 11:20pm (UTC)" or "resets 11:20pm UTC"
-  local time_str
-  time_str=$(printf '%s\n' "$text" | grep -oiE 'resets [0-9]{1,2}:[0-9]{2}(am|pm)' | head -1 || true)
-  if [ -z "$time_str" ]; then
-    printf '' > /tmp/dev-lead-rate-limit-reset
-    return 0
-  fi
-  # Extract H:MM(am|pm) part
-  local hhmm
-  hhmm=$(printf '%s' "$time_str" | grep -oiE '[0-9]{1,2}:[0-9]{2}(am|pm)$' || true)
+# _write_reset_time <hhmm>
+# Converts an H:MM(am|pm) string to ISO-8601 UTC and writes it to
+# /tmp/dev-lead-rate-limit-reset. Empty input → empty file (unknown).
+_write_reset_time() {
+  local hhmm="$1"
   if [ -z "$hhmm" ]; then
     printf '' > /tmp/dev-lead-rate-limit-reset
     return 0
@@ -650,6 +655,34 @@ parse_reset_time() {
     iso=$(date -u -d "${tomorrow} ${hhmm} UTC" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)
   fi
   printf '%s' "${iso:-}" > /tmp/dev-lead-rate-limit-reset
+}
+
+# parse_reset_time <text>
+# Extracts the rate-limit reset time from engine output and writes an ISO-8601
+# UTC timestamp to /tmp/dev-lead-rate-limit-reset for callers to embed in
+# status=rate-limited markers. Pattern: "resets H:MMam/pm (UTC)" or
+# "resets H:MM(am|pm) UTC".
+# Writes empty string if no reset time is found (caller treats as unknown).
+parse_reset_time() {
+  local text="$1"
+  # Match "resets 11:20pm (UTC)" or "resets 11:20pm UTC"
+  local time_str
+  time_str=$(printf '%s\n' "$text" | grep -oiE 'resets [0-9]{1,2}:[0-9]{2}(am|pm)' | head -1 || true)
+  local hhmm
+  hhmm=$(printf '%s' "$time_str" | grep -oiE '[0-9]{1,2}:[0-9]{2}(am|pm)$' || true)
+  _write_reset_time "$hhmm"
+}
+
+# parse_reset_time_files <file...>
+# File-aware variant of parse_reset_time that greps the files directly rather
+# than loading them into a shell variable. Use when output may be large enough
+# to risk ARG_MAX / OOM via $(cat file).
+parse_reset_time_files() {
+  local time_str
+  time_str=$(grep -hoiE 'resets [0-9]{1,2}:[0-9]{2}(am|pm)' "$@" 2>/dev/null | head -1 || true)
+  local hhmm
+  hhmm=$(printf '%s' "$time_str" | grep -oiE '[0-9]{1,2}:[0-9]{2}(am|pm)$' || true)
+  _write_reset_time "$hhmm"
 }
 
 # run_writer <prompt_file> [model]

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -277,7 +277,7 @@ _claude_chain_invoke() {
   IFS="$saved_ifs"
 
   local stdout_tmp="" stderr_tmp=""
-  local final_stdout="" final_stderr="" final_model="" final_rc=2
+  local final_stdout="" final_stderr="" final_model="" final_rc=0
   local rc=0 attempted=0 all_rl=1
   local model
 
@@ -329,12 +329,23 @@ _claude_chain_invoke() {
       all_rl=0
       break
     fi
-    # Rate-limited; record the message for diagnosis and try the next model.
-    echo "::warning::[claude] model $model rate-limited (rc=$rc) — trying next in chain" >&2
+    # Rate-limited; record diagnosis and try the next model.
+    # Phrasing intentionally avoids "rate-limit"/"429"/"quota" etc. — those
+    # tokens match is_rate_limited()/_rate_limit_pattern, and downstream
+    # callers (e.g. review-one-pr.sh) that scan our stderr would then
+    # misclassify a successful chain fallback as a provider rate-limit.
+    echo "::warning::[claude] model $model throttled (rc=$rc) — trying next in chain" >&2
   done
 
+  # Empty/whitespace-only chain → configuration error, not a rate-limit. Returning
+  # 2 here would trigger the cross-provider fallback as if quotas were exhausted.
+  if [ "$attempted" -eq 0 ]; then
+    echo "::error::_claude_chain_invoke: chain '$chain_csv' had no valid model entries" >&2
+    return 1
+  fi
+
   # If every attempt was rate-limited, parse the last reset time and return 2.
-  if [ "$all_rl" -eq 1 ] && [ "$attempted" -gt 0 ]; then
+  if [ "$all_rl" -eq 1 ]; then
     parse_reset_time_files "$final_stdout" "$final_stderr"
     final_rc=2
   fi
@@ -468,14 +479,28 @@ run_agentic() {
   fi
   case "$REVIEW_ENGINE" in
     claude)
-      local _agentic_chain
+      # Resolve the in-Claude model chain for this tier. The chain is the
+      # cascade tried on rate-limit (e.g. sonnet → opus). If the caller
+      # passed a model that does NOT match the tier's default ENGINE_*_MODEL,
+      # treat it as an explicit pin: honor it as a single-element chain so
+      # callers can still force a specific model when they need to (the
+      # documented `[model]` parameter on this function). The chain is only
+      # applied when the caller used the default model for the tier.
+      local _agentic_chain _tier_default=""
       case "$tier" in
-        deep)   _agentic_chain="${CLAUDE_DEEP_MODEL_CHAIN:-$model}" ;;
-        audit)  _agentic_chain="${CLAUDE_AUDIT_MODEL_CHAIN:-$model}" ;;
-        action) _agentic_chain="${CLAUDE_ACTION_MODEL_CHAIN:-$model}" ;;
-        single) _agentic_chain="${CLAUDE_SINGLE_MODEL_CHAIN:-$model}" ;;
+        deep)   _tier_default="${ENGINE_DEEP_MODEL:-}"
+                _agentic_chain="${CLAUDE_DEEP_MODEL_CHAIN:-$model}"   ;;
+        audit)  _tier_default="${ENGINE_AUDIT_MODEL:-}"
+                _agentic_chain="${CLAUDE_AUDIT_MODEL_CHAIN:-$model}"  ;;
+        action) _tier_default="${ENGINE_ACTION_MODEL:-}"
+                _agentic_chain="${CLAUDE_ACTION_MODEL_CHAIN:-$model}" ;;
+        single) _tier_default="${ENGINE_SINGLE_MODEL:-}"
+                _agentic_chain="${CLAUDE_SINGLE_MODEL_CHAIN:-$model}" ;;
         *)      _agentic_chain="$model" ;;
       esac
+      if [ -n "$_tier_default" ] && [ "$model" != "$_tier_default" ]; then
+        _agentic_chain="$model"
+      fi
       if [ -n "$_tok_tmp" ]; then
         _claude_chain_invoke "$_agentic_chain" "$prompt_file" "$DEEP_TIMEOUT_SEC" \
           --permission-mode acceptEdits \
@@ -741,7 +766,13 @@ run_writer() {
 
   case "$REVIEW_ENGINE" in
     claude)
+      # See run_agentic — honor caller's explicit model pin when it differs
+      # from the tier default. Chain only applies when the caller used the
+      # default action model for this engine.
       local _writer_chain="${CLAUDE_ACTION_MODEL_CHAIN:-$model}"
+      if [ -n "${ENGINE_ACTION_MODEL:-}" ] && [ "$model" != "$ENGINE_ACTION_MODEL" ]; then
+        _writer_chain="$model"
+      fi
       if [ -n "$_tmp" ]; then
         _claude_chain_invoke "$_writer_chain" "$prompt_file" "$ACTION_TIMEOUT_SEC" \
           --permission-mode acceptEdits \

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -10,6 +10,17 @@ set -euo pipefail
 #   ENGINE_* env vars for model names and labels
 #   DUCK_ENGINE / DUCK_MODEL for rubber-duck cross-engine review
 #
+# Rate-limit fallback (two layers, applied in order):
+#   1. In-Claude model fallback — per-tier CLAUDE_*_MODEL_CHAIN walks alternate
+#      Claude models (e.g. sonnet → opus) before declaring the provider
+#      rate-limited. Each Claude model has its own TPM/RPM bucket, so swapping
+#      models often recovers without leaving the provider. Does NOT help when
+#      the daily subscription cap is exhausted (cap is shared across all Claude
+#      models — see issue #206 for the proactive headroom guard).
+#   2. Cross-provider fallback — run_writer_with_fallback / review-batch.sh
+#      walk claude → gemini → copilot only after the in-engine chain is fully
+#      rate-limited (exit code 2 from the engine-layer call).
+#
 # Token logging (opt-in):
 #   Set TOKEN_LOG_FILE=<path> to capture per-call JSONL token records.
 #   TOKEN_WORKFLOW — workflow label for records (default: "unknown").
@@ -48,6 +59,17 @@ set_engine_config() {
       # Cross-engine rubber duck: use Copilot when Claude is primary
       DUCK_ENGINE="copilot"
       DUCK_MODEL="o4-mini"
+      # Per-tier in-Claude model fallback chains (comma-separated).
+      # On rate-limit, the chain is walked left-to-right before the cross-provider
+      # fallback (claude → gemini → copilot) kicks in. Per-model TPM/RPM buckets
+      # are independent, so swapping models within Claude often recovers without
+      # leaving the provider. (Daily subscription cap is shared — see issue #206.)
+      # Override per workflow via env to tune cost/capability trade-offs.
+      CLAUDE_TRIAGE_MODEL_CHAIN="${CLAUDE_TRIAGE_MODEL_CHAIN:-claude-haiku-4-5-20251001,claude-sonnet-4-6}"
+      CLAUDE_DEEP_MODEL_CHAIN="${CLAUDE_DEEP_MODEL_CHAIN:-claude-sonnet-4-6,claude-opus-4-7}"
+      CLAUDE_AUDIT_MODEL_CHAIN="${CLAUDE_AUDIT_MODEL_CHAIN:-claude-opus-4-7,claude-sonnet-4-6}"
+      CLAUDE_ACTION_MODEL_CHAIN="${CLAUDE_ACTION_MODEL_CHAIN:-claude-sonnet-4-6,claude-opus-4-7}"
+      CLAUDE_SINGLE_MODEL_CHAIN="${CLAUDE_SINGLE_MODEL_CHAIN:-claude-opus-4-7,claude-sonnet-4-6}"
       ;;
     gemini)
       ENGINE_TRIAGE_MODEL="gemini-2.0-flash"
@@ -60,6 +82,12 @@ set_engine_config() {
       # Cross-engine rubber duck: use Claude for diversity
       DUCK_ENGINE="claude"
       DUCK_MODEL="claude-sonnet-4-6"
+      # No in-engine chain for Gemini — only one production model in use today.
+      CLAUDE_TRIAGE_MODEL_CHAIN=""
+      CLAUDE_DEEP_MODEL_CHAIN=""
+      CLAUDE_AUDIT_MODEL_CHAIN=""
+      CLAUDE_ACTION_MODEL_CHAIN=""
+      CLAUDE_SINGLE_MODEL_CHAIN=""
       ;;
     copilot)
       ENGINE_TRIAGE_MODEL="o4-mini"
@@ -79,6 +107,12 @@ set_engine_config() {
       # Cross-engine rubber duck: use Gemini when Copilot is primary
       DUCK_ENGINE="gemini"
       DUCK_MODEL="gemini-2.0-flash"
+      # No in-engine chain for Copilot — single GitHub Models endpoint.
+      CLAUDE_TRIAGE_MODEL_CHAIN=""
+      CLAUDE_DEEP_MODEL_CHAIN=""
+      CLAUDE_AUDIT_MODEL_CHAIN=""
+      CLAUDE_ACTION_MODEL_CHAIN=""
+      CLAUDE_SINGLE_MODEL_CHAIN=""
       ;;
     *)
       echo "::error::Unknown REVIEW_ENGINE='$REVIEW_ENGINE' (expected: claude, gemini, or copilot)"
@@ -90,6 +124,9 @@ set_engine_config() {
   export ENGINE_ACTION_MODEL ENGINE_SINGLE_MODEL
   export ENGINE_LABEL ENGINE_SINGLE_LABEL
   export DUCK_ENGINE DUCK_MODEL COPILOT_API_MODEL
+  export CLAUDE_TRIAGE_MODEL_CHAIN CLAUDE_DEEP_MODEL_CHAIN
+  export CLAUDE_AUDIT_MODEL_CHAIN CLAUDE_ACTION_MODEL_CHAIN
+  export CLAUDE_SINGLE_MODEL_CHAIN
 }
 
 # Initial config
@@ -189,6 +226,104 @@ copilot_chat() {
     -s "$@" < /dev/null
 }
 
+# _claude_chain_invoke <chain_csv> <prompt_file> <timeout_sec> [extra_args...]
+# Walks a comma-separated list of Claude models, invoking `claude --print --model X`
+# with the given extra arguments. The first model whose run does NOT trigger
+# is_rate_limited() wins: its captured stdout is written to fd1, stderr to fd2,
+# and its exit code is returned. Rate-limited attempts are discarded and the
+# next model is tried. If every model in the chain rate-limits, returns 2 and
+# writes the parsed reset time to /tmp/dev-lead-rate-limit-reset.
+#
+# Empty chain → no-op return 0 (callers should fall back to the single-model
+# legacy path; this is only used when CLAUDE_*_MODEL_CHAIN is set).
+#
+# Sets _CLAUDE_CHAIN_MODEL_USED to the model that produced the final output
+# (success or last attempt) so callers can log which model actually ran.
+_claude_chain_invoke() {
+  local chain_csv="$1" prompt_file="$2" timeout_sec="$3"
+  shift 3
+  local extra_args=("$@")
+
+  if [ -z "$chain_csv" ]; then
+    echo "::error::_claude_chain_invoke called with empty chain" >&2
+    return 1
+  fi
+
+  local saved_ifs="$IFS"
+  IFS=',' read -ra models <<< "$chain_csv"
+  IFS="$saved_ifs"
+
+  local stdout_tmp="" stderr_tmp=""
+  local final_stdout="" final_stderr="" final_model="" final_rc=2
+  local rc=0 attempted=0 all_rl=1
+  local model
+
+  for model in "${models[@]}"; do
+    # Trim whitespace
+    model="${model#"${model%%[![:space:]]*}"}"
+    model="${model%"${model##*[![:space:]]}"}"
+    [ -z "$model" ] && continue
+
+    attempted=$((attempted + 1))
+    stdout_tmp="$(mktemp 2>/dev/null)" || stdout_tmp=""
+    stderr_tmp="$(mktemp 2>/dev/null)" || stderr_tmp=""
+    rc=0
+
+    if [ -n "$stdout_tmp" ] && [ -n "$stderr_tmp" ]; then
+      timeout "$timeout_sec" claude --print --model "$model" "${extra_args[@]}" \
+        < "$prompt_file" > "$stdout_tmp" 2> "$stderr_tmp" || rc=$?
+    else
+      # mktemp failure — degrade to direct stdout/stderr passthrough, no chain
+      timeout "$timeout_sec" claude --print --model "$model" "${extra_args[@]}" \
+        < "$prompt_file" || rc=$?
+      _CLAUDE_CHAIN_MODEL_USED="$model"
+      export _CLAUDE_CHAIN_MODEL_USED
+      return "$rc"
+    fi
+
+    # Drop any previous final-attempt buffers (we keep only the latest)
+    [ -n "$final_stdout" ] && rm -f "$final_stdout"
+    [ -n "$final_stderr" ] && rm -f "$final_stderr"
+    final_stdout="$stdout_tmp"
+    final_stderr="$stderr_tmp"
+    final_model="$model"
+
+    if [ "$rc" -eq 0 ]; then
+      final_rc=0
+      all_rl=0
+      break
+    fi
+    if ! is_rate_limited "$(cat "$stdout_tmp" "$stderr_tmp" 2>/dev/null)"; then
+      # Non-rate-limit failure — propagate immediately, do not try next model.
+      final_rc="$rc"
+      all_rl=0
+      break
+    fi
+    # Rate-limited; record the message for diagnosis and try the next model.
+    echo "::warning::[claude] model $model rate-limited (rc=$rc) — trying next in chain" >&2
+  done
+
+  # If every attempt was rate-limited, parse the last reset time and return 2.
+  if [ "$all_rl" -eq 1 ] && [ "$attempted" -gt 0 ]; then
+    parse_reset_time "$(cat "${final_stdout:-/dev/null}" "${final_stderr:-/dev/null}" 2>/dev/null)"
+    final_rc=2
+  fi
+
+  # Emit the final attempt's captured output to the caller.
+  if [ -n "$final_stdout" ]; then
+    cat "$final_stdout"
+    rm -f "$final_stdout"
+  fi
+  if [ -n "$final_stderr" ]; then
+    cat "$final_stderr" >&2
+    rm -f "$final_stderr"
+  fi
+
+  _CLAUDE_CHAIN_MODEL_USED="$final_model"
+  export _CLAUDE_CHAIN_MODEL_USED
+  return "$final_rc"
+}
+
 # _record_engine_tokens <tier> <engine> <model> <prompt_file> [output_file]
 # Writes one token record to TOKEN_LOG_FILE using estimate_tokens_from_file.
 # No-op when TOKEN_LOG_FILE is unset or the token-metrics library is not loaded.
@@ -229,16 +364,15 @@ run_triage() {
     [ -n "$_tok_tmp" ] && : > "$_tok_tmp"
     case "$REVIEW_ENGINE" in
       claude)
+        local _triage_chain="${CLAUDE_TRIAGE_MODEL_CHAIN:-$ENGINE_TRIAGE_MODEL}"
         if [ -n "$_tok_tmp" ]; then
-          timeout "$TRIAGE_TIMEOUT_SEC" claude --print \
-            --model "$ENGINE_TRIAGE_MODEL" \
+          _claude_chain_invoke "$_triage_chain" "$prompt_file" "$TRIAGE_TIMEOUT_SEC" \
             --disallowed-tools "Bash,Read,Write,Edit,Grep,Glob,WebFetch,WebSearch,Task,TodoWrite,NotebookEdit" \
-            < "$prompt_file" | tee "$_tok_tmp" || rc=${PIPESTATUS[0]}
+            | tee "$_tok_tmp" || rc=${PIPESTATUS[0]}
         else
-          timeout "$TRIAGE_TIMEOUT_SEC" claude --print \
-            --model "$ENGINE_TRIAGE_MODEL" \
+          _claude_chain_invoke "$_triage_chain" "$prompt_file" "$TRIAGE_TIMEOUT_SEC" \
             --disallowed-tools "Bash,Read,Write,Edit,Grep,Glob,WebFetch,WebSearch,Task,TodoWrite,NotebookEdit" \
-            < "$prompt_file" || rc=$?
+            || rc=$?
         fi
         ;;
       gemini)
@@ -266,7 +400,8 @@ run_triage() {
         ;;
     esac
     if [ "$rc" -eq 0 ]; then
-      _record_engine_tokens "triage" "$REVIEW_ENGINE" "$ENGINE_TRIAGE_MODEL" "$prompt_file" "$_tok_tmp"
+      local _triage_used="${_CLAUDE_CHAIN_MODEL_USED:-$ENGINE_TRIAGE_MODEL}"
+      _record_engine_tokens "triage" "$REVIEW_ENGINE" "$_triage_used" "$prompt_file" "$_tok_tmp"
       [ -n "$_tok_tmp" ] && rm -f "$_tok_tmp"
       return 0
     fi
@@ -303,18 +438,24 @@ run_agentic() {
   fi
   case "$REVIEW_ENGINE" in
     claude)
+      local _agentic_chain
+      case "$tier" in
+        deep)   _agentic_chain="${CLAUDE_DEEP_MODEL_CHAIN:-$model}" ;;
+        audit)  _agentic_chain="${CLAUDE_AUDIT_MODEL_CHAIN:-$model}" ;;
+        action) _agentic_chain="${CLAUDE_ACTION_MODEL_CHAIN:-$model}" ;;
+        single) _agentic_chain="${CLAUDE_SINGLE_MODEL_CHAIN:-$model}" ;;
+        *)      _agentic_chain="$model" ;;
+      esac
       if [ -n "$_tok_tmp" ]; then
-        timeout "$DEEP_TIMEOUT_SEC" claude --print \
-          --model "$model" \
+        _claude_chain_invoke "$_agentic_chain" "$prompt_file" "$DEEP_TIMEOUT_SEC" \
           --permission-mode acceptEdits \
           --allowed-tools "Bash,Read,Grep,Glob" \
-          < "$prompt_file" | tee "$_tok_tmp" || rc=${PIPESTATUS[0]}
+          | tee "$_tok_tmp" || rc=${PIPESTATUS[0]}
       else
-        timeout "$DEEP_TIMEOUT_SEC" claude --print \
-          --model "$model" \
+        _claude_chain_invoke "$_agentic_chain" "$prompt_file" "$DEEP_TIMEOUT_SEC" \
           --permission-mode acceptEdits \
           --allowed-tools "Bash,Read,Grep,Glob" \
-          < "$prompt_file" || rc=$?
+          || rc=$?
       fi
       ;;
     gemini)
@@ -351,7 +492,11 @@ run_agentic() {
       ;;
   esac
   if [ "$rc" -eq 0 ]; then
-    _record_engine_tokens "$tier" "$REVIEW_ENGINE" "$model" "$prompt_file" "$_tok_tmp"
+    local _agentic_used="$model"
+    if [ "$REVIEW_ENGINE" = "claude" ] && [ -n "${_CLAUDE_CHAIN_MODEL_USED:-}" ]; then
+      _agentic_used="$_CLAUDE_CHAIN_MODEL_USED"
+    fi
+    _record_engine_tokens "$tier" "$REVIEW_ENGINE" "$_agentic_used" "$prompt_file" "$_tok_tmp"
   fi
   [ -n "$_tok_tmp" ] && rm -f "$_tok_tmp"
   return "$rc"
@@ -531,18 +676,17 @@ run_writer() {
 
   case "$REVIEW_ENGINE" in
     claude)
+      local _writer_chain="${CLAUDE_ACTION_MODEL_CHAIN:-$model}"
       if [ -n "$_tmp" ]; then
-        timeout "$ACTION_TIMEOUT_SEC" claude --print \
-          --model "$model" \
+        _claude_chain_invoke "$_writer_chain" "$prompt_file" "$ACTION_TIMEOUT_SEC" \
           --permission-mode acceptEdits \
           --allowed-tools "Bash,Read,Write,Edit,Grep,Glob,WebFetch" \
-          < "$prompt_file" 2>&1 | tee "$_tmp" || rc=${PIPESTATUS[0]}
+          2>&1 | tee "$_tmp" || rc=${PIPESTATUS[0]}
       else
-        timeout "$ACTION_TIMEOUT_SEC" claude --print \
-          --model "$model" \
+        _claude_chain_invoke "$_writer_chain" "$prompt_file" "$ACTION_TIMEOUT_SEC" \
           --permission-mode acceptEdits \
           --allowed-tools "Bash,Read,Write,Edit,Grep,Glob,WebFetch" \
-          < "$prompt_file" || rc=$?
+          || rc=$?
       fi
       ;;
     gemini)
@@ -577,7 +721,11 @@ run_writer() {
     return 2
   fi
   if [ "$rc" -eq 0 ]; then
-    _record_engine_tokens "writer" "$REVIEW_ENGINE" "$model" "$prompt_file" "$_tmp"
+    local _writer_used="$model"
+    if [ "$REVIEW_ENGINE" = "claude" ] && [ -n "${_CLAUDE_CHAIN_MODEL_USED:-}" ]; then
+      _writer_used="$_CLAUDE_CHAIN_MODEL_USED"
+    fi
+    _record_engine_tokens "writer" "$REVIEW_ENGINE" "$_writer_used" "$prompt_file" "$_tmp"
   fi
   if [ -n "$_tmp" ]; then
     # Redact once: write secret-scrubbed content to the persisted path, then

--- a/tests/dev-lead/fixtures/engines/stub-claude
+++ b/tests/dev-lead/fixtures/engines/stub-claude
@@ -1,12 +1,53 @@
 #!/usr/bin/env bash
-# Configurable via: STUB_ENGINE_RESPONSE, STUB_ENGINE_EXIT, STUB_ENGINE_DELAY
+# Configurable via:
+#   STUB_ENGINE_RESPONSE, STUB_ENGINE_EXIT, STUB_ENGINE_DELAY
+#   STUB_ENGINE_EXIT_BY_MODEL  — pipe-delimited list of "model=exit_code" pairs.
+#                                If set and a pair matches --model, that exit
+#                                code overrides STUB_ENGINE_EXIT. Models not in
+#                                the map fall back to STUB_ENGINE_EXIT.
+#   STUB_ENGINE_RESPONSE_BY_MODEL  — pipe-delimited "model=response" pairs,
+#                                    same lookup as EXIT_BY_MODEL.
+#   STUB_ENGINE_RECORD_MODELS  — if set to a writable path, every --model value
+#                                seen is appended as a new line for inspection.
+model=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --print|--model|--permission-mode|--allowed-tools|--disallowed-tools|--max-turns)
+    --print)
+      shift ;;
+    --permission-mode|--allowed-tools|--disallowed-tools|--max-turns)
       shift; shift ;;
+    --model)
+      model="$2"; shift; shift ;;
     *) shift ;;
   esac
 done
+
+if [ -n "${STUB_ENGINE_RECORD_MODELS:-}" ]; then
+  printf '%s\n' "$model" >> "$STUB_ENGINE_RECORD_MODELS" 2>/dev/null || true
+fi
+
 sleep "${STUB_ENGINE_DELAY:-0}"
-printf '%s\n' "${STUB_ENGINE_RESPONSE:-stub engine response}"
-exit "${STUB_ENGINE_EXIT:-0}"
+
+# Resolve response: per-model override → default.
+response="${STUB_ENGINE_RESPONSE:-stub engine response}"
+if [ -n "${STUB_ENGINE_RESPONSE_BY_MODEL:-}" ] && [ -n "$model" ]; then
+  IFS='|' read -ra _pairs <<< "$STUB_ENGINE_RESPONSE_BY_MODEL"
+  for _p in "${_pairs[@]}"; do
+    case "$_p" in
+      "$model="*) response="${_p#"$model="}"; break ;;
+    esac
+  done
+fi
+printf '%s\n' "$response"
+
+# Resolve exit code: per-model override → default.
+exit_code="${STUB_ENGINE_EXIT:-0}"
+if [ -n "${STUB_ENGINE_EXIT_BY_MODEL:-}" ] && [ -n "$model" ]; then
+  IFS='|' read -ra _epairs <<< "$STUB_ENGINE_EXIT_BY_MODEL"
+  for _ep in "${_epairs[@]}"; do
+    case "$_ep" in
+      "$model="*) exit_code="${_ep#"$model="}"; break ;;
+    esac
+  done
+fi
+exit "$exit_code"

--- a/tests/dev-lead/unit/test_engine_chain.bats
+++ b/tests/dev-lead/unit/test_engine_chain.bats
@@ -246,3 +246,80 @@ _source_engine() {
   [ -f /tmp/dev-lead-rate-limit-reset ]
   [ ! -s /tmp/dev-lead-rate-limit-reset ]
 }
+
+# ── Codex review findings: warning phrasing + config errors + model pin ─────
+
+@test "chain: throttled warning phrase does NOT match is_rate_limited" {
+  # The warning must not contain any token that _rate_limit_pattern matches —
+  # otherwise downstream callers that scan our stderr (e.g. review-one-pr.sh
+  # triage) would misclassify a successful chain fallback as a rate-limit.
+  _source_engine "claude"
+  run is_rate_limited \
+    "::warning::[claude] model claude-sonnet-4-6 throttled (rc=1) — trying next in chain"
+  [ "$status" -ne 0 ]
+}
+
+@test "chain: writer non-RL failure after RL attempt propagates correctly (not remapped to 2)" {
+  # Model A (sonnet) rate-limited → warning emitted → 2>&1 merges into _tmp.
+  # Model B (opus) fails with a non-rate-limit error. run_writer must return
+  # opus's exit code, not 2, even though _tmp contains the throttled warning.
+  _source_engine "claude"
+  export STUB_ENGINE_EXIT_BY_MODEL="claude-sonnet-4-6=1|claude-opus-4-7=1"
+  export STUB_ENGINE_RESPONSE_BY_MODEL="claude-sonnet-4-6=rate limit exceeded|claude-opus-4-7=segfault in agent runtime"
+
+  run run_writer "$TEST_PROMPT"
+
+  # opus's non-RL failure → exit 1 (NOT 2). If the throttled-warning text
+  # matched is_rate_limited, this would incorrectly return 2.
+  [ "$status" -eq 1 ]
+}
+
+@test "chain: empty/whitespace-only chain → config error (rc=1), not rate-limited (rc=2)" {
+  _source_engine "claude"
+  run _claude_chain_invoke "  ,  ,  " "$TEST_PROMPT" 30 --allowed-tools Read
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"no valid model entries"* ]] || [[ "$stderr" == *"no valid model entries"* ]]
+}
+
+@test "agentic: explicit model arg differing from tier default is honored (no chain expansion)" {
+  _source_engine "claude"
+  # Caller pins haiku for deep tier (overriding default sonnet → opus chain).
+  # Chain expansion would record sonnet+opus; pinning must record ONLY haiku.
+  export STUB_ENGINE_EXIT=0
+
+  run run_agentic "$TEST_PROMPT" "claude-haiku-4-5-20251001" "deep"
+
+  [ "$status" -eq 0 ]
+  # Only one invocation, and it's the pinned model — not sonnet or opus.
+  [ "$(wc -l < "$MODEL_RECORD")" -eq 1 ]
+  grep -q "claude-haiku-4-5-20251001" "$MODEL_RECORD"
+  ! grep -q "claude-sonnet-4-6" "$MODEL_RECORD"
+  ! grep -q "claude-opus-4-7" "$MODEL_RECORD"
+}
+
+@test "writer: explicit model arg differing from action default is honored (no chain expansion)" {
+  _source_engine "claude"
+  export STUB_ENGINE_EXIT=0
+
+  run run_writer "$TEST_PROMPT" "claude-haiku-4-5-20251001"
+
+  [ "$status" -eq 0 ]
+  [ "$(wc -l < "$MODEL_RECORD")" -eq 1 ]
+  grep -q "claude-haiku-4-5-20251001" "$MODEL_RECORD"
+  ! grep -q "claude-sonnet-4-6" "$MODEL_RECORD"
+  ! grep -q "claude-opus-4-7" "$MODEL_RECORD"
+}
+
+@test "agentic: passing tier default model still expands to full chain on rate-limit" {
+  # Regression guard for the pin-check above: when caller passes the tier
+  # default (sonnet), chain expansion still works (sonnet → opus fallback).
+  _source_engine "claude"
+  export STUB_ENGINE_EXIT_BY_MODEL="claude-sonnet-4-6=1|claude-opus-4-7=0"
+  export STUB_ENGINE_RESPONSE_BY_MODEL="claude-sonnet-4-6=429 too many|claude-opus-4-7=ok"
+
+  run run_agentic "$TEST_PROMPT" "claude-sonnet-4-6" "deep"
+
+  [ "$status" -eq 0 ]
+  grep -q "claude-sonnet-4-6" "$MODEL_RECORD"
+  grep -q "claude-opus-4-7" "$MODEL_RECORD"
+}

--- a/tests/dev-lead/unit/test_engine_chain.bats
+++ b/tests/dev-lead/unit/test_engine_chain.bats
@@ -192,3 +192,57 @@ _source_engine() {
   # No claude model recorded (we ran gemini)
   [ ! -s "$MODEL_RECORD" ]
 }
+
+# ── File-based rate-limit + reset-time helpers ─────────────────────────────
+
+@test "is_rate_limited_files: detects rate-limit text across multiple files" {
+  _source_engine "claude"
+  local f1 f2
+  f1="$(mktemp)"; f2="$(mktemp)"
+  echo "all good" > "$f1"
+  echo "Error 429: too many requests" > "$f2"
+  run is_rate_limited_files "$f1" "$f2"
+  rm -f "$f1" "$f2"
+  [ "$status" -eq 0 ]
+}
+
+@test "is_rate_limited_files: returns 1 when nothing matches" {
+  _source_engine "claude"
+  local f1
+  f1="$(mktemp)"
+  echo "completed normally" > "$f1"
+  run is_rate_limited_files "$f1"
+  rm -f "$f1"
+  [ "$status" -ne 0 ]
+}
+
+@test "is_rate_limited_files: tolerates empty/missing paths" {
+  _source_engine "claude"
+  # No files → no match → exit 1
+  run is_rate_limited_files "" "/nonexistent/path/xyz"
+  [ "$status" -ne 0 ]
+}
+
+@test "parse_reset_time_files: writes ISO timestamp from rate-limit message in file" {
+  _source_engine "claude"
+  local f
+  f="$(mktemp)"
+  echo "You've hit your limit · resets 11:20pm (UTC)" > "$f"
+  rm -f /tmp/dev-lead-rate-limit-reset
+  parse_reset_time_files "$f"
+  rm -f "$f"
+  [ -f /tmp/dev-lead-rate-limit-reset ]
+  # Result should look like an ISO-8601 UTC timestamp ending in Z
+  grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$' /tmp/dev-lead-rate-limit-reset
+}
+
+@test "parse_reset_time_files: writes empty when no reset time present" {
+  _source_engine "claude"
+  local f
+  f="$(mktemp)"
+  echo "ordinary failure with no reset hint" > "$f"
+  parse_reset_time_files "$f"
+  rm -f "$f"
+  [ -f /tmp/dev-lead-rate-limit-reset ]
+  [ ! -s /tmp/dev-lead-rate-limit-reset ]
+}

--- a/tests/dev-lead/unit/test_engine_chain.bats
+++ b/tests/dev-lead/unit/test_engine_chain.bats
@@ -1,0 +1,194 @@
+#!/usr/bin/env bats
+# Unit tests for engine.sh — in-Claude model-tier fallback chain.
+#
+# Verifies that when the first model in a CLAUDE_*_MODEL_CHAIN hits a
+# rate-limit, the next model is tried before the call gives up with exit 2
+# (which triggers the outer cross-provider fallback).
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+ENGINE_SCRIPT="$SCRIPT_DIR/scripts/engine.sh"
+STUB_ENGINES_DIR="$SCRIPT_DIR/tests/dev-lead/fixtures/engines"
+
+setup() {
+  export GITHUB_ENV="$(mktemp)"
+  export GITHUB_OUTPUT="$(mktemp)"
+
+  STUB_BIN_DIR="$(mktemp -d)"
+  cp "$STUB_ENGINES_DIR/stub-claude" "$STUB_BIN_DIR/claude"
+  cp "$STUB_ENGINES_DIR/stub-gemini" "$STUB_BIN_DIR/gemini"
+  chmod +x "$STUB_BIN_DIR/claude" "$STUB_BIN_DIR/gemini"
+  export PATH="$STUB_BIN_DIR:$PATH"
+  export STUB_BIN_DIR
+
+  TEST_PROMPT="$(mktemp)"
+  echo "test prompt content" > "$TEST_PROMPT"
+  export TEST_PROMPT
+
+  MODEL_RECORD="$(mktemp)"
+  export STUB_ENGINE_RECORD_MODELS="$MODEL_RECORD"
+
+  export DEV_LEAD_DRY_RUN="false"
+}
+
+teardown() {
+  rm -f "$GITHUB_ENV" "$GITHUB_OUTPUT" "$TEST_PROMPT" "$MODEL_RECORD"
+  rm -rf "$STUB_BIN_DIR"
+  unset STUB_ENGINE_EXIT_BY_MODEL STUB_ENGINE_RESPONSE_BY_MODEL
+  unset STUB_ENGINE_RECORD_MODELS STUB_ENGINE_EXIT STUB_ENGINE_RESPONSE
+  unset CLAUDE_ACTION_MODEL_CHAIN CLAUDE_DEEP_MODEL_CHAIN
+  unset CLAUDE_TRIAGE_MODEL_CHAIN CLAUDE_AUDIT_MODEL_CHAIN
+}
+
+_source_engine() {
+  local engine="${1:-claude}"
+  export REVIEW_ENGINE="$engine"
+  source "$ENGINE_SCRIPT" 2>/dev/null || true
+}
+
+# ── _claude_chain_invoke unit tests ───────────────────────────────────────────
+
+@test "chain: first model succeeds → no fallback attempted" {
+  _source_engine "claude"
+  export STUB_ENGINE_EXIT=0
+
+  run _claude_chain_invoke "claude-sonnet-4-6,claude-opus-4-7" \
+    "$TEST_PROMPT" 30 --allowed-tools Read
+
+  [ "$status" -eq 0 ]
+  # Only one model invocation recorded
+  [ "$(wc -l < "$MODEL_RECORD")" -eq 1 ]
+  grep -q "claude-sonnet-4-6" "$MODEL_RECORD"
+  ! grep -q "claude-opus-4-7" "$MODEL_RECORD"
+}
+
+@test "chain: first model rate-limited → falls through to second" {
+  _source_engine "claude"
+  # sonnet returns a rate-limit message with non-zero exit; opus succeeds.
+  export STUB_ENGINE_EXIT_BY_MODEL="claude-sonnet-4-6=1|claude-opus-4-7=0"
+  export STUB_ENGINE_RESPONSE_BY_MODEL="claude-sonnet-4-6=You've hit your limit · resets 5pm (UTC)|claude-opus-4-7=opus response"
+
+  run _claude_chain_invoke "claude-sonnet-4-6,claude-opus-4-7" \
+    "$TEST_PROMPT" 30 --allowed-tools Read
+
+  [ "$status" -eq 0 ]
+  # Both models were invoked
+  grep -q "claude-sonnet-4-6" "$MODEL_RECORD"
+  grep -q "claude-opus-4-7" "$MODEL_RECORD"
+  # Final output is the opus response, not the rate-limit text
+  [[ "$output" == *"opus response"* ]]
+  [[ "$output" != *"hit your limit"* ]]
+}
+
+@test "chain: all models rate-limited → returns exit 2" {
+  _source_engine "claude"
+  export STUB_ENGINE_EXIT_BY_MODEL="claude-sonnet-4-6=1|claude-opus-4-7=1"
+  export STUB_ENGINE_RESPONSE_BY_MODEL="claude-sonnet-4-6=429 too many requests|claude-opus-4-7=429 too many requests"
+
+  run _claude_chain_invoke "claude-sonnet-4-6,claude-opus-4-7" \
+    "$TEST_PROMPT" 30 --allowed-tools Read
+
+  [ "$status" -eq 2 ]
+  grep -q "claude-sonnet-4-6" "$MODEL_RECORD"
+  grep -q "claude-opus-4-7" "$MODEL_RECORD"
+}
+
+@test "chain: non-rate-limit failure → propagates immediately without trying next" {
+  _source_engine "claude"
+  # sonnet fails with a non-rate-limit error; chain must NOT advance
+  export STUB_ENGINE_EXIT_BY_MODEL="claude-sonnet-4-6=1|claude-opus-4-7=0"
+  export STUB_ENGINE_RESPONSE_BY_MODEL="claude-sonnet-4-6=unexpected internal error|claude-opus-4-7=should not run"
+
+  run _claude_chain_invoke "claude-sonnet-4-6,claude-opus-4-7" \
+    "$TEST_PROMPT" 30 --allowed-tools Read
+
+  [ "$status" -eq 1 ]
+  grep -q "claude-sonnet-4-6" "$MODEL_RECORD"
+  ! grep -q "claude-opus-4-7" "$MODEL_RECORD"
+}
+
+@test "chain: whitespace and empty entries are tolerated" {
+  _source_engine "claude"
+  export STUB_ENGINE_EXIT_BY_MODEL="claude-sonnet-4-6=1|claude-opus-4-7=0"
+  export STUB_ENGINE_RESPONSE_BY_MODEL="claude-sonnet-4-6=rate limit exceeded|claude-opus-4-7=ok"
+
+  run _claude_chain_invoke "  claude-sonnet-4-6 , , claude-opus-4-7 " \
+    "$TEST_PROMPT" 30 --allowed-tools Read
+
+  [ "$status" -eq 0 ]
+  [ "$(wc -l < "$MODEL_RECORD")" -eq 2 ]
+}
+
+# ── End-to-end: writer uses the chain via CLAUDE_ACTION_MODEL_CHAIN ────────────
+
+@test "writer: sonnet rate-limited → opus tried via CLAUDE_ACTION_MODEL_CHAIN" {
+  _source_engine "claude"
+  # Defaults from set_engine_config: CLAUDE_ACTION_MODEL_CHAIN=sonnet,opus
+  export STUB_ENGINE_EXIT_BY_MODEL="claude-sonnet-4-6=1|claude-opus-4-7=0"
+  export STUB_ENGINE_RESPONSE_BY_MODEL="claude-sonnet-4-6=too many requests (429)|claude-opus-4-7=opus did the work"
+
+  run run_writer "$TEST_PROMPT"
+
+  [ "$status" -eq 0 ]
+  grep -q "claude-sonnet-4-6" "$MODEL_RECORD"
+  grep -q "claude-opus-4-7" "$MODEL_RECORD"
+}
+
+@test "writer: sonnet rate-limited and opus rate-limited → exit 2 (cross-provider fallback signal)" {
+  _source_engine "claude"
+  export STUB_ENGINE_EXIT_BY_MODEL="claude-sonnet-4-6=1|claude-opus-4-7=1"
+  export STUB_ENGINE_RESPONSE_BY_MODEL="claude-sonnet-4-6=quota exceeded|claude-opus-4-7=quota exceeded"
+
+  run run_writer "$TEST_PROMPT"
+
+  [ "$status" -eq 2 ]
+}
+
+@test "writer: custom chain via env override is honored" {
+  _source_engine "claude"
+  # Override the chain so opus is tried FIRST
+  export CLAUDE_ACTION_MODEL_CHAIN="claude-opus-4-7,claude-sonnet-4-6"
+  export STUB_ENGINE_EXIT=0
+
+  run run_writer "$TEST_PROMPT"
+
+  [ "$status" -eq 0 ]
+  head -1 "$MODEL_RECORD" | grep -q "claude-opus-4-7"
+}
+
+# ── End-to-end: agentic respects per-tier chain selection ────────────────────
+
+@test "agentic: deep tier sonnet rate-limited → opus tried (CLAUDE_DEEP_MODEL_CHAIN)" {
+  _source_engine "claude"
+  export STUB_ENGINE_EXIT_BY_MODEL="claude-sonnet-4-6=1|claude-opus-4-7=0"
+  export STUB_ENGINE_RESPONSE_BY_MODEL="claude-sonnet-4-6=service overload|claude-opus-4-7=deep result"
+
+  run run_agentic "$TEST_PROMPT" "claude-sonnet-4-6" "deep"
+
+  [ "$status" -eq 0 ]
+  grep -q "claude-opus-4-7" "$MODEL_RECORD"
+}
+
+@test "agentic: audit tier opus rate-limited → sonnet tried (CLAUDE_AUDIT_MODEL_CHAIN)" {
+  _source_engine "claude"
+  # Default CLAUDE_AUDIT_MODEL_CHAIN = opus,sonnet — opus is first
+  export STUB_ENGINE_EXIT_BY_MODEL="claude-opus-4-7=1|claude-sonnet-4-6=0"
+  export STUB_ENGINE_RESPONSE_BY_MODEL="claude-opus-4-7=usage limit reached|claude-sonnet-4-6=audit ok"
+
+  run run_agentic "$TEST_PROMPT" "claude-opus-4-7" "audit"
+
+  [ "$status" -eq 0 ]
+  grep -q "claude-sonnet-4-6" "$MODEL_RECORD"
+}
+
+# ── Gemini/Copilot unchanged: no chain applied ────────────────────────────────
+
+@test "gemini: no in-engine chain; single-model behavior unchanged" {
+  _source_engine "gemini"
+  export STUB_ENGINE_EXIT=0
+
+  run run_writer "$TEST_PROMPT"
+
+  [ "$status" -eq 0 ]
+  # No claude model recorded (we ran gemini)
+  [ ! -s "$MODEL_RECORD" ]
+}

--- a/tests/dev-lead/unit/test_fix_issue.bats
+++ b/tests/dev-lead/unit/test_fix_issue.bats
@@ -171,15 +171,26 @@ esac
 GITEOF
   chmod +x "$STUB_BIN_DIR/git"
 
-  # gh stub: no existing PRs, issue API, comment posts ok, copilot rate-limited
+  # gh stub: no existing PRs, issue API, comment posts ok, copilot rate-limited.
+  # Dispatch on the gh subcommand ($1), NOT a pattern match against the full
+  # args string — the prompt body contains literal "gh api .../issues/..."
+  # examples that would otherwise hit the api branch and mask the copilot path.
   cat > "$STUB_BIN_DIR/gh" <<'GHEOF'
 #!/usr/bin/env bash
-case "$*" in
-  *"pulls?state=open"*) echo "0" ;;
-  *"api"*"repos/"*"issues/"*) echo '{"title":"Test Issue","body":"Test body"}' ;;
-  *"api"*"users/"*) echo '{"id":12345}' ;;
-  *"issue comment"*) exit 0 ;;
-  *"copilot"*) echo "rate limit exceeded"; exit 1 ;;
+cmd="$1"; shift || true
+case "$cmd" in
+  copilot) echo "rate limit exceeded"; exit 1 ;;
+  api)
+    case "$*" in
+      *"pulls?state=open"*) echo "0" ;;
+      *"users/"*) echo '{"id":12345}' ;;
+      *) echo '{"title":"Test Issue","body":"Test body"}' ;;
+    esac ;;
+  issue)
+    case "$*" in
+      comment*) exit 0 ;;
+      *) echo "{}" ;;
+    esac ;;
   *) echo "{}" ;;
 esac
 GHEOF
@@ -221,14 +232,24 @@ esac
 GITEOF
   chmod +x "$STUB_BIN_DIR/git"
 
+  # Dispatch on subcommand ($1) so the prompt body's literal "gh api .../issues/..."
+  # text does not match the api branch and mask the copilot rate-limit path.
   cat > "$STUB_BIN_DIR/gh" <<GHEOF
 #!/usr/bin/env bash
-case "\$*" in
-  *"pulls?state=open"*) echo "0" ;;
-  *"api"*"repos/"*"issues/"*) echo '{"title":"Test","body":"body"}' ;;
-  *"api"*"users/"*) echo '{"id":12345}' ;;
-  *"issue comment"*) touch "${comment_posted_sentinel}"; exit 0 ;;
-  *"copilot"*) echo "rate limit exceeded"; exit 1 ;;
+cmd="\$1"; shift || true
+case "\$cmd" in
+  copilot) echo "rate limit exceeded"; exit 1 ;;
+  api)
+    case "\$*" in
+      *"pulls?state=open"*) echo "0" ;;
+      *"users/"*) echo '{"id":12345}' ;;
+      *) echo '{"title":"Test","body":"body"}' ;;
+    esac ;;
+  issue)
+    case "\$*" in
+      comment*) touch "${comment_posted_sentinel}"; exit 0 ;;
+      *) echo "{}" ;;
+    esac ;;
   *) echo "{}" ;;
 esac
 GHEOF


### PR DESCRIPTION
## Summary

When a Claude model hits its per-model rate limit, walk an in-engine model chain (e.g. `sonnet → opus`) before failing over to gemini/copilot. Each Claude model has its own TPM/RPM bucket, so swapping within Claude often recovers without leaving the provider.

- Closes a gap behind issues #195 (token spike incident) and #206 (proactive headroom check, complementary).

## Diagnosis that motivated this

- The 2026-05-16 incident exhausted Claude on `claude-sonnet-4-6` only — opus and haiku buckets were still available, but `run_writer_with_fallback` jumped straight to gemini.
- `scripts/engine.sh` hard-coded a single model per tier; cross-provider fallback in `review-batch.sh` and `run_writer_with_fallback` was the only escape hatch.
- PR #204 (intent-based dispatch from issue #195) was closed unmerged on 2026-05-20, so write tasks still hit sonnet unconditionally.

## What changed

- Defaults in `set_engine_config()`'s claude branch:
  - `CLAUDE_TRIAGE_MODEL_CHAIN=claude-haiku-4-5-20251001,claude-sonnet-4-6`
  - `CLAUDE_DEEP_MODEL_CHAIN=claude-sonnet-4-6,claude-opus-4-7`
  - `CLAUDE_AUDIT_MODEL_CHAIN=claude-opus-4-7,claude-sonnet-4-6`
  - `CLAUDE_ACTION_MODEL_CHAIN=claude-sonnet-4-6,claude-opus-4-7`
  - `CLAUDE_SINGLE_MODEL_CHAIN=claude-opus-4-7,claude-sonnet-4-6`
  - Haiku is intentionally excluded from the write/deep chains (capability concern for agentic edits).
- New `_claude_chain_invoke` helper walks the chain, captures per-attempt stdout/stderr, runs `is_rate_limited` on each, advances only on rate-limit, propagates non-RL failures immediately, returns `2` only if every model is rate-limited (preserving the cross-provider fallback contract).
- `run_writer`, `run_agentic`, `run_triage` (claude branches only) route through the helper. Gemini and Copilot paths are unchanged — they have no in-engine chain.
- Token-metrics records now log the model that actually ran (`_CLAUDE_CHAIN_MODEL_USED`), not the first chain entry.
- `tests/dev-lead/fixtures/engines/stub-claude` upgraded with `STUB_ENGINE_EXIT_BY_MODEL` / `STUB_ENGINE_RESPONSE_BY_MODEL` / `STUB_ENGINE_RECORD_MODELS` so per-model behavior can be simulated.

## What this does NOT solve

In-engine fallback only helps when the per-model bucket is the limiter. The **daily subscription cap** is shared across all Claude models — if that's exhausted (as on 2026-05-16), no Claude model will work and we still need the cross-provider hop. Issue #206 (proactive headroom guard) remains the right place to track that.

## Test plan

- [x] `bats tests/dev-lead/unit/test_engine_chain.bats` — 11/11 new cases pass
- [x] `bats tests/dev-lead/unit/test_engine_writer.bats tests/dev-lead/unit/test_engine_fallback.bats` — 38/38 pass (writer + cross-provider fallback contract preserved)
- [x] `bats tests/test_batch_fallback.bats tests/test_validate_engines.bats` — 3/3 pass
- [x] Full `tests/dev-lead/unit/*.bats` — 191/193 pass; the 2 failures (`test_fix_issue.bats` rate-limited tests) are **pre-existing on main**, unrelated to this change
- [x] `shellcheck scripts/engine.sh` — no new findings
- [ ] After merge: monitor one Claude rate-limit event in the wild to confirm the chain logs `model X rate-limited — trying next in chain`

## References

- Issue #195 — 2026-05-16 token spike, root cause analysis
- Issue #206 — proactive headroom check (complementary, deferred)
- Closed PR #204 — earlier intent-based dispatch attempt