### PR TITLE
feat(pr-review): agent_ref input for pinned self-checkout (#497/#506)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -2,6 +2,18 @@ name: PR Review Agent
 
 on:
   workflow_call:
+    inputs:
+      agent_ref:
+        # The .github-private ref to check out for the agent's own scripts
+        # (engine.sh, review-one-pr.sh, …). A trigger-stub caller passes its
+        # pinned channel (e.g. pr-review/stable) so the SCRIPTS run at the
+        # pinned version, not the caller's branch — closing the reusable
+        # self-ref gap (#506). Empty (the default) preserves the historical
+        # behaviour exactly: actions/checkout treats an empty ref as "default".
+        description: "Ref of petry-projects/.github-private to check out for agent scripts"
+        type: string
+        required: false
+        default: ""
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         required: false
@@ -182,6 +194,11 @@ jobs:
     steps:
       - name: Checkout agent repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Empty agent_ref => default checkout (unchanged behaviour). A pinned
+          # channel (e.g. pr-review/stable) makes the agent's own scripts run at
+          # that version regardless of which branch triggered the run (#506).
+          ref: ${{ inputs.agent_ref }}
 
       - name: Cache claude-code CLI
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5


### PR DESCRIPTION
Backward-compatible foundation for #497 self-host pinning (with #506's script-ref fix folded in). Adds a workflow_call input `agent_ref` threaded into the agent-repo checkout. Empty default == current behaviour exactly (actions/checkout treats empty ref as default) — no trigger/behaviour change. Lets the forthcoming trigger-stub pass `pr-review/stable` so scripts run pinned (#506). Next: stub + reusable-only flip, dev-lead, then 4 consumers. Part of #497 · epic #495.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration to support flexible agent script sourcing, improving deployment consistency and flexibility for continuous integration processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->