### PR TITLE
feat(pr-review): self-host pin via trigger stub — reusable-only (#497/#506)

### DIFF
--- a/.github/workflows/pr-review-trigger.yml
+++ b/.github/workflows/pr-review-trigger.yml
@@ -1,0 +1,65 @@
+name: PR Review Agent — Trigger
+
+# Thin trigger stub for .github-private's OWN pr-review duty (ring 0 / self-host).
+#
+# It fires on the review events and invokes the reusable pinned to
+# `pr-review.yml@pr-review/stable`, passing `agent_ref: pr-review/stable` so the
+# agent's scripts (engine.sh, review-one-pr.sh, …) also run at the pinned
+# version. The result: this repo's PRs are always reviewed by the known-good
+# `stable` release, independent of whatever pr-review.yml is on the branch under
+# review — which is what breaks the self-hosting circular dependency (#497).
+#
+# pr-review.yml itself is reusable-only; this stub owns the triggering. The
+# @mention flow (pr-review-mention.yml -> org reusable -> repository_dispatch)
+# still lands on the repository_dispatch trigger below.
+#
+# To promote a new pr-review version, move the pr-review/stable channel tag
+# (scripts/cut-release.sh … --channel stable). This file never changes.
+
+on:
+  check_suite:
+    types: [completed]
+  pull_request_review:
+    types: [submitted, dismissed]
+  pull_request:
+    types: [ready_for_review, reopened, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr_url:
+        description: "Optional: review a single PR URL instead of enumerating"
+        required: false
+        type: string
+      dry_run:
+        description: "If true, never submit reviews or comments"
+        required: false
+        default: "false"
+        type: string
+      force_review:
+        description: "If true, bypass idempotency and re-review at the same head SHA"
+        required: false
+        default: "false"
+        type: string
+  repository_dispatch:
+    # Triggered by the petry-projects/.github mention-listener (via
+    # pr-review-mention.yml). Payload: { pr_url, force_review }.
+    types: [pr-review-mention]
+
+# Granted to the called reusable's job (a reusable can be granted no more than
+# the calling job has). Mirrors pr-review.yml's own permissions block.
+permissions:
+  contents: read
+  pull-requests: write
+  checks: read
+
+jobs:
+  review:
+    uses: petry-projects/.github-private/.github/workflows/pr-review.yml@pr-review/stable
+    with:
+      # Pin the agent's own script checkout to the same channel (#506).
+      agent_ref: pr-review/stable
+      # Forward manual/dispatch inputs; empty for event triggers (the reusable
+      # then derives everything from the inherited github.event context).
+      pr_url: ${{ inputs.pr_url || '' }}
+      dry_run: ${{ inputs.dry_run || '' }}
+      force_review: ${{ inputs.force_review || '' }}
+    secrets: inherit

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -44,63 +44,16 @@ on:
       GH_PAT:
         required: false
 
-  # ── Event-driven triggers ────────────────────────────────────────────────
-  # These replace the former time-based schedule. The review engine's own
-  # idempotency check (head-SHA marker) prevents duplicate reviews, so
-  # firing multiple times on the same PR is always safe.
-  #
-  # Coverage note: these events are scoped to this repo (.github-private).
-  # For org-wide event-driven triggering (broodly, markets, etc.), deploy
-  # a thin pr-review-auto-trigger.yml caller stub to each repo (Phase 2).
-
-  check_suite:
-    # Fires when a CI check suite completes on any branch in this repo.
-    # We only act when the suite succeeded (failing/pending PRs are already
-    # skipped by review-one-pr.sh's CI gate, but filtering here avoids
-    # spinning up a runner at all). Empty pull_requests arrays (e.g. pushes
-    # to main) are dropped in the job condition below.
-    types: [completed]
-
-  pull_request_review:
-    # Fires when a reviewer submits a review or dismisses one.
-    #   submitted  — covers APPROVED (green light) and CHANGES_REQUESTED
-    #                (agent will skip via its own gate, but APPROVED is the
-    #                common case that unlocks a previously-blocked PR).
-    #   dismissed  — a CHANGES_REQUESTED review was dismissed, clearing the
-    #                block so the agent can re-engage with the updated code.
-    types: [submitted, dismissed]
-
-  pull_request:
-    # ready_for_review — draft PR promoted to open (ready for first review).
-    # reopened          — closed PR is reopened (e.g. after revision).
-    # synchronize       — new commits pushed (author addressed review comments);
-    #                     CI will be pending immediately, so review-one-pr.sh
-    #                     skips cheaply — the check_suite trigger fires once CI
-    #                     settles and is the real wake signal post-push.
-    types: [ready_for_review, reopened, synchronize]
-
-  # ── Manual / programmatic triggers ──────────────────────────────────────
-  workflow_dispatch:
-    inputs:
-      pr_url:
-        description: "Optional: review a single PR URL instead of enumerating"
-        required: false
-        type: string
-      dry_run:
-        description: "If true, never submit reviews or comments"
-        required: false
-        default: "false"
-        type: string
-      force_review:
-        description: "If true, bypass idempotency check and re-review even if already reviewed at head SHA (use for @mention-triggered reviews)"
-        required: false
-        default: "false"
-        type: string
-  repository_dispatch:
-    # Triggered by the petry-projects/.github mention-listener workflow.
-    # Requires only Contents: write on this repo (not Actions: write).
-    # Payload: { pr_url: "https://github.com/...", force_review: "true" }
-    types: [pr-review-mention]
+  # ── Reusable-only (#497 self-host pinning) ───────────────────────────────
+  # Event-driven triggering now lives in the thin caller `pr-review-trigger.yml`,
+  # which invokes this workflow pinned to `pr-review.yml@pr-review/stable` and
+  # passes `agent_ref: pr-review/stable` so the agent's own scripts run at the
+  # pinned version too. Keeping this file reusable-only is what lets
+  # .github-private's OWN PR reviews run the known-good `stable` release — not
+  # whatever is on the branch under review — which is what breaks the
+  # self-hosting circular dependency. The job below still reads `github.event.*`
+  # (inherited from the caller's triggering event) and `inputs.*` (forwarded by
+  # the stub), so its behaviour is unchanged.
 
 permissions:
   contents: read

--- a/scripts/pr_review_health.sh
+++ b/scripts/pr_review_health.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 
 LOOKBACK_DAYS="${LOOKBACK_DAYS:-1}"
 WORKFLOW_REPO="${AGENT_REPO:-petry-projects/.github-private}"
-WORKFLOW_FILE="pr-review.yml"
+WORKFLOW_FILE="pr-review-trigger.yml"
 REPORT_FILE="pr_review_health_report.md"
 LOG_DIR="health_run_logs"
 TODAY=$(date -u +%Y-%m-%d)


### PR DESCRIPTION
**The ring-0 self-host pin.** Flips .github-private's own pr-review to run the pinned `pr-review/stable` version, breaking the self-hosting circular dependency.

- `pr-review.yml` → **reusable-only** (event triggers removed; job logic unchanged — reads inherited `github.event.*` + forwarded `inputs.*`).
- **`pr-review-trigger.yml`** (new stub) → carries the triggers, calls `pr-review.yml@pr-review/stable` with `agent_ref: pr-review/stable` so workflow **and** scripts (#506) run pinned.

Squash-merge flips both **atomically** (no review-coverage gap). Mention flow preserved (repository_dispatch). After merge I'll validate the stub fires + reviews at `@stable`, and revert if not. Part of #497 · epic #495.