### PR TITLE
fix(pr-review): count only non-converging review cycles; make escalation recoverable

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,7 @@ jobs:
         run: sudo apt-get install -y bats
 
       - name: Run tests
-        run: bats tests/fleet_report.bats tests/token_report.bats tests/model_pricing.bats
+        run: bats tests/fleet_report.bats tests/token_report.bats tests/model_pricing.bats tests/test_review_cycle.bats
 
   validate-agent-profiles:
     runs-on: ubuntu-latest

--- a/docs/pr-review-agent/pr-review-agent.md
+++ b/docs/pr-review-agent/pr-review-agent.md
@@ -81,13 +81,20 @@ and **Copilot**.
    - **If escalated + no delegation (or max cycles reached):** labels
      `needs-human-review` and re-requests don-petry as reviewer.
    - **Cycle guard:** before running the cascade, `scripts/review-one-pr.sh`
-     counts existing review markers on the PR. If the count is
+     counts *non-converging* review cycles on the PR: non-approval review
+     markers posted since the most recent reset event (the latest approval
+     marker or the latest escalation comment). If the count is
      `>= MAX_REVIEW_CYCLES` (default 3), the cascade is skipped entirely;
      the script posts a single human-escalation comment marked
      `<!-- pr-review-agent escalation -->`, adds `needs-human-review`, and
