### PR TITLE
fix: simplify PR_URL_OVERRIDE logic to resolve review enumeration bug

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -141,8 +141,7 @@ jobs:
         ${{
           inputs.pr_url
           || github.event.client_payload.pr_url
-          || (github.event_name == 'pull_request_review' && github.event.pull_request.html_url)
-          || (github.event_name == 'pull_request' && github.event.pull_request.html_url)
+          || github.event.pull_request.html_url
           || ''
         }}
       # JSON array of PRs associated with a check_suite event. Empty for all


### PR DESCRIPTION
## Problem

PR #403 and potentially other PRs were not being reviewed despite the pr-review.yml workflow running successfully. Root cause analysis identified that `PR_URL_OVERRIDE` was evaluating to an empty string for pull_request synchronize events.

## Root Cause

The `PR_URL_OVERRIDE` environment variable used a complex YAML boolean expression with nested `&&` operators within `||` chains:

```yaml
PR_URL_OVERRIDE: >-
  ${{
    inputs.pr_url
    || github.event.client_payload.pr_url
    || (github.event_name == 'pull_request_review' && github.event.pull_request.html_url)
    || (github.event_name == 'pull_request' && github.event.pull_request.html_url)
    || ''
  }}
```

This expression had operator precedence issues or evaluation logic that caused `github.event.pull_request.html_url` to be treated as falsy/null, resulting in PR_URL_OVERRIDE becoming an empty string. When empty, the enumerate step would fall back to `list-prs.sh`, potentially missing the PR or encountering transient issues.

## Solution

Simplify the expression to directly access `github.event.pull_request.html_url` without event_name checks, matching the pattern already working successfully in the concurrency group:

```yaml
PR_URL_OVERRIDE: >-
  ${{
    inputs.pr_url
    || github.event.client_payload.pr_url
    || github.event.pull_request.html_url
    || ''
  }}
```

This works because:
- `pull_request` events (ready_for_review, reopened, synchronize) have `github.event.pull_request.html_url`
- `pull_request_review` events (submitted, dismissed) have `github.event.pull_request.html_url`
- `check_suite` events are handled separately via CHECK_SUITE_PRS
- `workflow_dispatch` and `repository_dispatch` are handled via inputs

## Testing

After this PR is merged, PR #403 or similar ready PRs should be properly reviewed on the next synchronize event. The enumerate step will now correctly populate PR_URL_OVERRIDE and use direct single-PR mode rather than falling back to list-prs.sh enumeration.