### PR TITLE
fix(dev-lead): trust chatgpt-codex-connector[bot] in the reusable workflow

### DIFF
--- a/.github/workflows/dev-lead-reusable.yml
+++ b/.github/workflows/dev-lead-reusable.yml
@@ -43,7 +43,7 @@ jobs:
       checks: read
     env:
       BOT_USER: ${{ vars.BOT_USER || 'donpetry-bot' }}
-      TRUSTED_BOTS: ${{ vars.TRUSTED_BOTS || 'copilot-pull-request-reviewer[bot],gemini-code-assist[bot],sonarqubecloud[bot],coderabbitai[bot]' }}
+      TRUSTED_BOTS: ${{ vars.TRUSTED_BOTS || 'copilot-pull-request-reviewer[bot],gemini-code-assist[bot],sonarqubecloud[bot],coderabbitai[bot],chatgpt-codex-connector[bot]' }}
       TRIGGER_PHRASES: ${{ vars.TRIGGER_PHRASES || '@dev-lead' }}
       DEV_LEAD_ENGINE: ${{ vars.DEV_LEAD_ENGINE || 'claude' }}
       DEV_LEAD_DRY_RUN: ${{ vars.DEV_LEAD_DRY_RUN || 'false' }}

--- a/scripts/dev-lead-intent.sh
+++ b/scripts/dev-lead-intent.sh
@@ -103,7 +103,7 @@ is_fork_pr() {
 EVENT_NAME="${GITHUB_EVENT_NAME:-}"
 EVENT_PATH="${GITHUB_EVENT_PATH:-}"
 BOT_USER="${BOT_USER:-donpetry-bot}"
-TRUSTED_BOTS="${TRUSTED_BOTS:-copilot-pull-request-reviewer[bot],gemini-code-assist[bot],sonarqubecloud[bot],coderabbitai[bot]}"
+TRUSTED_BOTS="${TRUSTED_BOTS:-copilot-pull-request-reviewer[bot],gemini-code-assist[bot],sonarqubecloud[bot],coderabbitai[bot],chatgpt-codex-connector[bot]}"
 TRIGGER_PHRASES="${TRIGGER_PHRASES:-@dev-lead}"
 
 if [ -z "$EVENT_NAME" ]; then


### PR DESCRIPTION
## Root cause

dev-lead silently ignores **all** `chatgpt-codex-connector[bot]` reviews **fleet-wide**.

The dev-lead **reusable** workflow (what every repo actually runs via its stub) had a `TRUSTED_BOTS` default that omitted codex, while the standalone `dev-lead.yml` default **and the unit tests** include it:

| Location | codex in default? |
|---|---|
| `dev-lead.yml:37` (standalone) | ✅ |
| `dev-lead-reusable.yml:46` ← **runs fleet-wide** | ❌ |
| `scripts/dev-lead-intent.sh:106` | ❌ |
| `tests/dev-lead/unit/test_intent_reviews.bats` (`codex COMMENTED → fix-reviews`) | ✅ expects it |

`vars.TRUSTED_BOTS` is unset, so the reusable falls back to its default (no codex). `is_trusted_bot` does an exact full-line match (`grep -qxF`), so codex never matches → `intent=skip reason=untrusted-reviewer`.

### Evidence
On `petry-projects/.github#400`, codex's review (`chatgpt-codex-connector[bot]`, type Bot) triggered two dev-lead runs that both skipped:
- run `27066366290` (`pull_request_review`): `intent=skip reason=untrusted-reviewer`
- run `27066366309` (`pull_request_review_comment`): `intent=skip reason=no-trigger-or-untrusted`

codex's P2 comments were only ever fixed because a human (OWNER) re-issued them via `@dev-lead` (on-mention is trusted). Autonomously, dev-lead never acted on codex anywhere.

## Fix
Add `chatgpt-codex-connector[bot]` to the `TRUSTED_BOTS` default in `dev-lead-reusable.yml` and `dev-lead-intent.sh`, matching the standalone workflow and the existing tests.

## Verification
- shellcheck clean; actionlint clean on my change (pre-existing SC2129 at line 97 is CI-ignored)
- Full dev-lead unit suite: **223/223 pass**, including the codex `fix-reviews` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)