### PR TITLE
test(dev-lead): assert per-issue/per-PR concurrency lanes (align with #450, unblocked by #449)

### DIFF
--- a/.github/workflows/test-dev-lead.yml
+++ b/.github/workflows/test-dev-lead.yml
@@ -17,6 +17,11 @@ on:
       - 'scripts/lib/**'
       - 'tests/dev-lead/**'
       - 'prompts/dev-lead/**'
+      # Guard the concurrency-config test on workflow changes too — otherwise a
+      # dev-lead.yml edit can land on main without ever running this suite
+      # (how the per-repo->per-lane mismatch stayed hidden after #450).
+      - '.github/workflows/dev-lead*.yml'
+      - '.github/workflows/test-dev-lead.yml'
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/test-dev-lead.yml
+++ b/.github/workflows/test-dev-lead.yml
@@ -73,5 +73,5 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - name: Validate concurrency config (per-repo serialization)
+      - name: Validate concurrency config (per-issue/per-PR lanes)
         run: bash tests/dev-lead/integration/test_concurrency_config.sh

--- a/tests/dev-lead/integration/test_concurrency_config.sh
+++ b/tests/dev-lead/integration/test_concurrency_config.sh
@@ -37,6 +37,22 @@ check_present() {
   fi
 }
 
+check_order() {
+  local file="$1" first="$2" second="$3" label="$4"
+  local line_first line_second
+  line_first=$(grep -nF "$first"  "$file" | head -1 | cut -d: -f1)
+  line_second=$(grep -nF "$second" "$file" | head -1 | cut -d: -f1)
+  if [ -z "$line_first" ] || [ -z "$line_second" ]; then
+    echo "FAIL [$label]: could not find both patterns in $file"
+    FAIL=$((FAIL + 1))
+  elif [ "$line_first" -lt "$line_second" ]; then
+    echo "PASS [$label]: correct ordering in $file"
+  else
+    echo "FAIL [$label]: '$first' must appear before '$second' in $file (first-match-wins routing)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
 # Both the inline workflow and the reusable (source of truth for all consumer
 # stubs) must carry the per-lane routing.
 for WORKFLOW in \
@@ -58,12 +74,35 @@ for WORKFLOW in \
   # ci-relay keeps its own ephemeral per-SHA slot so it fires immediately.
   check_present "$WORKFLOW" "format('dev-lead-ci-relay-" "ci-relay per-SHA lane"
 
+  # Assert the actual predicate-to-lane bindings, not just token presence.
+  # issue_comment on a PR has issue.pull_request set; that predicate must route
+  # to the PR lane so PR follow-up traffic shares the PR slot with other PR events.
+  check_present "$WORKFLOW" \
+    "github.event.issue.pull_request && format('dev-lead-pr-" \
+    "issue_comment-on-PR predicate routes to PR lane"
+  # repository_dispatch (ci-failure relay) carries client_payload.pr_number.
+  check_present "$WORKFLOW" \
+    "github.event.client_payload.pr_number && format('dev-lead-pr-" \
+    "repository_dispatch routes to PR lane via client_payload.pr_number"
+  # issue.pull_request must appear BEFORE issue.number in the || chain.
+  # If reordered, an issue_comment on a PR would fall through to the issue lane
+  # and share a slot with issue pickups, allowing cancellation.
+  check_order "$WORKFLOW" \
+    "github.event.issue.pull_request && format('dev-lead-pr-" \
+    "github.event.issue.number && format('dev-lead-issue-" \
+    "issue_comment-on-PR predicate before generic issue predicate"
+
   # Must NOT collapse back into a single repo-wide group (the #278 regression).
   # Guard all common bare-value spellings so a regression can't slip through
   # on quote-style changes.
   check_absent "$WORKFLOW" "group: dev-lead"    "no bare unquoted group: dev-lead"
   check_absent "$WORKFLOW" "group: 'dev-lead'"  "no bare single-quoted group: dev-lead"
   check_absent "$WORKFLOW" 'group: "dev-lead"'  "no bare double-quoted group: dev-lead"
+  # Also reject a repo-wide fallback hidden inside the ${{ ... }} expression.
+  # The group: >- form puts the value on the next lines starting with ||, so
+  # "group: dev-lead" patterns above would miss a regression like || 'dev-lead'.
+  check_absent "$WORKFLOW" "|| 'dev-lead'"      "no repo-wide || 'dev-lead' fallback in expression"
+  check_absent "$WORKFLOW" '|| "dev-lead"'      'no repo-wide || "dev-lead" fallback in expression'
 
   # cancel-in-progress must be false so a queued same-lane run waits for the active
   # run to finish instead of cancelling it (in-flight pickups always complete).

--- a/tests/dev-lead/integration/test_concurrency_config.sh
+++ b/tests/dev-lead/integration/test_concurrency_config.sh
@@ -84,6 +84,13 @@ for WORKFLOW in \
   check_present "$WORKFLOW" \
     "github.event.client_payload.pr_number && format('dev-lead-pr-" \
     "repository_dispatch routes to PR lane via client_payload.pr_number"
+  # client_payload.pr_number predicate must appear BEFORE the final run-id fallback.
+  # If reordered, the fallback is always truthy and every repository_dispatch
+  # (ci-failure relay) gets a unique run lane instead of sharing the PR lane.
+  check_order "$WORKFLOW" \
+    "github.event.client_payload.pr_number && format('dev-lead-pr-" \
+    "format('dev-lead-run-{0}', github.run_id)" \
+    "repository_dispatch predicate before run-id fallback"
   # issue.pull_request must appear BEFORE issue.number in the || chain.
   # If reordered, an issue_comment on a PR would fall through to the issue lane
   # and share a slot with issue pickups, allowing cancellation.

--- a/tests/dev-lead/integration/test_concurrency_config.sh
+++ b/tests/dev-lead/integration/test_concurrency_config.sh
@@ -43,17 +43,27 @@ for WORKFLOW in \
   ".github/workflows/dev-lead.yml" \
   ".github/workflows/dev-lead-reusable.yml"; do
   echo "── $WORKFLOW ──"
+  if [ ! -f "$WORKFLOW" ]; then
+    echo "FAIL: $WORKFLOW does not exist. Please run this script from the repository root."
+    FAIL=$((FAIL + 1))
+    continue
+  fi
 
   # Per-issue and per-PR lanes must be present so a labeled-issue pickup is never
   # cancelled by unrelated PR follow-up traffic.
-  check_present "$WORKFLOW" "dev-lead-pr-"    "per-PR lane"
-  check_present "$WORKFLOW" "dev-lead-issue-" "per-issue lane"
+  # Match format('dev-lead-…') to target the concurrency expression, not comments.
+  check_present "$WORKFLOW" "format('dev-lead-pr-"    "per-PR lane"
+  check_present "$WORKFLOW" "format('dev-lead-issue-" "per-issue lane"
 
   # ci-relay keeps its own ephemeral per-SHA slot so it fires immediately.
-  check_present "$WORKFLOW" "dev-lead-ci-relay-" "ci-relay per-SHA lane"
+  check_present "$WORKFLOW" "format('dev-lead-ci-relay-" "ci-relay per-SHA lane"
 
   # Must NOT collapse back into a single repo-wide group (the #278 regression).
-  check_absent "$WORKFLOW" "'dev-lead'" "no repo-wide 'dev-lead' group"
+  # Guard all common bare-value spellings so a regression can't slip through
+  # on quote-style changes.
+  check_absent "$WORKFLOW" "group: dev-lead"    "no bare unquoted group: dev-lead"
+  check_absent "$WORKFLOW" "group: 'dev-lead'"  "no bare single-quoted group: dev-lead"
+  check_absent "$WORKFLOW" 'group: "dev-lead"'  "no bare double-quoted group: dev-lead"
 
   # cancel-in-progress must be false so a queued same-lane run waits for the active
   # run to finish instead of cancelling it (in-flight pickups always complete).

--- a/tests/dev-lead/integration/test_concurrency_config.sh
+++ b/tests/dev-lead/integration/test_concurrency_config.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
-# Validates that dev-lead workflow files use per-repo serialized concurrency
-# (a single 'dev-lead' group) rather than per-PR or per-issue groups.
+# Validates that dev-lead workflow files use per-issue / per-PR concurrency lanes
+# (dev-lead-issue-<n>, dev-lead-pr-<n>) plus a per-SHA ci-relay lane, rather than a
+# single repo-wide 'dev-lead' group.
+#
+# History: #278 collapsed everything into one per-repo 'dev-lead' group so at most
+# one dispatch ran at a time — needed only because the agent checked out PR branches
+# IN PLACE, so concurrent runs corrupted each other's working tree. That serialization
+# then starved issue pickups: PR follow-up traffic (reviews/comments/ci-relay) held the
+# single slot and queued issue-labeled runs were superseded and cancelled before they
+# could open a PR (petry-projects/.github#402).
+#
+# #449 (#448) removed the root hazard by checking out each PR branch in an isolated
+# git worktree, so different issues/PRs can now run in parallel safely. #450 restored
+# per-issue / per-PR lanes. This test guards that design against regression.
 set -euo pipefail
 
 FAIL=0
@@ -25,20 +37,28 @@ check_present() {
   fi
 }
 
-WORKFLOW=".github/workflows/dev-lead.yml"
+# Both the inline workflow and the reusable (source of truth for all consumer
+# stubs) must carry the per-lane routing.
+for WORKFLOW in \
+  ".github/workflows/dev-lead.yml" \
+  ".github/workflows/dev-lead-reusable.yml"; do
+  echo "── $WORKFLOW ──"
 
-# Must not have per-PR or per-issue group keys (those allowed parallel runs)
-check_absent "$WORKFLOW" "dev-lead-pr-"    "no per-PR group"
-check_absent "$WORKFLOW" "dev-lead-issue-" "no per-issue group"
+  # Per-issue and per-PR lanes must be present so a labeled-issue pickup is never
+  # cancelled by unrelated PR follow-up traffic.
+  check_present "$WORKFLOW" "dev-lead-pr-"    "per-PR lane"
+  check_present "$WORKFLOW" "dev-lead-issue-" "per-issue lane"
 
-# ci-relay must still get its own ephemeral per-SHA slot
-check_present "$WORKFLOW" "dev-lead-ci-relay-" "ci-relay per-SHA group preserved"
+  # ci-relay keeps its own ephemeral per-SHA slot so it fires immediately.
+  check_present "$WORKFLOW" "dev-lead-ci-relay-" "ci-relay per-SHA lane"
 
-# The fallback group must be the bare repo-scoped key
-check_present "$WORKFLOW" "'dev-lead'" "per-repo 'dev-lead' fallback group"
+  # Must NOT collapse back into a single repo-wide group (the #278 regression).
+  check_absent "$WORKFLOW" "'dev-lead'" "no repo-wide 'dev-lead' group"
 
-# cancel-in-progress must be false so queued runs aren't dropped
-check_present "$WORKFLOW" "cancel-in-progress: false" "cancel-in-progress is false"
+  # cancel-in-progress must be false so a queued same-lane run waits for the active
+  # run to finish instead of cancelling it (in-flight pickups always complete).
+  check_present "$WORKFLOW" "cancel-in-progress: false" "cancel-in-progress is false"
+done
 
 echo ""
 if [ "$FAIL" -eq 0 ]; then


### PR DESCRIPTION
## Why

#450 restored per-issue / per-PR concurrency lanes — the fix for issue pickups being cancelled by PR follow-up traffic (petry-projects/.github#402). But `tests/dev-lead/integration/test_concurrency_config.sh` still asserts the **old** single repo-wide `'dev-lead'` group from #278, so it **fails 3 checks** against the current `dev-lead.yml`:

```
FAIL [no per-PR group]: 'dev-lead-pr-' found ...
FAIL [no per-issue group]: 'dev-lead-issue-' found ...
FAIL [per-repo 'dev-lead' fallback group]: ''dev-lead'' not found ...
```

It didn't go red when #450 merged only because the `push:` → `main` path filter in `test-dev-lead.yml` excludes `.github/workflows/dev-lead*.yml`. It **would fail on the next dev-lead PR** (any PR touching a `dev-lead*` path).

## The #449 connection

#278's per-repo serialization existed solely to stop concurrent **in-place** PR checkouts from corrupting the agent's working tree. **#449 (#448) removed that hazard** by checking out each PR branch in an isolated git worktree — so parallel per-lane runs are now safe, and the per-lane design is the correct end state.

## Change

- Invert the assertions: require `dev-lead-pr-` / `dev-lead-issue-` / `dev-lead-ci-relay-` lanes and `cancel-in-progress: false`; forbid a repo-wide `'dev-lead'` group (guards against a #278-style regression).
- Extend coverage to `dev-lead-reusable.yml` (the source of truth all consumer stubs delegate to), not just the inline workflow.
- Update the CI step label to "per-issue/per-PR lanes".

Verified: the updated test **passes** against current `main` (10/10 across both workflows); `shellcheck -S warning` clean.

Refs petry-projects/.github#402 · follows #450, #449.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced concurrency-lane validation across multiple workflow configurations to ensure distinct per-PR and per-issue lanes.
  * Strengthened negative checks to prevent unintended collapse into a single repo-wide concurrency group.
  * Continued enforcement that in-progress runs are not auto-cancelled.

* **Chores**
  * Renamed a workflow step label for clearer intent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->