-     re-requests don-petry. Subsequent runs detect the escalation marker and
-     no-op without spamming. This prevents infinite review loops on PRs
-     that aren't converging.
+     re-requests don-petry. Subsequent runs no-op while the escalation marker
+     AND the `needs-human-review` label are both present. This prevents
+     infinite review loops on PRs that aren't converging, without punishing
+     PRs that converge (approve) and then legitimately evolve (issue #467).
+     Re-engagement paths: remove the `needs-human-review` label (cascade
+     resumes on the next run with a fresh cycle budget), or mention the bot —
+     mention-triggered runs (`FORCE_REVIEW=true`) bypass the escalation pause
+     and the cap, and drop the label so the cascade stays engaged.
 
 5. **Idempotency + iterative review cycles** — every posted review starts with
    an HTML marker on line 1:

--- a/scripts/lib/review-cycle.sh
+++ b/scripts/lib/review-cycle.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Shared helpers for the PR-review cascade's cycle cap (issue #467).
+#
+# The cycle cap exists to break non-converging fix-request ping-pong loops
+# (review requests fixes → dev-lead applies → review requests more fixes).
+# It must NOT fire on PRs that are converging: approvals and history that
+# predates a human escalation do not count toward the cap.
+#
+# All functions take a JSON array of `{when, body}` items — every review and
+# comment on the PR, tagged with its timestamp (reviews' submittedAt,
+# comments' createdAt). ISO-8601 timestamps compare correctly as strings.
+#
+# Marker formats found in the wild (see prompts/single-review.md,
+# prompts/synthesize.md, scripts/post-pr-review.sh, scripts/backfill-review-markers.sh):
+#   approval review:   <!-- pr-review-agent v1 sha=<SHA> decision=approved risk=... -->
+#   escalated review:  <!-- pr-review-agent v1 sha=<SHA> decision=escalated risk=... -->
+#   fix-request:       <!-- pr-review-agent v1 sha=<SHA> --> <!-- decision=fix-requested risk=... -->
+#   human escalation:  <!-- pr-review-agent escalation -->
+#
+# Superseded comments are edited in place (createdAt preserved) and keep the
+# original markers inside a <details> block, so markers and timestamps remain
+# meaningful for counting.
+
+# Shared jq predicate definitions, prepended to every program below.
+_REVIEW_CYCLE_JQ_DEFS='
+  def has_marker: (.body // "") | test("<!-- pr-review-agent v1 sha=[a-f0-9]+");
+  def is_approval: (.body // "") | test("<!-- pr-review-agent v1 sha=[a-f0-9]+\\s+decision=approved");
+  def is_escalation: (.body // "") | test("<!-- pr-review-agent escalation -->");
+'
+
+# compute_review_cycle <items_json>
+#   Prints the number of NON-CONVERGING review cycles: v1 markers that are not
+#   approvals, posted after the most recent reset event. Reset events:
+#     - the latest approval marker (the cascade converged; later cycles are a
+#       fresh attempt on an evolved PR, not a continuation of an old loop)
+#     - the latest `<!-- pr-review-agent escalation -->` comment (a human was
+#       brought in; re-engagement starts with a fresh budget)
+#   With no reset event present, all non-approval markers count.
+compute_review_cycle() {
+  local items_json="${1:-[]}"
+  local count
+  count=$(jq -r "$_REVIEW_CYCLE_JQ_DEFS"'
+    map(select(.when != null and .when != ""))
+    | ([.[] | select(is_approval)   | .when] | max // "") as $last_approval
+    | ([.[] | select(is_escalation) | .when] | max // "") as $last_escalation
+    | (if $last_approval > $last_escalation then $last_approval else $last_escalation end) as $reset
+    | [.[] | select(has_marker and (is_approval | not) and (.when > $reset))]
+    | length
+  ' <<<"$items_json" 2>/dev/null) || count=0
+  # Defensive: malformed input must degrade to 0, not break the integer
+  # comparison at the cycle cap ("integer expression expected").
+  case "$count" in
+    ''|*[!0-9]*) echo 0 ;;
+    *) echo "$count" ;;
+  esac
+}
+
+# has_escalation_marker <items_json>
+#   Exit 0 if any review/comment carries the human-escalation marker.
+has_escalation_marker() {
+  local items_json="${1:-[]}"
+  jq -e "$_REVIEW_CYCLE_JQ_DEFS"'
+    any(.[]; is_escalation)
+  ' <<<"$items_json" >/dev/null 2>&1
+}

--- a/scripts/review-one-pr.sh
+++ b/scripts/review-one-pr.sh
@@ -25,6 +25,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=engine.sh
 source "$SCRIPT_DIR/engine.sh"
+# Cycle-cap helpers: compute_review_cycle, has_escalation_marker (issue #467).
+# shellcheck source=lib/review-cycle.sh
+source "$SCRIPT_DIR/lib/review-cycle.sh"
 
 PR_URL="${1:?usage: review-one-pr.sh <pr-url>}"
 export PR_URL
@@ -40,7 +43,7 @@ echo "==> $PR_URL"
 #                NEUTRAL covers informational checks that don't gate merging.
 #      failing — anything else (FAILURE, ACTION_REQUIRED, TIMED_OUT, CANCELLED,
 #                STALE, STARTUP_FAILURE, or unknown conclusions)
-PR_SNAPSHOT=$(gh pr view "$PR_URL" --json headRefOid,statusCheckRollup,reviewDecision,reviews)
+PR_SNAPSHOT=$(gh pr view "$PR_URL" --json headRefOid,statusCheckRollup,reviewDecision,reviews,labels)
 PR_HEAD_SHA=$(echo "$PR_SNAPSHOT" | jq -r '.headRefOid')
 export PR_HEAD_SHA
 echo "    head SHA: $PR_HEAD_SHA"
@@ -135,38 +138,59 @@ if [ -n "${EXISTING_MARKER_SHA:-}" ]; then
   echo "    re-review: prior marker was $EXISTING_MARKER_SHA, head is $PR_HEAD_SHA"
 fi
 
-# Count how many review cycles we've already done on this PR (number of distinct markers).
-# This prevents infinite review loops (AI-delegation OR cascade-only).
-PR_BODIES=$(
+# Count how many NON-CONVERGING review cycles we've done on this PR.
+# This prevents infinite review loops (AI-delegation OR cascade-only) without
+# punishing PRs that are converging (issue #467): compute_review_cycle counts
+# only non-approval markers newer than the most recent reset event (latest
+# approval marker or latest escalation comment). An approval, or a human
+# re-engaging after escalation, grants a fresh budget of MAX_REVIEW_CYCLES.
+PR_ITEMS=$(
   gh pr view "$PR_URL" --json reviews,comments \
-    --jq '((.reviews // []) + (.comments // [])) | .[].body | select(. != null)' 2>/dev/null || true
+    --jq '((.reviews  // [] | map({when: .submittedAt, body: .body})) +
+           (.comments // [] | map({when: .createdAt,   body: .body})))
+          | map(select(.body != null))' 2>/dev/null || echo '[]'
 )
-# grep -c always prints a count line (including "0" for no matches) and exits 1
-# when there are no matches. Under `set -o pipefail`, a non-zero exit in the
-# pipe causes the substitution to fail; the previous `|| echo 0` then appended
-# a second "0", yielding the literal string "0\n0" — which broke the integer
-# comparison at the cycle cap below ("integer expression expected"). Use
-# `|| true` so we keep grep's count and don't add a duplicate.
-# `printf '%s\n'` instead of `echo` because PR body content is user-authored
-# and could begin with `-n`/`-e` or contain backslash escapes that some
-# `echo` builtins reinterpret.
-REVIEW_CYCLE=$(printf '%s\n' "$PR_BODIES" | grep -cE '<!-- pr-review-agent v1 sha=[a-f0-9]+' || true)
-REVIEW_CYCLE="${REVIEW_CYCLE:-0}"
+REVIEW_CYCLE=$(compute_review_cycle "$PR_ITEMS")
 export REVIEW_CYCLE
 MAX_CYCLES="${MAX_REVIEW_CYCLES:-3}"
 echo "    review cycle: $REVIEW_CYCLE (max: $MAX_CYCLES)"
 
-# Cycle cap: once we've reviewed this PR MAX_REVIEW_CYCLES times without it
-# merging, stop running the cascade and escalate to a human. We post a single
-# escalation comment marked with `<!-- pr-review-agent escalation -->` so
-# subsequent runs detect the marker and no-op without spamming.
-if printf '%s\n' "$PR_BODIES" | grep -qE '<!-- pr-review-agent escalation -->'; then
-  echo "    noop: human-escalation marker present — cascade already capped"
-  echo "{\"pr\":\"$PR_URL\",\"sha\":\"$PR_HEAD_SHA\",\"decision\":\"noop\",\"reason\":\"human-escalated\"}"
-  exit 100
+# Escalation handling (issue #467). Once a PR is escalated to a human, the
+# cascade pauses — but not unconditionally:
+#   1. FORCE_REVIEW=true (mention-triggered) always proceeds. An explicit
+#      human request IS the human-in-the-loop the cap exists to obtain; we
+#      also drop the needs-human-review label so the cascade stays engaged
+#      on subsequent scheduled runs.
+#   2. Otherwise we pause only while the `needs-human-review` label is still
+#      present. Removing the label re-engages the cascade exactly as the
+#      escalation comment promises (previously the label was never consulted,
+#      so a capped PR was permanently un-reviewable).
+# Markers older than the escalation comment don't count toward the next cap
+# (see compute_review_cycle), so re-engagement starts with a fresh budget
+# instead of immediately re-escalating.
+if has_escalation_marker "$PR_ITEMS"; then
+  HAS_HUMAN_LABEL=$(echo "$PR_SNAPSHOT" | jq -r '[.labels // [] | .[].name] | if index("needs-human-review") then "true" else "false" end')
+  if [ "${FORCE_REVIEW:-false}" = "true" ]; then
+    echo "    force-review: escalation marker present, but FORCE_REVIEW=true — re-engaging cascade"
+    if [ "${DRY_RUN:-false}" != "true" ]; then
+      gh pr edit "$PR_URL" --remove-label needs-human-review 2>/dev/null || true
+    fi
+  elif [ "$HAS_HUMAN_LABEL" = "true" ]; then
+    echo "    noop: human-escalation active (needs-human-review label present) — remove the label or mention the bot to re-engage"
+    echo "{\"pr\":\"$PR_URL\",\"sha\":\"$PR_HEAD_SHA\",\"decision\":\"noop\",\"reason\":\"human-escalated\"}"
+    exit 100
+  else
+    echo "    re-engage: escalation marker present but needs-human-review label removed — resuming cascade"
+  fi
 fi
 
-if [ "$REVIEW_CYCLE" -ge "$MAX_CYCLES" ]; then
+# Cycle cap: MAX_REVIEW_CYCLES consecutive non-converging cycles → escalate to
+# a human. We post a single escalation comment marked with
+# `<!-- pr-review-agent escalation -->`; the block above detects it (together
+# with the needs-human-review label) and no-ops without spamming.
+# FORCE_REVIEW bypasses the cap: a mention-triggered run must deliver the
+# review it acknowledged, never silently no-op.
+if [ "${FORCE_REVIEW:-false}" != "true" ] && [ "$REVIEW_CYCLE" -ge "$MAX_CYCLES" ]; then
   echo "    cap: review cycle $REVIEW_CYCLE >= max $MAX_CYCLES — escalating to human"
   if [ "${DRY_RUN:-false}" = "true" ]; then
     echo "    DRY_RUN: would post escalation comment, add label, request reviewer"
@@ -178,9 +202,9 @@ if [ "$REVIEW_CYCLE" -ge "$MAX_CYCLES" ]; then
 
 ## Automated review — human attention needed
 
-This PR has been through $REVIEW_CYCLE automated review cycles (cap: $MAX_CYCLES) without converging on an approval-and-merge state. Further automated review has been paused to avoid infinite loops.
+This PR has been through $REVIEW_CYCLE automated review cycles since the last approval or escalation (cap: $MAX_CYCLES) without converging. Further automated review has been paused to avoid infinite loops.
 
-Please take a look manually, or close this PR if it's no longer needed. Once a human review resolves the situation, remove the \`needs-human-review\` label and the cascade can be re-engaged on the next push.
+Please take a look manually, or close this PR if it's no longer needed. To re-engage the automated cascade with a fresh cycle budget, either remove the \`needs-human-review\` label, or mention the bot (e.g. \`@${BOT_USER:-donpetry-bot} review\`) for an immediate re-review.
 
 _Posted by the ${BOT_USER:-donpetry-bot} PR-review cascade._
 ESCALATION_END

--- a/scripts/review-one-pr.sh
+++ b/scripts/review-one-pr.sh
@@ -43,7 +43,7 @@ echo "==> $PR_URL"
 #                NEUTRAL covers informational checks that don't gate merging.
 #      failing — anything else (FAILURE, ACTION_REQUIRED, TIMED_OUT, CANCELLED,
 #                STALE, STARTUP_FAILURE, or unknown conclusions)
-PR_SNAPSHOT=$(gh pr view "$PR_URL" --json headRefOid,statusCheckRollup,reviewDecision,reviews,labels)
+PR_SNAPSHOT=$(gh pr view "$PR_URL" --json headRefOid,statusCheckRollup,reviewDecision,reviews,labels,comments)
 PR_HEAD_SHA=$(echo "$PR_SNAPSHOT" | jq -r '.headRefOid')
 export PR_HEAD_SHA
 echo "    head SHA: $PR_HEAD_SHA"
@@ -144,11 +144,13 @@ fi
 # only non-approval markers newer than the most recent reset event (latest
 # approval marker or latest escalation comment). An approval, or a human
 # re-engaging after escalation, grants a fresh budget of MAX_REVIEW_CYCLES.
+# Reuse the snapshot fetched at the top of the script instead of a second
+# `gh pr view` round-trip (review feedback: saves an API call per PR).
 PR_ITEMS=$(
-  gh pr view "$PR_URL" --json reviews,comments \
-    --jq '((.reviews  // [] | map({when: .submittedAt, body: .body})) +
-           (.comments // [] | map({when: .createdAt,   body: .body})))
-          | map(select(.body != null))' 2>/dev/null || echo '[]'
+  echo "$PR_SNAPSHOT" | jq '
+    ((.reviews  // [] | map({when: .submittedAt, body: .body})) +
+     (.comments // [] | map({when: .createdAt,   body: .body})))
+    | map(select(.body != null))' 2>/dev/null || echo '[]'
 )
 REVIEW_CYCLE=$(compute_review_cycle "$PR_ITEMS")
 export REVIEW_CYCLE
@@ -169,7 +171,7 @@ echo "    review cycle: $REVIEW_CYCLE (max: $MAX_CYCLES)"
 # (see compute_review_cycle), so re-engagement starts with a fresh budget
 # instead of immediately re-escalating.
 if has_escalation_marker "$PR_ITEMS"; then
-  HAS_HUMAN_LABEL=$(echo "$PR_SNAPSHOT" | jq -r '[.labels // [] | .[].name] | if index("needs-human-review") then "true" else "false" end')
+  HAS_HUMAN_LABEL=$(echo "$PR_SNAPSHOT" | jq -r '[.labels // [] | .[].name] | any(. == "needs-human-review")')
   if [ "${FORCE_REVIEW:-false}" = "true" ]; then
     echo "    force-review: escalation marker present, but FORCE_REVIEW=true — re-engaging cascade"
     if [ "${DRY_RUN:-false}" != "true" ]; then

--- a/tests/test_review_cycle.bats
+++ b/tests/test_review_cycle.bats
@@ -1,0 +1,189 @@
+#!/usr/bin/env bats
+# Unit tests for the cycle-cap helpers in scripts/lib/review-cycle.sh
+# (issue #467: cap must break fix-request ping-pong loops without punishing
+# converging PRs, and escalation must be recoverable).
+#
+# Run with: bats tests/test_review_cycle.bats
+# Install bats: https://github.com/bats-core/bats-core
+
+setup() {
+  source "$(dirname "$BATS_TEST_FILENAME")/../scripts/lib/review-cycle.sh"
+}
+
+# Helpers to build {when, body} items.
+fix_request() {  # fix_request <when> <sha>
+  jq -n --arg when "$1" --arg sha "$2" \
+    '{when: $when, body: ("<!-- pr-review-agent v1 sha=" + $sha + " --> <!-- decision=fix-requested risk=LOW -->\n\n## Review — fix requested")}'
+}
+approval() {  # approval <when> <sha>
+  jq -n --arg when "$1" --arg sha "$2" \
+    '{when: $when, body: ("<!-- pr-review-agent v1 sha=" + $sha + " decision=approved risk=LOW -->\n\n## Automated review — APPROVED ✓")}'
+}
+escalated_review() {  # escalated_review <when> <sha>
+  jq -n --arg when "$1" --arg sha "$2" \
+    '{when: $when, body: ("<!-- pr-review-agent v1 sha=" + $sha + " decision=escalated risk=MEDIUM -->\n\n## Automated review — NEEDS HUMAN REVIEW")}'
+}
+escalation_comment() {  # escalation_comment <when>
+  jq -n --arg when "$1" \
+    '{when: $when, body: "<!-- pr-review-agent escalation -->\n\n## Automated review — human attention needed"}'
+}
+items() {  # items <item-json>...
+  printf '%s\n' "$@" | jq -s '.'
+}
+
+# ---------------------------------------------------------------------------
+# compute_review_cycle: basics
+# ---------------------------------------------------------------------------
+
+@test "no markers at all counts 0" {
+  run compute_review_cycle '[{"when":"2026-06-07T01:00:00Z","body":"just a human comment"}]'
+  [ "$status" -eq 0 ]
+  [ "$output" = "0" ]
+}
+
+@test "empty array counts 0" {
+  run compute_review_cycle '[]'
+  [ "$output" = "0" ]
+}
+
+@test "missing argument counts 0" {
+  run compute_review_cycle
+  [ "$output" = "0" ]
+}
+
+@test "malformed JSON degrades to 0, not an error" {
+  run compute_review_cycle 'not-json at all'
+  [ "$status" -eq 0 ]
+  [ "$output" = "0" ]
+}
+
+@test "three consecutive fix-requests count 3" {
+  local j
+  j=$(items \
+    "$(fix_request 2026-06-07T01:00:00Z aaa111)" \
+    "$(fix_request 2026-06-07T02:00:00Z bbb222)" \
+    "$(fix_request 2026-06-07T03:00:00Z ccc333)")
+  run compute_review_cycle "$j"
+  [ "$output" = "3" ]
+}
+
+@test "escalated (needs-human) reviews count as non-converging cycles" {
+  local j
+  j=$(items \
+    "$(escalated_review 2026-06-07T01:00:00Z aaa111)" \
+    "$(escalated_review 2026-06-07T02:00:00Z bbb222)")
+  run compute_review_cycle "$j"
+  [ "$output" = "2" ]
+}
+
+# ---------------------------------------------------------------------------
+# compute_review_cycle: approvals reset the count (defect 1 in #467)
+# ---------------------------------------------------------------------------
+
+@test "approval marker itself never counts as a cycle" {
+  run compute_review_cycle "$(items "$(approval 2026-06-07T01:00:00Z aaa111)")"
+  [ "$output" = "0" ]
+}
+
+@test "PR #458 shape: fix, fix, approve counts 0 (was 3 — escalated wrongly)" {
+  local j
+  j=$(items \
+    "$(fix_request 2026-06-07T04:11:06Z 05ae5d9)" \
+    "$(fix_request 2026-06-07T04:20:56Z 0655052)" \
+    "$(approval    2026-06-07T05:01:52Z 022cecf)")
+  run compute_review_cycle "$j"
+  [ "$output" = "0" ]
+}
+
+@test "fix-requests after an approval count from the approval, not from zero history" {
+  local j
+  j=$(items \
+    "$(fix_request 2026-06-07T01:00:00Z aaa111)" \
+    "$(fix_request 2026-06-07T02:00:00Z bbb222)" \
+    "$(approval    2026-06-07T03:00:00Z ccc333)" \
+    "$(fix_request 2026-06-07T04:00:00Z ddd444)")
+  run compute_review_cycle "$j"
+  [ "$output" = "1" ]
+}
+
+@test "approval preserved inside a superseded <details> wrapper still resets" {
+  # mark_prior_agent_items_obsolete edits comments in place, preserving
+  # createdAt and the original marker inside a <details> block.
+  local wrapped j
+  wrapped=$(jq -n '{when: "2026-06-07T03:00:00Z", body: "<!-- pr-review-agent superseded -->\n<details><summary>prior</summary>\n<!-- pr-review-agent v1 sha=ccc333 decision=approved risk=LOW -->\n</details>"}')
+  j=$(items \
+    "$(fix_request 2026-06-07T01:00:00Z aaa111)" \
+    "$wrapped" \
+    "$(fix_request 2026-06-07T04:00:00Z ddd444)")
+  run compute_review_cycle "$j"
+  [ "$output" = "1" ]
+}
+
+# ---------------------------------------------------------------------------
+# compute_review_cycle: escalation comments reset the count (defect 3 in #467)
+# ---------------------------------------------------------------------------
+
+@test "markers older than the escalation comment do not count (re-engagement gets a fresh budget)" {
+  local j
+  j=$(items \
+    "$(fix_request 2026-06-07T01:00:00Z aaa111)" \
+    "$(fix_request 2026-06-07T02:00:00Z bbb222)" \
+    "$(fix_request 2026-06-07T03:00:00Z ccc333)" \
+    "$(escalation_comment 2026-06-07T04:00:00Z)")
+  run compute_review_cycle "$j"
+  [ "$output" = "0" ]
+}
+
+@test "cycles after re-engagement count from the escalation comment" {
+  local j
+  j=$(items \
+    "$(fix_request 2026-06-07T01:00:00Z aaa111)" \
+    "$(fix_request 2026-06-07T02:00:00Z bbb222)" \
+    "$(fix_request 2026-06-07T03:00:00Z ccc333)" \
+    "$(escalation_comment 2026-06-07T04:00:00Z)" \
+    "$(fix_request 2026-06-07T05:00:00Z ddd444)" \
+    "$(fix_request 2026-06-07T06:00:00Z eee555)")
+  run compute_review_cycle "$j"
+  [ "$output" = "2" ]
+}
+
+@test "newest reset event wins: approval after escalation resets again" {
+  local j
+  j=$(items \
+    "$(escalation_comment 2026-06-07T01:00:00Z)" \
+    "$(fix_request 2026-06-07T02:00:00Z aaa111)" \
+    "$(approval    2026-06-07T03:00:00Z bbb222)" \
+    "$(fix_request 2026-06-07T04:00:00Z ccc333)")
+  run compute_review_cycle "$j"
+  [ "$output" = "1" ]
+}
+
+@test "items with null/missing timestamps are ignored rather than fatal" {
+  local pending j
+  # A PENDING review has submittedAt=null; it must not break counting.
+  pending=$(jq -n '{when: null, body: "<!-- pr-review-agent v1 sha=fff666 --> <!-- decision=fix-requested risk=LOW -->"}')
+  j=$(items "$pending" "$(fix_request 2026-06-07T01:00:00Z aaa111)")
+  run compute_review_cycle "$j"
+  [ "$output" = "1" ]
+}
+
+# ---------------------------------------------------------------------------
+# has_escalation_marker
+# ---------------------------------------------------------------------------
+
+@test "has_escalation_marker: true when an escalation comment exists" {
+  run has_escalation_marker "$(items "$(escalation_comment 2026-06-07T01:00:00Z)")"
+  [ "$status" -eq 0 ]
+}
+
+@test "has_escalation_marker: false for plain review markers" {
+  run has_escalation_marker "$(items "$(fix_request 2026-06-07T01:00:00Z aaa111)")"
+  [ "$status" -ne 0 ]
+}
+
+@test "has_escalation_marker: false on empty/malformed input" {
+  run has_escalation_marker '[]'
+  [ "$status" -ne 0 ]
+  run has_escalation_marker 'garbage'
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Summary

Fixes #467 — the PR-review cascade's cycle cap escalated converging PRs (e.g. #458) and, once escalated, permanently disengaged.

### Defects fixed

| # | Defect | Fix |
|---|--------|-----|
| 1 | Lifetime marker count; approvals counted against the cap | `compute_review_cycle` (new `scripts/lib/review-cycle.sh`) counts only **non-approval** markers newer than the latest **reset event** (latest approval marker or latest escalation comment) |
| 2 | `@bot review` mentions acked "starting fresh review" then silently no-op'd at the cap | `FORCE_REVIEW=true` bypasses the escalation pause and the cycle cap, and drops the `needs-human-review` label so the cascade stays engaged |
| 3 | "Remove the label to re-engage" promise was false — only the (never-removed) escalation comment marker was consulted | Escalation pause now requires marker **AND** label; pre-escalation markers don't count toward the next cap, so re-engagement gets a fresh budget instead of instantly re-escalating |

### What still quits (by design)

The cap still escalates after `MAX_REVIEW_CYCLES` (default 3) **consecutive non-converging** fix-request/escalated cycles — the genuine reviewer↔dev-lead ping-pong loop the breaker exists for.

### Tests

`tests/test_review_cycle.bats` (17 cases, wired into the lint.yml bats job):
- the exact #458 regression shape (fix, fix, **approve** → count 0, previously 3 → wrongful escalation)
- approval/escalation reset semantics, newest-reset-wins
- approval preserved inside a superseded `<details>` wrapper still resets
- null timestamps (PENDING reviews) and malformed input degrade safely
- `has_escalation_marker` positive/negative/garbage

Local verification: all 87 bats tests pass (full lint.yml list), `shellcheck --severity=warning -x` clean across `scripts/**/*.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)