### PR TITLE
fix(dev-lead): stop false "rate-limited" claims; dedupe superseded check runs

### DIFF
--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -290,7 +290,7 @@ fetch_pr_context() {
       2>/dev/null \
       | jq -s '[.[].check_runs[]?]
                | group_by(.name)
-               | map(sort_by(.started_at // "", .id // 0) | last
+               | map(sort_by([.started_at // "", .id // 0]) | last
                      | {name:.name, status:.status, conclusion:.conclusion, details_url:.details_url})' \
       2>/dev/null); then
       echo "::error::fetch_pr_context: failed to fetch CI check-runs for ${HEAD_SHA} — cannot assess PR state" >&2

--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -278,21 +278,36 @@ fetch_pr_context() {
   # (e.g., review-changes in dry-run where the PR API call is skipped).
   CI_STATUS_JSON="[]"
   if [ -n "${HEAD_SHA:-}" ]; then
-    # Dedupe check runs by (name, app.id), keeping the newest run (started_at, then id).
-    # Each triggering event creates a new check suite, so the API's default
-    # filter=latest does NOT collapse runs across suites: a concurrency-cancelled
-    # run sits forever next to its successful same-named replacement and would
-    # otherwise register as a permanent Tier-1 blocker (issue #461). Using app.id
-    # as a discriminator ensures that two independent checks with the same name
-    # from different GitHub Apps are not collapsed: each (name, app) pair is its
-    # own logical check. A run that is genuinely the latest of its (name, app)
-    # pair (e.g. a lone cancelled run) still counts as a blocker.
+    # Two-stage check-run dedup:
+    # Stage 1: group by (name, app.id, check_suite.id) and keep the highest-id
+    #   run per suite. check_suite discriminates distinct workflow runs, so two
+    #   workflows that happen to share a job name are kept as separate entries.
+    #   id is always present and monotonically increasing, so it reliably picks
+    #   the newest run even when started_at is absent (e.g. queued runs).
+    # Stage 2: drop cancelled/timed_out runs when a newer run (higher id, same
+    #   name+app) has a terminal non-cancelled conclusion. This collapses a
+    #   concurrency-cancelled run from an earlier suite once its replacement
+    #   succeeds, without hiding a genuinely failing check from a distinct
+    #   workflow. A lone cancelled/timed_out run (no newer replacement) still
+    #   counts as a Tier-1 blocker (issue #461).
     if ! CI_STATUS_JSON=$(gh api --paginate "repos/${REPO}/commits/${HEAD_SHA}/check-runs?per_page=100" \
       2>/dev/null \
       | jq -s '[.[].check_runs[]?]
-               | group_by([.name, (.app.id // null)])
-               | map(sort_by([.started_at // "", .id // 0]) | last
-                     | {name:.name, status:.status, conclusion:.conclusion, details_url:.details_url})' \
+               | group_by([.name, (.app.id // null), (.check_suite.id // null)])
+               | map(sort_by([.id // 0]) | last)
+               | . as $runs
+               | map(select(
+                   (.conclusion != "cancelled" and .conclusion != "timed_out")
+                   or (. as $r | ($runs | any(
+                         .name == $r.name
+                         and (.app.id // null) == ($r.app.id // null)
+                         and (.id // 0) > ($r.id // 0)
+                         and .conclusion != null
+                         and .conclusion != "cancelled"
+                         and .conclusion != "timed_out"
+                       )) | not)
+                 ))
+               | map({name:.name, status:.status, conclusion:.conclusion, details_url:.details_url})' \
       2>/dev/null); then
       echo "::error::fetch_pr_context: failed to fetch CI check-runs for ${HEAD_SHA} — cannot assess PR state" >&2
       return 1

--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -298,6 +298,20 @@ fetch_pr_context() {
     #   succeeds, without hiding a genuinely failing check from a distinct
     #   workflow. A lone cancelled/timed_out run (no newer replacement) still
     #   counts as a Tier-1 blocker (issue #461).
+    #
+    # Stage 2 deliberately matches on (name, app) ACROSS suites — wider than
+    # Stage 1's key. The asymmetry is load-bearing: a concurrency-cancelled
+    # run is superseded by a run from a *different* event, which always lives
+    # in a *different* check suite (the PR #453 incident shape), so requiring
+    # suite equality here would never drop anything and would reintroduce the
+    # endless 30-minute retry loop. The check-runs API exposes no workflow
+    # identity, so a cancelled check from a sibling workflow sharing a
+    # name+app with a newer success is also dropped — accepted trade-off:
+    # GitHub's own required-check gate keys on the latest same-named run
+    # (PR #453 merged with stale cancelled `review` runs still on its head
+    # SHA), so such a PR is not actually merge-blocked. Failures are exempt
+    # from Stage 2 (conservative: a real failure from a sibling workflow
+    # stays visible to the agent even when GitHub would let the merge pass).
     if ! CI_STATUS_JSON=$(gh api --paginate "repos/${REPO}/commits/${HEAD_SHA}/check-runs?per_page=100" \
       2>/dev/null \
       | jq -s '[.[].check_runs[]?]

--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -278,9 +278,20 @@ fetch_pr_context() {
   # (e.g., review-changes in dry-run where the PR API call is skipped).
   CI_STATUS_JSON="[]"
   if [ -n "${HEAD_SHA:-}" ]; then
+    # Dedupe check runs by name, keeping the newest run (started_at, then id).
+    # Each triggering event creates a new check suite, so the API's default
+    # filter=latest does NOT collapse runs across suites: a concurrency-cancelled
+    # run sits forever next to its successful same-named replacement and would
+    # otherwise register as a permanent Tier-1 blocker (issue #461). Branch
+    # protection keys required checks by name, so name-level dedup matches
+    # GitHub's own merge semantics; a run that is genuinely the latest of its
+    # name (e.g. a lone cancelled run) still counts.
     if ! CI_STATUS_JSON=$(gh api --paginate "repos/${REPO}/commits/${HEAD_SHA}/check-runs?per_page=100" \
       2>/dev/null \
-      | jq -s '[.[].check_runs[]? | {name:.name, status:.status, conclusion:.conclusion, details_url:.details_url}]' \
+      | jq -s '[.[].check_runs[]?]
+               | group_by(.name)
+               | map(sort_by(.started_at // "", .id // 0) | last
+                     | {name:.name, status:.status, conclusion:.conclusion, details_url:.details_url})' \
       2>/dev/null); then
       echo "::error::fetch_pr_context: failed to fetch CI check-runs for ${HEAD_SHA} — cannot assess PR state" >&2
       return 1
@@ -666,8 +677,26 @@ has_reviews_rate_limited_marker() {
 # For retryable intents (fix-reviews, review-changes, rebase), the cron will re-dispatch.
 # For non-retryable intents (on-mention, fix-bot-comment), asks the user to re-trigger
 # since USER_INSTRUCTION/COMMENT_BODY cannot be reconstructed at retry time.
+#
+# $2 (reason) selects the user-facing wording:
+#   rate-limit (default) — all AI engines genuinely rate-limited (engine exit 2)
+#   blocked              — engine ran fine but the PR still has hard blockers
+#                          (failing/cancelled checks or CHANGES_REQUESTED reviews);
+#                          schedules a 30-minute backoff retry (issue #461)
+# Both reasons post the same machine-readable `status=rate-limited` marker token —
+# dev-lead-retry.sh keys its re-dispatch scan on that string — only the visible
+# text differs, so users are no longer told "rate-limited" when the real cause
+# is PR blockers.
 post_reviews_rate_limited() {
   local intent="$1"
+  local reason="${2:-rate-limit}"
+
+  # The blocked path owns its backoff: a fixed 30-minute reset so the retry cron
+  # backs off instead of re-dispatching immediately. The rate-limit path's reset
+  # is parsed from engine output (parse_reset_time) before this function is called.
+  if [ "$reason" = "blocked" ]; then
+    printf '%s' "$(date -u -d '+30 minutes' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)" > /tmp/dev-lead-rate-limit-reset
+  fi
 
   # Expire any stale terminal markers (applied/no-changes/failed) for this SHA+intent
   # so the retry cron is not masked by a prior terminal that predates the current blocker.
@@ -709,32 +738,45 @@ post_reviews_rate_limited() {
     sha_detail=" sha=${HEAD_SHA}"
   fi
 
-  local marker="${REVIEWS_MARKER_PREFIX}${PR_NUMBER}${sha_detail} intent=${intent} status=rate-limited${reset_detail} -->"
+  # `reason=` is informational (visible-text selection + marker forensics); the
+  # retry cron and marker dedup patterns match on `status=rate-limited` and are
+  # unaffected by the extra field.
+  local marker="${REVIEWS_MARKER_PREFIX}${PR_NUMBER}${sha_detail} intent=${intent} status=rate-limited reason=${reason}${reset_detail} -->"
 
-  # Retry message depends on whether the intent can be re-dispatched automatically
-  local retry_msg
-  case "$intent" in
-    fix-reviews|review-changes|rebase)
-      retry_msg="The retry cron will re-attempt automatically."
-      ;;
-    on-mention|fix-bot-comment)
-      retry_msg="Please re-trigger manually (re-mention \`@dev-lead\`) when the rate limit clears — the original request cannot be reconstructed automatically."
-      ;;
-    *)
-      retry_msg="Manual re-trigger may be required."
-      ;;
-  esac
-  if [ -n "$reset_time" ]; then
-    retry_msg="${retry_msg} Rate limit resets at: \`${reset_time}\`"
+  # Retry message depends on the reason and on whether the intent can be
+  # re-dispatched automatically.
+  local heading retry_msg
+  if [ "$reason" = "blocked" ]; then
+    heading="## Dev-Lead — waiting on PR blockers (intent: ${intent})"
+    retry_msg="No changes were committed, but the PR still has blocking checks or reviews (failing or cancelled checks, or changes-requested reviews). The retry cron will re-attempt automatically."
+    if [ -n "$reset_time" ]; then
+      retry_msg="${retry_msg} Next attempt after: \`${reset_time}\`"
+    fi
+  else
+    heading="## Dev-Lead — rate-limited (intent: ${intent})"
+    case "$intent" in
+      fix-reviews|review-changes|rebase)
+        retry_msg="The retry cron will re-attempt automatically."
+        ;;
+      on-mention|fix-bot-comment)
+        retry_msg="Please re-trigger manually (re-mention \`@dev-lead\`) when the rate limit clears — the original request cannot be reconstructed automatically."
+        ;;
+      *)
+        retry_msg="Manual re-trigger may be required."
+        ;;
+    esac
+    if [ -n "$reset_time" ]; then
+      retry_msg="${retry_msg} Rate limit resets at: \`${reset_time}\`"
+    fi
   fi
 
   local marker_body="${marker}
-## Dev-Lead — rate-limited (intent: ${intent})
+${heading}
 **PR:** #${PR_NUMBER}
 ${retry_msg}"
 
   if [ "$DEV_LEAD_DRY_RUN" = "true" ]; then
-    echo "[dry-run] would post rate-limited marker for intent=${intent}"
+    echo "[dry-run] would post rate-limited marker for intent=${intent} reason=${reason}"
     echo "$marker_body"
   else
     # Post the new marker FIRST, then remove old marker(s) only after the replacement
@@ -758,11 +800,18 @@ ${retry_msg}"
         local actor_mention=""
         [ -n "${ACTOR:-}" ] && actor_mention="@${ACTOR} "
         local reset_display="${reset_time:-unknown}"
-        local ack_body="> [!NOTE]
+        local ack_body
+        if [ "$reason" = "blocked" ]; then
+          ack_body="> [!NOTE]
+> ${actor_mention}I reviewed this PR and no code changes were needed, but it still has blocking checks or reviews (failing or cancelled checks, or changes-requested reviews), so I cannot mark it done yet. I'll re-check automatically.
+> Next attempt after: \`${reset_display}\`"
+        else
+          ack_body="> [!NOTE]
 > ${actor_mention}I received your request but all AI engines are currently rate-limited. I'll retry automatically once the rate limit clears.
 > Rate limit resets at: \`${reset_display}\`"
+        fi
         if [ "$DEV_LEAD_DRY_RUN" = "true" ]; then
-          echo "[dry-run] would post user-visible rate-limit acknowledgment"
+          echo "[dry-run] would post user-visible ${reason} acknowledgment"
           echo "$ack_body"
         else
           gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$ack_body"
@@ -835,8 +884,7 @@ case "$INTENT_TYPE" in
         notify_coderabbit_resolve
         if has_hard_blockers; then
           echo "::warning::Tier-1 blockers still present (failing CI or CHANGES_REQUESTED reviews) — posting retry marker with backoff"
-          printf '%s' "$(date -u -d '+30 minutes' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)" > /tmp/dev-lead-rate-limit-reset
-          post_reviews_rate_limited "fix-reviews"
+          post_reviews_rate_limited "fix-reviews" "blocked"
         elif has_tier1_blockers; then
           echo "::notice::Unresolved bot review threads remain — not posting no-changes terminal to allow future retries"
         else
@@ -932,8 +980,7 @@ case "$INTENT_TYPE" in
         notify_coderabbit_resolve
         if has_hard_blockers; then
           echo "::warning::Tier-1 blockers still present (failing CI or CHANGES_REQUESTED reviews) — posting retry marker with backoff"
-          printf '%s' "$(date -u -d '+30 minutes' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)" > /tmp/dev-lead-rate-limit-reset
-          post_reviews_rate_limited "review-changes"
+          post_reviews_rate_limited "review-changes" "blocked"
         elif has_tier1_blockers; then
           echo "::notice::Unresolved bot review threads remain — not posting no-changes terminal to allow future retries"
         else

--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -278,18 +278,19 @@ fetch_pr_context() {
   # (e.g., review-changes in dry-run where the PR API call is skipped).
   CI_STATUS_JSON="[]"
   if [ -n "${HEAD_SHA:-}" ]; then
-    # Dedupe check runs by name, keeping the newest run (started_at, then id).
+    # Dedupe check runs by (name, app.id), keeping the newest run (started_at, then id).
     # Each triggering event creates a new check suite, so the API's default
     # filter=latest does NOT collapse runs across suites: a concurrency-cancelled
     # run sits forever next to its successful same-named replacement and would
-    # otherwise register as a permanent Tier-1 blocker (issue #461). Branch
-    # protection keys required checks by name, so name-level dedup matches
-    # GitHub's own merge semantics; a run that is genuinely the latest of its
-    # name (e.g. a lone cancelled run) still counts.
+    # otherwise register as a permanent Tier-1 blocker (issue #461). Using app.id
+    # as a discriminator ensures that two independent checks with the same name
+    # from different GitHub Apps are not collapsed: each (name, app) pair is its
+    # own logical check. A run that is genuinely the latest of its (name, app)
+    # pair (e.g. a lone cancelled run) still counts as a blocker.
     if ! CI_STATUS_JSON=$(gh api --paginate "repos/${REPO}/commits/${HEAD_SHA}/check-runs?per_page=100" \
       2>/dev/null \
       | jq -s '[.[].check_runs[]?]
-               | group_by(.name)
+               | group_by([.name, (.app.id // null)])
                | map(sort_by([.started_at // "", .id // 0]) | last
                      | {name:.name, status:.status, conclusion:.conclusion, details_url:.details_url})' \
       2>/dev/null); then

--- a/tests/dev-lead/unit/test_fix_reviews.bats
+++ b/tests/dev-lead/unit/test_fix_reviews.bats
@@ -2134,6 +2134,53 @@ GHEOF
   [[ "$output" != *"status=no-changes"* ]]
 }
 
+@test "review-changes: same-named check runs from different apps are not collapsed" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+
+  # Stub: two check runs with the same name but from different GitHub Apps.
+  # App 111 (success, newer) must not hide app 222 (cancelled, older) — they are
+  # distinct logical checks and both must be evaluated independently.
+  cat > "$STUB_BIN_DIR/gh" <<'GHEOF'
+#!/usr/bin/env bash
+ARGS="$*"
+case "$ARGS" in
+  *"check-runs"*)
+    echo '{"check_runs":[{"id":301,"name":"ShellCheck","status":"completed","conclusion":"success","started_at":"2026-06-07T14:00:00Z","details_url":"https://example.com/1","app":{"id":111}},{"id":302,"name":"ShellCheck","status":"completed","conclusion":"cancelled","started_at":"2026-06-07T13:55:00Z","details_url":"https://example.com/2","app":{"id":222}}]}' ;;
+  *"statuses"*)
+    echo '[]' ;;
+  *"pulls/"*"reviews"*)
+    echo '[]' ;;
+  *"graphql"*)
+    echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]},"reviewDecision":null}}}}' ;;
+  *"pr checkout"*) exit 0 ;;
+  *"pr comment"*) exit 0 ;;
+  *"pr merge"*) exit 0 ;;
+  *"pulls/"*) echo '{"head":{"sha":"abc123"},"auto_merge":null}' ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN_DIR/gh"
+
+  run bash -c "
+    cd '$tmpdir'
+    export INTENT_TYPE=review-changes DEV_LEAD_DRY_RUN=true
+    export PR_NUMBER=422 HEAD_SHA=abc123 REPO='petry-projects/.github-private'
+    export REVIEW_ENGINE=claude BASE_REF=main PROMPTS_DIR='$SCRIPT_DIR/prompts/dev-lead'
+    export PATH=\"$STUB_BIN_DIR:\$PATH\"
+    bash '$FIX_REVIEWS_SCRIPT'
+  " 2>&1
+  rm -rf "$tmpdir"
+
+  [ "$status" -eq 0 ]
+  # The cancelled run from a different app must not be hidden by the same-named success.
+  # Both must remain distinct in CI_STATUS_JSON, so the cancelled one still blocks.
+  [[ "$output" == *"Tier-1 blockers still present"* ]]
+  [[ "$output" == *"rate-limited marker"* ]]
+  [[ "$output" == *"reason=blocked"* ]]
+  [[ "$output" != *"status=no-changes"* ]]
+}
+
 @test "fix-reviews: bot-thread-only blocker suppresses no-changes terminal (fix-reviews intent)" {
   local tmpdir
   tmpdir="$(mktemp -d)"

--- a/tests/dev-lead/unit/test_fix_reviews.bats
+++ b/tests/dev-lead/unit/test_fix_reviews.bats
@@ -195,6 +195,9 @@ GHEOF
   [ "$status" -eq 2 ]
   [[ "$output" == *"rate-limited"* ]]
   [[ "$output" == *"intent=fix-reviews"* ]]
+  # Genuine rate limit keeps the rate-limited wording and tags the marker reason
+  [[ "$output" == *"reason=rate-limit"* ]]
+  [[ "$output" == *"Dev-Lead — rate-limited"* ]]
 }
 
 @test "fix-reviews: rate-limited: on-mention intent posts re-trigger ack (not auto-retry)" {
@@ -1979,6 +1982,12 @@ GHEOF
   [[ "$output" != *"status=no-changes"* ]]
   # Must include a future reset time so the retry cron backs off instead of re-dispatching immediately
   [[ "$output" == *"reset="* ]]
+  # Honest wording (issue #461): blocked-path marker keeps the machine-readable
+  # status token but must not claim the engines are rate-limited
+  [[ "$output" == *"status=rate-limited"* ]]
+  [[ "$output" == *"reason=blocked"* ]]
+  [[ "$output" == *"waiting on PR blockers"* ]]
+  [[ "$output" != *"all AI engines are currently rate-limited"* ]]
 }
 
 @test "review-changes: hard blockers path posts rate-limited marker for retry" {
@@ -2023,6 +2032,106 @@ GHEOF
   [[ "$output" != *"status=no-changes"* ]]
   # Must include a future reset time so the retry cron backs off instead of re-dispatching immediately
   [[ "$output" == *"reset="* ]]
+  # Honest wording (issue #461): blocked-path marker keeps the machine-readable
+  # status token but must not claim the engines are rate-limited
+  [[ "$output" == *"status=rate-limited"* ]]
+  [[ "$output" == *"reason=blocked"* ]]
+  [[ "$output" == *"waiting on PR blockers"* ]]
+  [[ "$output" != *"all AI engines are currently rate-limited"* ]]
+  # The visible review-changes ack explains the real cause honestly
+  [[ "$output" == *"no code changes were needed"* ]]
+}
+
+# ── check-run dedup: superseded runs must not register as blockers (issue #461) ─
+
+@test "review-changes: superseded cancelled check run is not a hard blocker" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+
+  # Stub: three same-named check runs from different check suites — two
+  # concurrency-cancelled runs superseded by a newer successful one (the exact
+  # shape of the PR #453 incident). Only the newest run per name may count.
+  cat > "$STUB_BIN_DIR/gh" <<'GHEOF'
+#!/usr/bin/env bash
+ARGS="$*"
+case "$ARGS" in
+  *"check-runs"*)
+    echo '{"check_runs":[{"id":101,"name":"review","status":"completed","conclusion":"cancelled","started_at":"2026-06-07T13:08:53Z","details_url":"https://example.com/1"},{"id":102,"name":"review","status":"completed","conclusion":"cancelled","started_at":"2026-06-07T13:08:54Z","details_url":"https://example.com/2"},{"id":103,"name":"review","status":"completed","conclusion":"success","started_at":"2026-06-07T13:08:56Z","details_url":"https://example.com/3"}]}' ;;
+  *"statuses"*)
+    echo '[]' ;;
+  *"pulls/"*"reviews"*)
+    echo '[]' ;;
+  *"graphql"*)
+    echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]},"reviewDecision":null}}}}' ;;
+  *"pr checkout"*) exit 0 ;;
+  *"pr comment"*) exit 0 ;;
+  *"pr merge"*) exit 0 ;;
+  *"pulls/"*) echo '{"head":{"sha":"abc123"},"auto_merge":null}' ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN_DIR/gh"
+
+  run bash -c "
+    cd '$tmpdir'
+    export INTENT_TYPE=review-changes DEV_LEAD_DRY_RUN=true
+    export PR_NUMBER=422 HEAD_SHA=abc123 REPO='petry-projects/.github-private'
+    export REVIEW_ENGINE=claude BASE_REF=main PROMPTS_DIR='$SCRIPT_DIR/prompts/dev-lead'
+    export PATH=\"$STUB_BIN_DIR:\$PATH\"
+    bash '$FIX_REVIEWS_SCRIPT'
+  " 2>&1
+  rm -rf "$tmpdir"
+
+  [ "$status" -eq 0 ]
+  # The superseded cancelled runs must not block: no retry marker, terminal no-changes posted
+  [[ "$output" != *"Tier-1 blockers still present"* ]]
+  [[ "$output" != *"rate-limited marker"* ]]
+  [[ "$output" == *"status=no-changes"* ]]
+}
+
+@test "review-changes: lone cancelled check run still counts as a hard blocker" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+
+  # Stub: a single cancelled check run with no newer same-named replacement —
+  # genuinely the latest of its name, so it must still block (regression guard
+  # against over-eager dedup).
+  cat > "$STUB_BIN_DIR/gh" <<'GHEOF'
+#!/usr/bin/env bash
+ARGS="$*"
+case "$ARGS" in
+  *"check-runs"*)
+    echo '{"check_runs":[{"id":201,"name":"review","status":"completed","conclusion":"cancelled","started_at":"2026-06-07T13:08:53Z","details_url":"https://example.com/1"}]}' ;;
+  *"statuses"*)
+    echo '[]' ;;
+  *"pulls/"*"reviews"*)
+    echo '[]' ;;
+  *"graphql"*)
+    echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]},"reviewDecision":null}}}}' ;;
+  *"pr checkout"*) exit 0 ;;
+  *"pr comment"*) exit 0 ;;
+  *"pr merge"*) exit 0 ;;
+  *"pulls/"*) echo '{"head":{"sha":"abc123"},"auto_merge":null}' ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN_DIR/gh"
+
+  run bash -c "
+    cd '$tmpdir'
+    export INTENT_TYPE=review-changes DEV_LEAD_DRY_RUN=true
+    export PR_NUMBER=422 HEAD_SHA=abc123 REPO='petry-projects/.github-private'
+    export REVIEW_ENGINE=claude BASE_REF=main PROMPTS_DIR='$SCRIPT_DIR/prompts/dev-lead'
+    export PATH=\"$STUB_BIN_DIR:\$PATH\"
+    bash '$FIX_REVIEWS_SCRIPT'
+  " 2>&1
+  rm -rf "$tmpdir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Tier-1 blockers still present"* ]]
+  [[ "$output" == *"rate-limited marker"* ]]
+  [[ "$output" == *"reason=blocked"* ]]
+  [[ "$output" != *"status=no-changes"* ]]
 }
 
 @test "fix-reviews: bot-thread-only blocker suppresses no-changes terminal (fix-reviews intent)" {

--- a/tests/dev-lead/unit/test_fix_reviews.bats
+++ b/tests/dev-lead/unit/test_fix_reviews.bats
@@ -2181,6 +2181,104 @@ GHEOF
   [[ "$output" != *"status=no-changes"* ]]
 }
 
+@test "review-changes: same app different workflow suites are not collapsed — failure survives" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+
+  # Stub: two check runs with the same name and same app (GitHub Actions, id=15368)
+  # but from different check suites (different workflows). The newer run (id=502,
+  # suite 501) succeeds while the older run (id=501, suite 500) fails. With the old
+  # group_by([name, app]) key the failure was hidden; the new check_suite discriminator
+  # keeps them separate so the failure still registers as a Tier-1 blocker.
+  cat > "$STUB_BIN_DIR/gh" <<'GHEOF'
+#!/usr/bin/env bash
+ARGS="$*"
+case "$ARGS" in
+  *"check-runs"*)
+    echo '{"check_runs":[{"id":501,"name":"Build","status":"completed","conclusion":"failure","started_at":"2026-06-07T14:00:00Z","details_url":"https://example.com/1","app":{"id":15368},"check_suite":{"id":500}},{"id":502,"name":"Build","status":"completed","conclusion":"success","started_at":"2026-06-07T14:00:01Z","details_url":"https://example.com/2","app":{"id":15368},"check_suite":{"id":501}}]}' ;;
+  *"statuses"*)
+    echo '[]' ;;
+  *"pulls/"*"reviews"*)
+    echo '[]' ;;
+  *"graphql"*)
+    echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]},"reviewDecision":null}}}}' ;;
+  *"pr checkout"*) exit 0 ;;
+  *"pr comment"*) exit 0 ;;
+  *"pr merge"*) exit 0 ;;
+  *"pulls/"*) echo '{"head":{"sha":"abc123"},"auto_merge":null}' ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN_DIR/gh"
+
+  run bash -c "
+    cd '$tmpdir'
+    export INTENT_TYPE=review-changes DEV_LEAD_DRY_RUN=true
+    export PR_NUMBER=422 HEAD_SHA=abc123 REPO='petry-projects/.github-private'
+    export REVIEW_ENGINE=claude BASE_REF=main PROMPTS_DIR='$SCRIPT_DIR/prompts/dev-lead'
+    export PATH=\"$STUB_BIN_DIR:\$PATH\"
+    bash '$FIX_REVIEWS_SCRIPT'
+  " 2>&1
+  rm -rf "$tmpdir"
+
+  [ "$status" -eq 0 ]
+  # The failure from workflow-suite 500 must not be hidden by the success from
+  # workflow-suite 501 — different suites mean different required checks.
+  [[ "$output" == *"Tier-1 blockers still present"* ]]
+  [[ "$output" == *"rate-limited marker"* ]]
+  [[ "$output" == *"reason=blocked"* ]]
+  [[ "$output" != *"status=no-changes"* ]]
+}
+
+@test "review-changes: queued check run without started_at wins over older cancelled run by id" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+
+  # Stub: two same-named runs in the same (name, app, suite=null) group. The older
+  # run (id=99) is cancelled and has a started_at; the newer run (id=100) is queued
+  # and has no started_at. With the old sort_by([.started_at // "", .id // 0]) the
+  # empty string sorts before any timestamp, so the cancelled run (started_at set)
+  # ended up as `last` and wrongly blocked. sort_by([.id // 0]) always picks the
+  # higher-id (newer) run regardless of started_at presence.
+  cat > "$STUB_BIN_DIR/gh" <<'GHEOF'
+#!/usr/bin/env bash
+ARGS="$*"
+case "$ARGS" in
+  *"check-runs"*)
+    echo '{"check_runs":[{"id":99,"name":"review","status":"completed","conclusion":"cancelled","started_at":"2026-06-07T13:00:00Z","details_url":"https://example.com/1"},{"id":100,"name":"review","status":"queued","conclusion":null,"details_url":"https://example.com/2"}]}' ;;
+  *"statuses"*)
+    echo '[]' ;;
+  *"pulls/"*"reviews"*)
+    echo '[]' ;;
+  *"graphql"*)
+    echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]},"reviewDecision":null}}}}' ;;
+  *"pr checkout"*) exit 0 ;;
+  *"pr comment"*) exit 0 ;;
+  *"pr merge"*) exit 0 ;;
+  *"pulls/"*) echo '{"head":{"sha":"abc123"},"auto_merge":null}' ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN_DIR/gh"
+
+  run bash -c "
+    cd '$tmpdir'
+    export INTENT_TYPE=review-changes DEV_LEAD_DRY_RUN=true
+    export PR_NUMBER=422 HEAD_SHA=abc123 REPO='petry-projects/.github-private'
+    export REVIEW_ENGINE=claude BASE_REF=main PROMPTS_DIR='$SCRIPT_DIR/prompts/dev-lead'
+    export PATH=\"$STUB_BIN_DIR:\$PATH\"
+    bash '$FIX_REVIEWS_SCRIPT'
+  " 2>&1
+  rm -rf "$tmpdir"
+
+  [ "$status" -eq 0 ]
+  # The queued run (id=100) must win: the cancelled run (id=99) is superseded within
+  # its group and must not register as a Tier-1 blocker.
+  [[ "$output" != *"Tier-1 blockers still present"* ]]
+  [[ "$output" != *"rate-limited marker"* ]]
+  [[ "$output" == *"status=no-changes"* ]]
+}
+
 @test "fix-reviews: bot-thread-only blocker suppresses no-changes terminal (fix-reviews intent)" {
   local tmpdir
   tmpdir="$(mktemp -d)"

--- a/tests/dev-lead/unit/test_fix_reviews.bats
+++ b/tests/dev-lead/unit/test_fix_reviews.bats
@@ -2230,6 +2230,56 @@ GHEOF
   [[ "$output" != *"status=no-changes"* ]]
 }
 
+@test "review-changes: same app different suites — superseded cancelled run is dropped" {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+
+  # Stub: same name and app (GitHub Actions, id=15368) across DIFFERENT check
+  # suites — the exact PR #453 incident with explicit suite ids: a concurrency-
+  # cancelled run (id=501, suite 500) superseded by a newer success (id=502,
+  # suite 501). Stage 1 keeps both (distinct suites); Stage 2's deliberate
+  # cross-suite (name, app) match must drop the cancelled one. Requiring suite
+  # equality in Stage 2 would make this test fail and reintroduce issue #461's
+  # endless retry loop — the superseding run always lives in a different suite.
+  cat > "$STUB_BIN_DIR/gh" <<'GHEOF'
+#!/usr/bin/env bash
+ARGS="$*"
+case "$ARGS" in
+  *"check-runs"*)
+    echo '{"check_runs":[{"id":501,"name":"review","status":"completed","conclusion":"cancelled","started_at":"2026-06-07T14:00:00Z","details_url":"https://example.com/1","app":{"id":15368},"check_suite":{"id":500}},{"id":502,"name":"review","status":"completed","conclusion":"success","started_at":"2026-06-07T14:00:01Z","details_url":"https://example.com/2","app":{"id":15368},"check_suite":{"id":501}}]}' ;;
+  *"statuses"*)
+    echo '[]' ;;
+  *"pulls/"*"reviews"*)
+    echo '[]' ;;
+  *"graphql"*)
+    echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]},"reviewDecision":null}}}}' ;;
+  *"pr checkout"*) exit 0 ;;
+  *"pr comment"*) exit 0 ;;
+  *"pr merge"*) exit 0 ;;
+  *"pulls/"*) echo '{"head":{"sha":"abc123"},"auto_merge":null}' ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN_DIR/gh"
+
+  run bash -c "
+    cd '$tmpdir'
+    export INTENT_TYPE=review-changes DEV_LEAD_DRY_RUN=true
+    export PR_NUMBER=422 HEAD_SHA=abc123 REPO='petry-projects/.github-private'
+    export REVIEW_ENGINE=claude BASE_REF=main PROMPTS_DIR='$SCRIPT_DIR/prompts/dev-lead'
+    export PATH=\"$STUB_BIN_DIR:\$PATH\"
+    bash '$FIX_REVIEWS_SCRIPT'
+  " 2>&1
+  rm -rf "$tmpdir"
+
+  [ "$status" -eq 0 ]
+  # The superseded cancelled run must be dropped even though its suite differs
+  # from the success's — matches GitHub's latest-same-named-run merge gate.
+  [[ "$output" != *"Tier-1 blockers still present"* ]]
+  [[ "$output" != *"rate-limited marker"* ]]
+  [[ "$output" == *"status=no-changes"* ]]
+}
+
 @test "review-changes: queued check run without started_at wins over older cancelled run by id" {
   local tmpdir
   tmpdir="$(mktemp -d)"


### PR DESCRIPTION
## Summary

Fixes #461 — dev-lead told users *"all AI engines are currently rate-limited"* when no engine was rate-limited (PR #453 incident, comment 4642769821). Two defects combined:

### 1. Superseded cancelled check runs counted as permanent Tier-1 blockers

`fetch_pr_context` built `CI_STATUS_JSON` from `GET /commits/{sha}/check-runs` with no dedup by name. Each triggering event creates its own check suite, so the API's default `filter=latest` never collapses runs across suites — on PR #453, two concurrency-cancelled `review` runs sat forever next to their successful same-named replacement, and `has_hard_blockers` counted `cancelled` → endless 30-minute retry cycling.

**Fix:** dedupe check runs by name, keeping the newest (`started_at`, then `id`). This mirrors the legacy-statuses dedup already present a few lines below (same rationale, same function), and matches GitHub's own merge semantics — branch protection keys required checks by name. A **lone** cancelled run (genuinely the latest of its name) still blocks.

### 2. The hard-blocker backoff path reused the rate-limit messaging verbatim

The "engine ran fine, no changes, but hard blockers remain" path called `post_reviews_rate_limited` and posted the literal "all AI engines are currently rate-limited" ack with a fabricated `now+30min` "reset" time.

**Fix:** `post_reviews_rate_limited` gains a `reason` param (`rate-limit` default | `blocked`). The blocked path now posts *"waiting on PR blockers"* marker wording and an honest review-changes ack ("no code changes were needed, but it still has blocking checks or reviews…"). The machine-readable `status=rate-limited` marker token is **unchanged** — `dev-lead-retry.sh` keys its re-dispatch scan on it — and a new informational `reason=` field records the real cause. The `+30min` backoff write moves from the two duplicated call sites into the function.

## Compatibility verified

- `dev-lead-retry.sh` marker patterns are substring `test()` matches ending at `status=rate-limited`; the `reset=` capture is position-independent — both parse the new `reason=`-tagged format (verified directly).
- e2e scenario 07 fixtures/assertions are loose greps and old-format synthetic markers — both formats remain valid inputs.
- `dev-lead-fix-ci.sh` markers untouched (it never scans/classifies the commit's check-run list).

## Tests

- New: superseded cancelled run is not a hard blocker (exact PR #453 shape: 2 cancelled + newer same-named success).
- New: lone cancelled run still blocks (regression guard against over-eager dedup).
- Extended: both hard-blocker tests now pin `reason=blocked`, the "waiting on PR blockers" wording, the kept `status=rate-limited` token, and assert the false "all AI engines…" claim is gone; genuine rate-limit test pins `reason=rate-limit` and unchanged wording.
- `bats tests/dev-lead/unit/` — 295/295 pass; `shellcheck --severity=warning` clean; both CI integration tests pass.

## Known limitation (pre-existing, out of scope)

A *lone* cancelled check (nothing newer of the same name) still cycles 30-minute retries without anything re-triggering the cancelled workflow — the retry re-runs the engine, not the check. Pre-dates this change (#426); this PR shrinks its blast radius to genuinely-latest cancellations only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Concurrent CI check-runs are now deduplicated by name and GitHub App ID, preventing canceled runs from being incorrectly flagged as persistent blockers. This improves blocker accuracy.
* Rate-limit and PR blocker messages are now differentiated. When held up by PR blockers, notifications now display "waiting on PR blockers" with updated backoff timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->