### PR TITLE
fix(dev-lead): per-issue/per-PR concurrency lanes so issue pickups aren't cancelled

### DIFF
--- a/.github/workflows/dev-lead-reusable.yml
+++ b/.github/workflows/dev-lead-reusable.yml
@@ -23,6 +23,36 @@ on:
 
 permissions: {}
 
+# ── concurrency ───────────────────────────────────────────────────────────────
+# Centralised here (single source of truth) so caller stubs no longer carry —
+# and can no longer drift into — their own concurrency group. Separate per-issue
+# and per-PR lanes ensure issue pickups are NEVER cancelled by unrelated PR
+# follow-up traffic (reviews, comments, ci-relay) — the root cause of issue
+# pickups being cancelled before they could open a PR. See petry-projects/.github#402.
+#
+# Routing (first match wins):
+#   check_run                        -> dev-lead-ci-relay-<sha>  (per-SHA relay lane)
+#   pull_request / *_review[_comment]-> dev-lead-pr-<n>          (PR lane)
+#   issue_comment on a PR            -> dev-lead-pr-<n>           (issue.pull_request set;
+#                                                                 avoids issue#/PR# collision)
+#   issues / issue_comment on issue  -> dev-lead-issue-<n>       (issue lane)
+#   repository_dispatch (ci-failure) -> dev-lead-pr-<n>          (client_payload.pr_number)
+#   anything else                    -> dev-lead-run-<run_id>    (unique; never cancelled)
+#
+# cancel-in-progress is false: a newer same-lane event queues behind the active
+# run rather than killing it, so an in-flight pickup always finishes.
+concurrency:
+  group: >-
+    ${{
+      (github.event_name == 'check_run' && format('dev-lead-ci-relay-{0}', github.event.check_run.head_sha))
+      || (github.event.pull_request.number && format('dev-lead-pr-{0}', github.event.pull_request.number))
+      || (github.event.issue.pull_request && format('dev-lead-pr-{0}', github.event.issue.number))
+      || (github.event.issue.number && format('dev-lead-issue-{0}', github.event.issue.number))
+      || (github.event.client_payload.pr_number && format('dev-lead-pr-{0}', github.event.client_payload.pr_number))
+      || format('dev-lead-run-{0}', github.run_id)
+    }}
+  cancel-in-progress: false
+
 jobs:
   # ── dispatch ────────────────────────────────────────────────────────────────
   # Handles all events except check_run (which is routed by the caller).

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -24,12 +24,18 @@ permissions:
   statuses: read
 
 concurrency:
-  # One active run per repo; ci-relay (check_run) keeps an ephemeral per-SHA slot
-  # so it can fire immediately without blocking or being blocked by the dispatch queue.
+  # Per-issue and per-PR lanes so issue pickups are never cancelled by unrelated
+  # PR follow-up traffic. This repo's dev-lead.yml is inline (not a reusable
+  # caller), so it carries the same routing as dev-lead-reusable.yml. See
+  # petry-projects/.github#402.
   group: >-
     ${{
-      github.event_name == 'check_run' && format('dev-lead-ci-relay-{0}', github.event.check_run.head_sha) ||
-      'dev-lead'
+      (github.event_name == 'check_run' && format('dev-lead-ci-relay-{0}', github.event.check_run.head_sha))
+      || (github.event.pull_request.number && format('dev-lead-pr-{0}', github.event.pull_request.number))
+      || (github.event.issue.pull_request && format('dev-lead-pr-{0}', github.event.issue.number))
+      || (github.event.issue.number && format('dev-lead-issue-{0}', github.event.issue.number))
+      || (github.event.client_payload.pr_number && format('dev-lead-pr-{0}', github.event.client_payload.pr_number))
+      || format('dev-lead-run-{0}', github.run_id)
     }}
   cancel-in-progress: false
 


### PR DESCRIPTION
## Problem

dev-lead issue-pickup runs are cancelled before they can open a PR. The concurrency group funnels **every** event (issue labels, PR comments, reviews, ci-relay) through one repo-wide `'dev-lead'` slot, so PR follow-up traffic supersedes queued issue pickups.

Evidence: **ContentTwin 7/7** and **TalkTerm 13/13** `issues`-event runs were `cancelled`; org-wide **111 labeled issues have no linked PR**. Full analysis in petry-projects/.github#402.

## Fix

Add intent-aware **top-level concurrency** to `dev-lead-reusable.yml` (the single source of truth all caller stubs delegate to), and apply the same routing to this repo's **inline** `dev-lead.yml`:

| Event | Lane |
|---|---|
| `check_run` | `dev-lead-ci-relay-<sha>` |
| `pull_request` / reviews / review comments | `dev-lead-pr-<n>` |
| `issue_comment` on a PR (`issue.pull_request` set) | `dev-lead-pr-<n>` |
| `issues` / `issue_comment` on an issue | `dev-lead-issue-<n>` |
| `repository_dispatch` (ci-failure) | `dev-lead-pr-<n>` (`client_payload.pr_number`) |
| anything else | `dev-lead-run-<run_id>` (unique, never cancelled) |

Issue pickups now get their own lane and can never be cancelled by unrelated PR traffic. PR comments route to the PR lane (via `issue.pull_request`) to avoid the issue#/PR# collision that bit TalkTerm. `cancel-in-progress: false` so a same-lane event queues rather than killing an in-flight pickup.

## Follow-ups (separate PRs)

- Align the 6 caller-stub repos to drop their own (drifted) concurrency and re-pin to this reusable.
- Backfill the 111 already-labeled-but-cancelled pickups (won't self-heal; no new `labeled` event fires).

Refs petry-projects/.github#402

🤖 Generated with [Claude Code](https://claude.com/claude-code)