### PR TITLE
fix: pin GitHub Actions to commit SHAs in .github-private workflows

### DIFF
--- a/.github/workflows/daily-pr-review-health.yml
+++ b/.github/workflows/daily-pr-review-health.yml
@@ -42,7 +42,7 @@ jobs:
           node-version: '20'
 
       - name: Cache claude-code CLI
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f0  # v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ~/.npm-global
           key: claude-code-${{ env.CLAUDE_CODE_VERSION }}-${{ runner.os }}

--- a/.github/workflows/daily-pr-review-health.yml
+++ b/.github/workflows/daily-pr-review-health.yml
@@ -42,7 +42,7 @@ jobs:
           node-version: '20'
 
       - name: Cache claude-code CLI
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f0  # v5.0.5
         with:
           path: ~/.npm-global
           key: claude-code-${{ env.CLAUDE_CODE_VERSION }}-${{ runner.os }}

--- a/.github/workflows/repair-pr-approvals.yml
+++ b/.github/workflows/repair-pr-approvals.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Repair PR approvals
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Run copilot_chat tests
         run: bash tests/test_copilot_chat.sh


### PR DESCRIPTION
This PR addresses compliance issue #360 by pinning all GitHub Actions to specific commit SHAs instead of version tags.

**Changes:**
- repair-pr-approvals.yml: actions/checkout@v6.0.2 → SHA
- test.yml: actions/checkout@v6.0.2 → SHA  
- daily-pr-review-health.yml: actions/cache@v5.0.5 → SHA

**Closes:** #360

All actions are now pinned to specific commits per ci-standards.md action-pinning-policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI reliability by pinning third-party workflow actions to fixed revisions across daily PR review, repair approvals, and test workflows to reduce unexpected breakages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/petry-projects/.github-private/pull/403?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->