### PR TITLE
feat(initiative): dependency-aware driver to deliver epics agentically

### DIFF
--- a/.github/workflows/initiative-driver.yml
+++ b/.github/workflows/initiative-driver.yml
@@ -1,0 +1,72 @@
+name: Initiative Driver
+
+# Dependency-aware label dispatcher. Releases an initiative epic's sub-issues to
+# the dev-lead agent (by applying the `dev-lead` label) as their "blocked by"
+# dependencies close — turning the per-item agent into a coordinated, ordered
+# delivery of a whole initiative.
+#
+# Mechanics, gates, and the PAT requirement are documented in
+# scripts/initiative-driver.sh and docs/initiatives/agentic-release-strategy.md.
+#
+# SAFETY: the driver no-ops unless the epic carries the `initiative:auto` label,
+# so Phase 1 stays human-driven. Flip it on for Phase 2 by adding that label to
+# the epic (#495). Per-issue `dev-lead:hands-off` / `initiative:hold` are never
+# released.
+
+on:
+  issues:
+    types: [closed] # a close may unblock successors — re-evaluate the DAG
+  schedule:
+    - cron: "23 */6 * * *" # safety net for missed close events
+  workflow_dispatch:
+    inputs:
+      epic:
+        description: "Epic issue number to drive"
+        required: false
+        default: "495"
+      dry_run:
+        description: "Log decisions but do not apply labels"
+        required: false
+        default: "false"
+      max_in_flight:
+        description: "Max sub-issues released at once"
+        required: false
+        default: "2"
+
+permissions:
+  issues: write
+
+concurrency:
+  group: initiative-driver-${{ github.event.inputs.epic || '495' }}
+  cancel-in-progress: false
+
+env:
+  # PAT required: a label applied with the default GITHUB_TOKEN does NOT trigger
+  # dev-lead.yml (GitHub loop-prevention). GH_PAT_WORKFLOWS makes the resulting
+  # issues:[labeled] event fire the agent.
+  GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
+  REPO: ${{ github.repository }}
+  EPIC: ${{ github.event.inputs.epic || '495' }}
+  CLOSED_ISSUE: ${{ github.event.issue.number }}
+  DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+  MAX_IN_FLIGHT: ${{ github.event.inputs.max_in_flight || '2' }}
+
+jobs:
+  drive:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout agent repo
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Guard — PAT present
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::GH_PAT_WORKFLOWS is required — a label applied with GITHUB_TOKEN will not trigger dev-lead."
+            exit 1
+          fi
+
+      - name: Drive initiative
+        run: bash scripts/initiative-driver.sh

--- a/.github/workflows/initiative-driver.yml
+++ b/.github/workflows/initiative-driver.yml
@@ -34,18 +34,13 @@ on:
         default: "2"
 
 permissions:
-  contents: read
-  issues: write
+  contents: read  # actions/checkout; all issue mutations use the PAT (GH_TOKEN)
 
 concurrency:
   group: initiative-driver-${{ github.event.inputs.epic || '495' }}
   cancel-in-progress: false
 
 env:
-  # PAT required: a label applied with the default GITHUB_TOKEN does NOT trigger
-  # dev-lead.yml (GitHub loop-prevention). GH_PAT_WORKFLOWS makes the resulting
-  # issues:[labeled] event fire the agent.
-  GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
   REPO: ${{ github.repository }}
   EPIC: ${{ github.event.inputs.epic || '495' }}
   CLOSED_ISSUE: ${{ github.event.issue.number }}
@@ -63,6 +58,9 @@ jobs:
           persist-credentials: false
 
       - name: Guard — PAT present
+        # PAT required: a label applied with GITHUB_TOKEN does NOT trigger dev-lead.yml.
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
         run: |
           if [ -z "${GH_TOKEN}" ]; then
             echo "::error::GH_PAT_WORKFLOWS is required — a label applied with GITHUB_TOKEN will not trigger dev-lead."
@@ -70,4 +68,6 @@ jobs:
           fi
 
       - name: Drive initiative
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
         run: bash scripts/initiative-driver.sh

--- a/.github/workflows/initiative-driver.yml
+++ b/.github/workflows/initiative-driver.yml
@@ -6,7 +6,7 @@ name: Initiative Driver
 # delivery of a whole initiative.
 #
 # Mechanics, gates, and the PAT requirement are documented in
-# scripts/initiative-driver.sh and docs/initiatives/agentic-release-strategy.md.
+# scripts/initiative-driver.sh and docs/initiatives/agentic-release-strategy-orchestration.md.
 #
 # SAFETY: the driver no-ops unless the epic carries the `initiative:auto` label,
 # so Phase 1 stays human-driven. Flip it on for Phase 2 by adding that label to
