### PR TITLE
chore(dev-lead): retire the legacy `claude` issue-trigger label

### DIFF
--- a/docs/dev-lead/spec.md
+++ b/docs/dev-lead/spec.md
@@ -106,7 +106,7 @@ Every GitHub webhook event that reaches `dev-lead.yml` is classified into exactl
 | `issue_comment` created on PR | Trusted bot (`sonarqubecloud[bot]`, `coderabbitai[bot]`) | `fix-bot-comment` | `dev-lead-fix-reviews.sh` |
 | `issue_comment` created on PR | Human OWNER/MEMBER/COLLABORATOR + trigger phrase | `human` | `dev-lead-fix-reviews.sh` |
 | `issue_comment` created on PR | `<!-- auto-rebase-conflict:` marker | `rebase` | `dev-lead-fix-reviews.sh` |
-| `issues` labeled `dev-lead` or `claude` | Any | `issue` | `dev-lead-fix-issue.sh` |
+| `issues` labeled `dev-lead` | Any | `issue` | `dev-lead-fix-issue.sh` |
 | `check_run` completed, failure | Not a `dev-lead /` check | _relay only_ | `ci-relay` job |
 | `repository_dispatch` `dev-lead-ci-failure` | Dispatched by `ci-relay` | `fix-ci` | `dev-lead-fix-ci.sh` |
 | All others | — | `skip` | (no-op) |
@@ -123,7 +123,7 @@ Every GitHub webhook event that reaches `dev-lead.yml` is classified into exactl
 
 **`human-pr`** — A new PR was opened/synchronized or a human submitted a review. The agent reads the PR and all open review threads, addresses anything it can, and posts a status comment.
 
-**`issue`** — An issue was labeled `dev-lead` or `claude`. The agent implements the issue, opens a PR, self-reviews, and tags CODEOWNERS when CI is green.
+**`issue`** — An issue was labeled `dev-lead`. The agent implements the issue, opens a PR, self-reviews, and tags CODEOWNERS when CI is green.
 
 **`rebase`** — An auto-rebase-conflict sentinel comment was posted on a PR. The agent performs an agentic rebase, resolving conflicts per the conflict-resolution strategy, and pushes.
 

--- a/scripts/dev-lead-intent.sh
+++ b/scripts/dev-lead-intent.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 #   fix-bot-comment — Bot issue comment to address
 #   on-mention       — Human-directed @mention task
 #   review-changes   — Human review changes-requested
-#   issue           — Issue labeled dev-lead/claude
+#   issue           — Issue labeled dev-lead
 #   rebase          — Rebase conflict sentinel
 #   enable-auto-merge — Bot approval: enable auto-merge if PR is APPROVED
 #   ci-relay        — check_run relay (handled by ci-relay job, not this script)
@@ -322,7 +322,7 @@ case "$EVENT_NAME" in
     label_name=$(jq -r '.label.name // empty' "$EVENT_PATH" 2>/dev/null || true)
     issue_number=$(jq -r '.issue.number // empty' "$EVENT_PATH" 2>/dev/null || true)
     case "$label_name" in
-      dev-lead|claude)
+      dev-lead)
         context=$(printf '{"issue_number":%s}' "${issue_number:-0}")
         emit_intent "issue" "issue-labeled-${label_name}" "$context"
         ;;

--- a/tests/dev-lead/unit/test_intent_issue.bats
+++ b/tests/dev-lead/unit/test_intent_issue.bats
@@ -51,14 +51,16 @@ _get_context_field() {
   [ "$(_get_env INTENT_TYPE)" = "issue" ]
 }
 
-@test "issue: issues labeled claude → issue (backward compat)" {
+@test "issue: issues labeled claude → skip (legacy label retired)" {
+  # The `claude` label was retired in favour of `dev-lead`; it no longer
+  # triggers the issue intent.
   export GITHUB_EVENT_NAME="issues"
   export GITHUB_EVENT_PATH="$FIXTURES_DIR/issues_labeled_claude.json"
 
   run bash "$INTENT_SCRIPT"
 
   [ "$status" -eq 0 ]
-  [ "$(_get_env INTENT_TYPE)" = "issue" ]
+  [ "$(_get_env INTENT_TYPE)" = "skip" ]
 }
 
 @test "issue: issues labeled bug → skip" {


### PR DESCRIPTION
## Summary

dev-lead historically accepted **both** `dev-lead` and `claude` labels on `issues:labeled`, with `claude` kept as backward-compat from the retired `claude.yml` workflow (deprecated 2026-05). We're removing the `claude` label org-wide, so the classifier now routes **only** the `dev-lead` label to the `issue` intent. A `claude`-labeled issue is skipped like any other non-trigger label.

## Changes
- `scripts/dev-lead-intent.sh` — `dev-lead|claude)` → `dev-lead)` (+ comment).
- `tests/dev-lead/unit/test_intent_issue.bats` — the backward-compat test now asserts `claude` → **skip**.
- `docs/dev-lead/spec.md` — issue intent triggers on `dev-lead` only.

## Scope notes
- The `@claude` trigger **phrase** (`TRIGGER_PHRASES`) is intentionally **unaffected** — this is about the issue **label**, not @mentions.
- `docs/dev-lead/implementation-plan.md` is a point-in-time planning doc and is left as a historical record.

## Companion / ordering
Pairs with **petry-projects/.github#400**, which migrates the compliance audit to create/cycle the `dev-lead` label and ships the one-time runtime migration (re-label existing open `claude` issues → `dev-lead`, then delete the `claude` label). Recommended order: run the runtime migration (so open issues gain `dev-lead`) **before/with** merging this, so no open issue is left only-`claude` during the cutover.

## Verification
- `shellcheck -x scripts/dev-lead-intent.sh` clean
- Full dev-lead unit suite: **223/223 pass, 0 failures** (incl. the updated `claude → skip` test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)