### PR TITLE
fix(dev-lead): expose GEMINI_API_KEY so gemini fallback works

### DIFF
--- a/.github/workflows/dev-lead-reusable.yml
+++ b/.github/workflows/dev-lead-reusable.yml
@@ -82,6 +82,7 @@ jobs:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           COPILOT_GITHUB_TOKEN: ${{ secrets.GH_PAT }}
         run: bash .dev-lead/scripts/dev-lead-intent.sh
 
@@ -109,6 +110,7 @@ jobs:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GH_PAT_WORKFLOWS: ${{ secrets.GH_PAT_WORKFLOWS }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           GH_PAT: ${{ secrets.GH_PAT }}
         run: bash .dev-lead/scripts/dev-lead-preflight.sh
 
@@ -161,6 +163,7 @@ jobs:
           REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           COPILOT_GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           PROMPTS_DIR: .dev-lead/prompts/dev-lead
         run: bash .dev-lead/scripts/dev-lead-fix-ci.sh
@@ -176,6 +179,7 @@ jobs:
           TRIGGERING_REVIEWER: ${{ env.INTENT_ACTOR }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           COPILOT_GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           PROMPTS_DIR: .dev-lead/prompts/dev-lead
         run: bash .dev-lead/scripts/dev-lead-fix-reviews.sh
@@ -190,6 +194,7 @@ jobs:
           REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           COPILOT_GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           PROMPTS_DIR: .dev-lead/prompts/dev-lead
         run: bash .dev-lead/scripts/dev-lead-fix-reviews.sh
@@ -204,6 +209,7 @@ jobs:
           REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           COPILOT_GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           PROMPTS_DIR: .dev-lead/prompts/dev-lead
         run: bash .dev-lead/scripts/dev-lead-fix-reviews.sh
@@ -218,6 +224,7 @@ jobs:
           REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           COPILOT_GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           PROMPTS_DIR: .dev-lead/prompts/dev-lead
         run: bash .dev-lead/scripts/dev-lead-fix-reviews.sh
@@ -231,6 +238,7 @@ jobs:
           REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           COPILOT_GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           PROMPTS_DIR: .dev-lead/prompts/dev-lead
         run: bash .dev-lead/scripts/dev-lead-fix-issue.sh
@@ -244,6 +252,7 @@ jobs:
           REVIEW_ENGINE: ${{ env.DEV_LEAD_ENGINE }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           COPILOT_GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           PROMPTS_DIR: .dev-lead/prompts/dev-lead
         run: bash .dev-lead/scripts/dev-lead-fix-reviews.sh


### PR DESCRIPTION
## Summary

The gemini CLI looks for `GEMINI_API_KEY` (not `GOOGLE_API_KEY`). The dev-lead workflow exposes the org secret as `GOOGLE_API_KEY` only, so when Claude is rate-limited and the engine falls back to gemini, it errors immediately.

## Observed failure

During the 2026-05-23 compliance blitz, Claude's monthly cap was exhausted (resets May 26). 33 cycled compliance issues had their dev-lead runs fail with:

```
You've hit your limit · resets May 26, 4pm (UTC)
##[warning]claude rate-limited, trying next engine
Please set an Auth method in your /home/runner/.gemini/settings.json or specify one of the following environment variables before running: GEMINI_API_KEY, GOOGLE_GENAI_USE_VERTEXAI, GOOGLE_GENAI_USE_GCA
##[error]Engine failed to implement issue #N
```

No PRs created → compliance backlog stayed stuck.

## Fix

Add `GEMINI_API_KEY: ${{ secrets.GOOGLE_API_KEY }}` next to every existing `GOOGLE_API_KEY` env line in `dev-lead-reusable.yml`. Same secret value, two env names — covers both naming conventions without needing a new secret.

## Test plan

- [ ] Merge.
- [ ] Trigger any dev-lead run during Claude rate-limit window (or set DEV_LEAD_ENGINE=gemini explicitly).
- [ ] Confirm gemini CLI accepts the key and proceeds past the auth step.
- [ ] Confirm a dev-lead-fix-issue run can produce a PR via gemini.

🤖 Generated with [Claude Code](https://claude.com/claude-code)