@@ -34,6 +34,7 @@ on:
         default: "2"
 
 permissions:
+  contents: read
   issues: write
 
 concurrency:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,7 @@ jobs:
         run: sudo apt-get install -y bats
 
       - name: Run tests
-        run: bats tests/fleet_report.bats tests/token_report.bats tests/model_pricing.bats tests/test_review_cycle.bats tests/test_ci_status.bats tests/test_verify_auth_scopes.bats
+        run: bats tests/fleet_report.bats tests/token_report.bats tests/model_pricing.bats tests/test_review_cycle.bats tests/test_ci_status.bats tests/test_verify_auth_scopes.bats tests/test_initiative_driver.bats
 
   validate-agent-profiles:
     runs-on: ubuntu-latest

--- a/docs/initiatives/agentic-release-strategy-orchestration.md
+++ b/docs/initiatives/agentic-release-strategy-orchestration.md
@@ -1,6 +1,6 @@
 # Delivering the Release-Strategy initiative agentically
 
-Companion to [`agentic-release-strategy.md`](./agentic-release-strategy.md). This doc explains how the
+Companion to `agentic-release-strategy.md` (not yet published). This doc explains how the
 10 child issues of epic #495 are delivered by the existing **per-item dev-lead agent** in dependency
 order — without changing the agent itself.
 

