### PR TITLE
feat(pr-review): workflow_call inputs for trigger-stub forwarding (#497)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -14,6 +14,24 @@ on:
         type: string
         required: false
         default: ""
+      # Mirror the workflow_dispatch inputs as workflow_call inputs so a trigger
+      # stub can forward them. The job's env block already reads `inputs.*`;
+      # these resolve from whichever trigger fired (dispatch or call).
+      pr_url:
+        description: "Optional: review a single PR URL instead of enumerating"
+        type: string
+        required: false
+        default: ""
+      dry_run:
+        description: "If true, never submit reviews or comments"
+        type: string
+        required: false
+        default: ""
+      force_review:
+        description: "If true, bypass idempotency and re-review at the same head SHA"
+        type: string
+        required: false
+        default: ""
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         required: false


### PR DESCRIPTION
Adds `pr_url`/`dry_run`/`force_review` as `workflow_call` inputs (alongside `agent_ref`) so the trigger stub can forward them to `pr-review.yml@pr-review/stable` without an input-mismatch. Triggers + behaviour unchanged (job env already reads `inputs.*`). Zero-gap step before the reusable-only flip. Part of #497 · epic #495.