--- a/docs/initiatives/agentic-release-strategy-orchestration.md
+++ b/docs/initiatives/agentic-release-strategy-orchestration.md
@@ -1,0 +1,102 @@
+# Delivering the Release-Strategy initiative agentically
+
+Companion to [`agentic-release-strategy.md`](./agentic-release-strategy.md). This doc explains how the
+10 child issues of epic #495 are delivered by the existing **per-item dev-lead agent** in dependency
+order — without changing the agent itself.
+
+## The problem this solves
+
+Dev-lead is purely reactive and **per-item**: it works one issue only when the `dev-lead` label is
+applied (`issues: [labeled]`), opens a PR that `Closes #N`, and drives that PR to merge. It has **no
+ordering or dependency awareness** — labelling all 10 issues at once runs them in parallel and produces
+PRs racing to merge with no regard for "#496 must land before #497".
+
+**Reframe:** coordinating an initiative = deciding *when* the `dev-lead` label is applied to each
+ready issue. That decision is what `scripts/initiative-driver.sh` + `.github/workflows/initiative-driver.yml`
+automate.
+
+## How the driver works
+
+```
+dev-lead merges a PR ──► "Closes #N" closes issue #N
+        │
+        ▼
+initiative-driver  (on: issues:[closed]  +  safety-net cron  +  workflow_dispatch)
+        │   gate: epic carries `initiative:auto`?  ── no ─► no-op (human-driven)
+        │   for each OPEN sub-issue of the epic:
+        │     • all `blocked_by` deps CLOSED?
+        │     • not `dev-lead:hands-off` / `initiative:hold`?
+        │     • in-flight < MAX_IN_FLIGHT?
+        ▼
+   apply `dev-lead` label ──► dev-lead picks up the next ready issue
+```
+
+- **Native dependencies.** Edges are GitHub "blocked by" relationships (set on #496–#506), visible in
+  the issue UI and queried via `…/issues/{n}/dependencies/blocked_by`.
+- **Event-driven, self-propelling.** A merge closes an issue, which fires the driver, which releases
+  the now-unblocked successors. The cron (`23 */6 * * *`) is only a backstop for missed events.
+- **Bounded.** `MAX_IN_FLIGHT` (default 2) caps how many sub-issues run at once — controlling parallel
+  token cost and blast radius. Per-issue concurrency lanes in dev-lead keep concurrent items isolated.
+
+### The PAT requirement (important)
+
+A label applied with the default `GITHUB_TOKEN` does **not** start a new workflow run (GitHub
+loop-prevention — the same mechanism behind pr-review #463). The driver therefore applies the
+`dev-lead` label using **`GH_PAT_WORKFLOWS`**, so the resulting `issues:[labeled]` event actually
+triggers dev-lead. The workflow fails fast if that PAT is absent.
+
+### Safety gates
+
+| Gate | Effect |
+|---|---|
+| `initiative:auto` on the **epic** | Master switch. Absent ⇒ driver no-ops. Phase 1 stays human-driven until you add it. |
+| `dev-lead:hands-off` on an **issue** | Never released (needs a human — e.g. PRs that modify dev-lead/pr-review themselves). |
+| `initiative:hold` on an **issue** | Never released (temporary human hold). |
+| `MAX_IN_FLIGHT` | Upper bound on concurrently-released sub-issues. |
+
+## The dependency DAG (epic #495)
+
+```
+#496 ──┬─► #497 ──┬─► #498
+       │          ├─► #499 ──► #500 ──┐
+       └─► #505   └─► #506 ──────────►#501 ──► #502 ──► #503
+                        #505 ───────────┘
+```
+
+| Wave | Issues | Gated on |
+|---|---|---|
+| 1 | #496 cut `vX.Y.Z` + create `stable` | — |
+| 2 | #497 pin callers · #505 tag protection | #496 |
+| 3 | #498 runbook · #499 next/ring tags · #506 caller-ref integrity | #497 |
+| 4 | #500 rings | #499 |
+| 5 | #501 promotion workflow | #500, #505, #506 |
+| 6 | #502 rollback + observability | #501 |
+| 7 | #503 SC2 game-day | #502 |
+
+## Bootstrap order: human-driven → agent-driven
+
+This initiative modifies dev-lead/pr-review themselves, so the rollout order is also a **safety
+bootstrap**, not just a technical dependency:
+
+- **Phase 1 (#496, #497, #505, #498) — human-in-the-loop.** Until `@stable` exists and production duty
+  is pinned to it (#497), there is no known-good fallback; letting the agent autonomously merge changes
+  that could brick itself is exactly the failure mode we're removing. Leave `initiative:auto` **off**;
+  apply the `dev-lead` label by hand, wave by wave (or merge by hand). Issues that edit
+  `dev-lead.yml`/`pr-review.yml` carry `dev-lead:hands-off` and require human merge regardless.
+- **Phase 2 (#499 onward) — agent-driven.** Once #497 lands, production review/dev duty runs `@stable`,
+  so a broken `main`/`next` can no longer block its own fix. **Now** add `initiative:auto` to the epic
+  and let the driver run the rest.
+
+## Operating the driver (runbook)
+
+- **Dry-run / preview** what would be released:
+  `gh workflow run initiative-driver.yml -f dry_run=true` (or run the script with `DRY_RUN=true`).
+- **Arm Phase 2:** `gh issue edit 495 --add-label initiative:auto`.
+- **Pause one issue:** add `initiative:hold`; **hand back to a human:** add `dev-lead:hands-off`.
+- **Throttle:** `gh workflow run initiative-driver.yml -f max_in_flight=1`.
+- **Disarm:** remove `initiative:auto` from the epic — in-flight items finish; nothing new is released.
+
+## Follow-ups (not in this scaffold)
+
+- A bats test that mocks `gh` to assert the gate / blocker / cap logic.
+- Generalize `EPIC` beyond the hard-coded `495` default if a second initiative adopts the driver.

--- a/scripts/initiative-driver.sh
+++ b/scripts/initiative-driver.sh
@@ -49,6 +49,14 @@ HOLD_LABEL="${HOLD_LABEL:-initiative:hold}"
 MAX_IN_FLIGHT="${MAX_IN_FLIGHT:-2}"
 DRY_RUN="${DRY_RUN:-false}"
 
+# Validate numeric inputs before they reach arithmetic or API paths.
+[[ "$EPIC" =~ ^[0-9]+$ ]] || { echo "::error::EPIC must be a positive integer, got: '$EPIC'"; exit 1; }
+[[ "$MAX_IN_FLIGHT" =~ ^[0-9]+$ ]] || { echo "::error::MAX_IN_FLIGHT must be a non-negative integer, got: '$MAX_IN_FLIGHT'"; exit 1; }
+if [ -n "$CLOSED_ISSUE" ] && ! [[ "$CLOSED_ISSUE" =~ ^[0-9]+$ ]]; then
+  echo "::warning::CLOSED_ISSUE is not a valid issue number ('$CLOSED_ISSUE') — treating as unset."
+  CLOSED_ISSUE=""
+fi
+
 log() { printf '%s\n' "$*"; }
 
 # has_label <comma-separated-labels> <name> — exact match on a label name.

--- a/scripts/initiative-driver.sh
+++ b/scripts/initiative-driver.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# initiative-driver.sh — dependency-aware label dispatcher for initiative epics.
+#
+# Turns an epic's sub-issue dependency graph (native GitHub "blocked by"
+# relationships) into dev-lead pickups: it applies the `dev-lead` label to each
+# OPEN sub-issue whose blockers are ALL closed, bounded by a max-in-flight cap.
+# The dev-lead agent triggers on issues:[labeled]; this script is the only thing
+# that decides WHEN that label goes on, so the per-item agent stays unchanged.
+#
+# Event-driven chain: dev-lead merges a PR -> "Closes #N" closes the issue ->
+# this driver (on issues:[closed]) re-evaluates the DAG -> labels the now-ready
+# successors. The schedule cron is only a safety net for missed close events.
+#
+# IMPORTANT — the trigger requires a PAT, not GITHUB_TOKEN:
+#   GitHub does not start new workflow runs from events created by the default
+#   GITHUB_TOKEN (loop prevention). The `dev-lead` label MUST be applied with a
+#   PAT (GH_PAT_WORKFLOWS) or the resulting issues:[labeled] event will NOT
+#   trigger dev-lead.yml. (Same class of bug as pr-review #463.)
+#
+# Safety gates:
+#   - The epic must carry GATE_LABEL (default: initiative:auto). Without it the
+#     driver no-ops, so Phase 1 stays human-driven until you opt in.
+#   - Issues carrying HANDS_OFF_LABEL (dev-lead:hands-off) or HOLD_LABEL
+#     (initiative:hold) are never released — they need a human.
+#   - MAX_IN_FLIGHT bounds how many sub-issues run at once (cost / blast radius).
+#
+# Env:
+#   REPO            owner/repo (default: petry-projects/.github-private)
+#   EPIC            epic issue number (required)
+#   CLOSED_ISSUE    issue number from an issues:closed event (optional; the run
+#                   exits early if it is not one of the epic's sub-issues)
+#   DEV_LEAD_LABEL  label that triggers dev-lead (default: dev-lead)
+#   GATE_LABEL      opt-in label on the epic (default: initiative:auto)
+#   HANDS_OFF_LABEL never-release label (default: dev-lead:hands-off)
+#   HOLD_LABEL      never-release label (default: initiative:hold)
+#   MAX_IN_FLIGHT   cap on concurrently-released sub-issues (default: 2)
+#   DRY_RUN         "true" to log decisions without labeling (default: false)
+#
+set -euo pipefail
+
+REPO="${REPO:-petry-projects/.github-private}"
+EPIC="${EPIC:?EPIC issue number required}"
+CLOSED_ISSUE="${CLOSED_ISSUE:-}"
+DEV_LEAD_LABEL="${DEV_LEAD_LABEL:-dev-lead}"
+GATE_LABEL="${GATE_LABEL:-initiative:auto}"
+HANDS_OFF_LABEL="${HANDS_OFF_LABEL:-dev-lead:hands-off}"
+HOLD_LABEL="${HOLD_LABEL:-initiative:hold}"
+MAX_IN_FLIGHT="${MAX_IN_FLIGHT:-2}"
+DRY_RUN="${DRY_RUN:-false}"
+
+log() { printf '%s\n' "$*"; }
+
+# has_label <comma-separated-labels> <name> — exact match on a label name.
+has_label() { printf '%s' "$1" | tr ',' '\n' | grep -qx "$2"; }
+
+# labels_of <issue-number> — comma-joined label names.
+labels_of() {
+  gh api "repos/$REPO/issues/$1" --jq '[.labels[].name] | join(",")'
+}
+
+# ── gate: the epic must opt in ────────────────────────────────────────────────
+epic_labels="$(labels_of "$EPIC")"
+if ! has_label "$epic_labels" "$GATE_LABEL"; then
+  log "Gate '$GATE_LABEL' not on epic #$EPIC — no-op (Phase-1 human-driven). Add the label to activate."
+  exit 0
+fi
+
+# ── enumerate sub-issues (all states) ─────────────────────────────────────────
+mapfile -t all_children < <(
+  gh api --paginate "repos/$REPO/issues/$EPIC/sub_issues" --jq '.[].number'
+)
+if [ "${#all_children[@]}" -eq 0 ]; then
+  log "Epic #$EPIC has no sub-issues — nothing to drive."
+  exit 0
+fi
+
+# ── on a close event, only act if the closed issue belongs to this epic ───────
+if [ -n "$CLOSED_ISSUE" ]; then
+  in_epic=false
+  for n in "${all_children[@]}"; do
+    [ "$n" = "$CLOSED_ISSUE" ] && in_epic=true && break
+  done
+  if [ "$in_epic" != true ]; then
+    log "Closed issue #$CLOSED_ISSUE is not a sub-issue of epic #$EPIC — no-op."
+    exit 0
+  fi
+fi
+
+# ── count in-flight (released but not yet closed) ─────────────────────────────
+declare -A released
+in_flight=0
+mapfile -t open_children < <(
+  gh api --paginate "repos/$REPO/issues/$EPIC/sub_issues" \
+    --jq '.[] | select(.state=="open") | .number'
+)
+for n in "${open_children[@]}"; do
+  if has_label "$(labels_of "$n")" "$DEV_LEAD_LABEL"; then
+    released[$n]=1
+    in_flight=$((in_flight + 1))
+  fi
+done
+log "Epic #$EPIC: ${#open_children[@]} open sub-issue(s); in-flight=$in_flight; cap=$MAX_IN_FLIGHT."
+
+# ── release ready sub-issues up to the cap ────────────────────────────────────
+slots=$((MAX_IN_FLIGHT - in_flight))
+[ "$slots" -lt 0 ] && slots=0
+released_now=0
+
+for n in "${open_children[@]}"; do
+  [ "$slots" -le 0 ] && break
+  [ -n "${released[$n]:-}" ] && continue
+
+  labels="$(labels_of "$n")"
+  if has_label "$labels" "$HANDS_OFF_LABEL"; then
+    log "  #$n — skip: $HANDS_OFF_LABEL (needs a human)."
+    continue
+  fi
+  if has_label "$labels" "$HOLD_LABEL"; then
+    log "  #$n — skip: $HOLD_LABEL (held)."
+    continue
+  fi
+
+  open_blockers="$(
+    gh api "repos/$REPO/issues/$n/dependencies/blocked_by" \
+      --jq '[.[] | select(.state=="open") | .number] | join(",")'
+  )"
+  if [ -n "$open_blockers" ]; then
+    log "  #$n — blocked by open: [$open_blockers]."
+    continue
+  fi
+
+  if [ "$DRY_RUN" = "true" ]; then
+    log "  #$n — READY (dry-run, not labeling)."
+  else
+    gh issue edit "$n" --repo "$REPO" --add-label "$DEV_LEAD_LABEL" >/dev/null
+    log "  #$n — RELEASED: applied '$DEV_LEAD_LABEL'."
+  fi
+  slots=$((slots - 1))
+  released_now=$((released_now + 1))
+done
+
+log "Released this run: $released_now."

--- a/scripts/initiative-driver.sh
+++ b/scripts/initiative-driver.sh
@@ -49,18 +49,25 @@ HOLD_LABEL="${HOLD_LABEL:-initiative:hold}"
 MAX_IN_FLIGHT="${MAX_IN_FLIGHT:-2}"
 DRY_RUN="${DRY_RUN:-false}"
 
-# Validate numeric inputs before they reach arithmetic or API paths.
+# Validate and normalize inputs before they reach arithmetic or API paths.
 [[ "$EPIC" =~ ^[0-9]+$ ]] || { echo "::error::EPIC must be a positive integer, got: '$EPIC'"; exit 1; }
 [[ "$MAX_IN_FLIGHT" =~ ^[0-9]+$ ]] || { echo "::error::MAX_IN_FLIGHT must be a non-negative integer, got: '$MAX_IN_FLIGHT'"; exit 1; }
-if [ -n "$CLOSED_ISSUE" ] && ! [[ "$CLOSED_ISSUE" =~ ^[0-9]+$ ]]; then
+if [[ -n "$CLOSED_ISSUE" ]] && ! [[ "$CLOSED_ISSUE" =~ ^[0-9]+$ ]]; then
   echo "::warning::CLOSED_ISSUE is not a valid issue number ('$CLOSED_ISSUE') — treating as unset."
   CLOSED_ISSUE=""
 fi
+DRY_RUN="${DRY_RUN,,}"
+case "$DRY_RUN" in
+  true|1|yes)  DRY_RUN=true  ;;
+  false|0|no)  DRY_RUN=false ;;
+  *) echo "::error::DRY_RUN must be true or false, got: '$DRY_RUN'"; exit 1 ;;
+esac
+readonly REPO EPIC CLOSED_ISSUE DEV_LEAD_LABEL GATE_LABEL HANDS_OFF_LABEL HOLD_LABEL MAX_IN_FLIGHT DRY_RUN
 
 log() { printf '%s\n' "$*"; }
 
-# has_label <newline-separated-labels> <name> — exact fixed-string match on a label name.
-has_label() { printf '%s\n' "$1" | grep -qxF "$2"; }
+# has_label <newline-separated-labels> <name> — pure-bash exact-line match; no subprocesses.
+has_label() { [[ $'\n'"${1}"$'\n' == *$'\n'"${2}"$'\n'* ]]; }
 
 # labels_of <issue-number> — newline-separated label names.
 labels_of() {
@@ -75,21 +82,24 @@ if ! has_label "$epic_labels" "$GATE_LABEL"; then
 fi
 
 # ── enumerate sub-issues (all states) ─────────────────────────────────────────
-mapfile -t all_children < <(
-  gh api --paginate "repos/$REPO/issues/$EPIC/sub_issues" --jq '.[].number'
-)
-if [ "${#all_children[@]}" -eq 0 ]; then
+all_children_raw="$(gh api --paginate "repos/$REPO/issues/$EPIC/sub_issues" --jq '.[].number')"
+if [[ -z "$all_children_raw" ]]; then
+  all_children=()
+else
+  mapfile -t all_children <<< "$all_children_raw"
+fi
+if [[ "${#all_children[@]}" -eq 0 ]]; then
   log "Epic #$EPIC has no sub-issues — nothing to drive."
   exit 0
 fi
 
 # ── on a close event, only act if the closed issue belongs to this epic ───────
-if [ -n "$CLOSED_ISSUE" ]; then
+if [[ -n "$CLOSED_ISSUE" ]]; then
   in_epic=false
   for n in "${all_children[@]}"; do
-    [ "$n" = "$CLOSED_ISSUE" ] && in_epic=true && break
+    [[ "$n" = "$CLOSED_ISSUE" ]] && in_epic=true && break
   done
-  if [ "$in_epic" != true ]; then
+  if [[ "$in_epic" != true ]]; then
     log "Closed issue #$CLOSED_ISSUE is not a sub-issue of epic #$EPIC — no-op."
     exit 0
   fi
@@ -98,12 +108,16 @@ fi
 # ── count in-flight (released but not yet closed) ─────────────────────────────
 declare -A released
 in_flight=0
-mapfile -t open_children < <(
-  gh api --paginate "repos/$REPO/issues/$EPIC/sub_issues" \
-    --jq '.[] | select(.state=="open") | .number'
-)
+open_children_raw="$(gh api --paginate "repos/$REPO/issues/$EPIC/sub_issues" \
+    --jq '.[] | select(.state=="open") | .number')"
+if [[ -z "$open_children_raw" ]]; then
+  open_children=()
+else
+  mapfile -t open_children <<< "$open_children_raw"
+fi
 for n in "${open_children[@]}"; do
-  if has_label "$(labels_of "$n")" "$DEV_LEAD_LABEL"; then
+  n_labels="$(labels_of "$n")"
+  if has_label "$n_labels" "$DEV_LEAD_LABEL"; then
     released[$n]=1
     in_flight=$((in_flight + 1))
   fi
@@ -112,12 +126,12 @@ log "Epic #$EPIC: ${#open_children[@]} open sub-issue(s); in-flight=$in_flight; 
 
 # ── release ready sub-issues up to the cap ────────────────────────────────────
 slots=$((MAX_IN_FLIGHT - in_flight))
-[ "$slots" -lt 0 ] && slots=0
+[[ "$slots" -lt 0 ]] && slots=0
 released_now=0
 
 for n in "${open_children[@]}"; do
-  [ "$slots" -le 0 ] && break
-  [ -n "${released[$n]:-}" ] && continue
+  [[ "$slots" -le 0 ]] && break
+  [[ -n "${released[$n]:-}" ]] && continue
 
   labels="$(labels_of "$n")"
   if has_label "$labels" "$HANDS_OFF_LABEL"; then
@@ -133,12 +147,12 @@ for n in "${open_children[@]}"; do
     gh api "repos/$REPO/issues/$n/dependencies/blocked_by" \
       --jq '[.[] | select(.state=="open") | .number] | join(",")'
   )"
-  if [ -n "$open_blockers" ]; then
+  if [[ -n "$open_blockers" ]]; then
     log "  #$n — blocked by open: [$open_blockers]."
     continue
   fi
 
-  if [ "$DRY_RUN" = "true" ]; then
+  if [[ "$DRY_RUN" = "true" ]]; then
     log "  #$n — READY (dry-run, not labeling)."
   else
     gh issue edit "$n" --repo "$REPO" --add-label "$DEV_LEAD_LABEL" >/dev/null

--- a/scripts/initiative-driver.sh
+++ b/scripts/initiative-driver.sh
@@ -59,12 +59,12 @@ fi
 
 log() { printf '%s\n' "$*"; }
 
-# has_label <comma-separated-labels> <name> — exact match on a label name.
-has_label() { printf '%s' "$1" | tr ',' '\n' | grep -qx "$2"; }
+# has_label <newline-separated-labels> <name> — exact fixed-string match on a label name.
+has_label() { printf '%s\n' "$1" | grep -qxF "$2"; }
 
-# labels_of <issue-number> — comma-joined label names.
+# labels_of <issue-number> — newline-separated label names.
 labels_of() {
-  gh api "repos/$REPO/issues/$1" --jq '[.labels[].name] | join(",")'
+  gh api "repos/$REPO/issues/$1" --jq '.labels[].name'
 }
 
 # ── gate: the epic must opt in ────────────────────────────────────────────────

--- a/tests/test_initiative_driver.bats
+++ b/tests/test_initiative_driver.bats
@@ -1,0 +1,167 @@
+#!/usr/bin/env bats
+# Unit tests for scripts/initiative-driver.sh
+# Covers has_label regex safety, gate label, MAX_IN_FLIGHT cap, and blocked_by evaluation.
+# Mocks the gh CLI to avoid network calls.
+#
+# Run with: bats tests/test_initiative_driver.bats
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/initiative-driver.sh"
+
+setup() {
+  MOCK_BIN="$(mktemp -d)"
+  GH_LOG="$(mktemp)"
+  export GH_LOG
+  export PATH="$MOCK_BIN:$PATH"
+  export REPO="owner/repo"
+  export EPIC="1"
+  export CLOSED_ISSUE=""
+  export DRY_RUN="false"
+  export MAX_IN_FLIGHT="2"
+  export GH_TOKEN="tok"
+}
+
+teardown() {
+  rm -rf "${MOCK_BIN:-}"
+  rm -f "${GH_LOG:-}"
+}
+
+# ── has_label: fixed-string matching ─────────────────────────────────────────
+
+@test "has_label matches an exact label name" {
+  has_label() { printf '%s\n' "$1" | grep -qxF "$2"; }
+  run has_label $'initiative:auto\nother-label' 'initiative:auto'
+  [ "$status" -eq 0 ]
+}
+
+@test "has_label with -F does not match regex dot against a different label" {
+  # Before the fix, grep -qx 'a.b' would match 'axb' (dot = any char in regex).
+  # With -F the pattern is literal, so 'a.b' must not match 'axb'.
+  has_label() { printf '%s\n' "$1" | grep -qxF "$2"; }
+  run has_label $'axb\nother' 'a.b'
+  [ "$status" -ne 0 ]
+}
+
+@test "has_label returns non-zero when label is absent" {
+  has_label() { printf '%s\n' "$1" | grep -qxF "$2"; }
+  run has_label $'foo\nbar' 'not-present'
+  [ "$status" -ne 0 ]
+}
+
+# ── gate: epic must carry initiative:auto ────────────────────────────────────
+
+@test "gate: exits 0 with no-op when epic lacks initiative:auto" {
+  cat > "$MOCK_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_LOG"
+# labels_of epic: return empty (no labels)
+if [[ "$*" == *"issues/1 --jq"* ]]; then printf ''; exit 0; fi
+printf '[]'
+EOF
+  chmod +x "$MOCK_BIN/gh"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no-op"* ]]
+  ! grep -qF "issue edit" "$GH_LOG"
+}
+
+@test "gate: proceeds past gate when epic carries initiative:auto" {
+  cat > "$MOCK_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_LOG"
+# Epic labels: initiative:auto
+if [[ "$*" == *"issues/1 --jq"* ]] && [[ "$*" != *"sub_issues"* ]]; then
+  printf 'initiative:auto'; exit 0
+fi
+# No sub-issues
+if [[ "$*" == *"sub_issues"* ]]; then printf ''; exit 0; fi
+printf '[]'
+EOF
+  chmod +x "$MOCK_BIN/gh"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no sub-issues"* ]]
+}
+
+# ── MAX_IN_FLIGHT cap ─────────────────────────────────────────────────────────
+
+@test "cap: does not label new issues when in-flight equals MAX_IN_FLIGHT" {
+  export MAX_IN_FLIGHT="2"
+  cat > "$MOCK_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_LOG"
+args="$*"
+# Epic labels: initiative:auto
+if [[ "$args" == *"issues/1 --jq"* ]] && [[ "$args" != *"sub_issues"* ]]; then
+  printf 'initiative:auto'; exit 0
+fi
+# Sub-issues (all states and open): issues 2 and 3
+if [[ "$args" == *"sub_issues"* ]]; then printf '2\n3'; exit 0; fi
+# Both issues already carry dev-lead (in-flight = 2)
+if [[ "$args" == *"issues/2 --jq"* ]] || [[ "$args" == *"issues/3 --jq"* ]]; then
+  printf 'dev-lead'; exit 0
+fi
+printf '[]'
+EOF
+  chmod +x "$MOCK_BIN/gh"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"in-flight=2"* ]]
+  ! grep -qF "issue edit" "$GH_LOG"
+}
+
+# ── blocked_by evaluation ─────────────────────────────────────────────────────
+
+@test "blocked_by: does not label an issue that has an open blocker" {
+  cat > "$MOCK_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_LOG"
+args="$*"
+# Epic labels: initiative:auto
+if [[ "$args" == *"issues/1 --jq"* ]] && [[ "$args" != *"sub_issues"* ]]; then
+  printf 'initiative:auto'; exit 0
+fi
+# Sub-issues: only issue 2
+if [[ "$args" == *"sub_issues"* ]]; then printf '2'; exit 0; fi
+# Issue 2 has no dev-lead yet
+if [[ "$args" == *"issues/2 --jq"* ]]; then printf ''; exit 0; fi
+# Issue 2 has an open blocker (issue 99)
+if [[ "$args" == *"issues/2/dependencies/blocked_by"* ]]; then printf '99'; exit 0; fi
+printf '[]'
+EOF
+  chmod +x "$MOCK_BIN/gh"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"blocked by open"* ]]
+  ! grep -qF "issue edit" "$GH_LOG"
+}
+
+@test "blocked_by: labels a sub-issue when all blockers are closed" {
+  cat > "$MOCK_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_LOG"
+args="$*"
+# Epic labels: initiative:auto
+if [[ "$args" == *"issues/1 --jq"* ]] && [[ "$args" != *"sub_issues"* ]]; then
+  printf 'initiative:auto'; exit 0
+fi
+# Sub-issues: only issue 2
+if [[ "$args" == *"sub_issues"* ]]; then printf '2'; exit 0; fi
+# Issue 2 has no dev-lead yet
+if [[ "$args" == *"issues/2 --jq"* ]]; then printf ''; exit 0; fi
+# No open blockers
+if [[ "$args" == *"issues/2/dependencies/blocked_by"* ]]; then printf ''; exit 0; fi
+# Label application succeeds
+if [[ "$args" == "issue edit"* ]]; then exit 0; fi
+printf '[]'
+EOF
+  chmod +x "$MOCK_BIN/gh"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"RELEASED"* ]]
+  grep -qF "issue edit" "$GH_LOG"
+}


### PR DESCRIPTION
## What

Adds an **orchestration layer** that delivers an initiative epic's child issues through the existing
**per-item dev-lead agent** in dependency order — without modifying dev-lead itself.

- `scripts/initiative-driver.sh` — reads an epic's native **"blocked by"** edges and applies the
  `dev-lead` label to each OPEN sub-issue whose blockers are all closed, bounded by `MAX_IN_FLIGHT`.
- `.github/workflows/initiative-driver.yml` — runs on `issues:[closed]` (merge → close → unblock →
  label → next pickup), a safety-net cron, and `workflow_dispatch`.
- `docs/initiatives/agentic-release-strategy-orchestration.md` — model, DAG/waves, gates, the
  human→agent bootstrap order, and an operator runbook.

Companion to #504 (the analysis). Dependency edges for epic #495's children (#496–#506) are already
set as native GitHub "blocked by" relationships.

## Why

Dev-lead is reactive and per-item (triggers only on the `dev-lead` label). Coordinating a multi-issue
initiative = deciding **when** that label is applied to each ready issue. This driver makes that
decision from the dependency graph, so a merge automatically releases the now-unblocked successors.

## Safety design

- **Gated off by default:** the driver no-ops unless the **epic** carries `initiative:auto`, so
  **Phase 1 stays human-driven** (you arm Phase 2 by adding that label once `@stable` exists).
- Skips `dev-lead:hands-off` and `initiative:hold` issues (need a human).
- `MAX_IN_FLIGHT` (default 2) caps parallel token cost / blast radius.
- **PAT requirement:** applies the label via `GH_PAT_WORKFLOWS` — a `GITHUB_TOKEN`-applied label does
  **not** trigger dev-lead (GitHub loop-prevention; same class as #463). Workflow fails fast if absent.

## Validation

- `shellcheck scripts/initiative-driver.sh` — clean.
- Dry-run against the live DAG: releases only **#496** (no blockers); correctly holds the other 9.
- Default `initiative:auto` gate: no-ops as intended (epic not yet armed).
- `markdownlint-cli2` — clean.

## Follow-ups (noted in the doc, not in this PR)

- A bats test mocking `gh` for the gate/blocker/cap logic.
- Generalize the hard-coded `EPIC=495` default if a second initiative adopts the driver.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated initiative release orchestration with dependency-aware task assignment.
  * Supports manual triggers, scheduled runs, and automatic activation on issue closure.
  * Includes safety gates, hold mechanisms, and in-flight limits for controlled rollout.

* **Documentation**
  * Added comprehensive guide for release orchestration strategy and operational procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->