### PR TITLE
fix(pr-review): classic PAT for approvals w/ fine-grained fallback (#497)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -41,6 +41,11 @@ on:
         required: false
       DON_PETRY_BOT_GH_PAT:
         required: false
+      # Classic PAT for the bot. Required for `gh pr review --approve`
+      # (addPullRequestReview), which fails for fine-grained PATs. Preferred
+      # over DON_PETRY_BOT_GH_PAT when set; see docs/pr-review-agent/machine-user-setup.md.
+      DON_PETRY_BOT_GH_PAT_CLASSIC:
+        required: false
       GH_PAT:
         required: false
 
@@ -106,7 +111,10 @@ jobs:
        github.event.review.state == 'dismissed')
     env:
       # Auth for every gh / script call in this job. The PAT must belong to BOT_USER.
-      GH_TOKEN: ${{ secrets.DON_PETRY_BOT_GH_PAT }}
+      # Prefer the CLASSIC PAT (required for `gh pr review --approve` —
+      # fine-grained PATs fail addPullRequestReview), falling back to the
+      # fine-grained DON_PETRY_BOT_GH_PAT when the classic secret is unset.
+      GH_TOKEN: ${{ secrets.DON_PETRY_BOT_GH_PAT_CLASSIC || secrets.DON_PETRY_BOT_GH_PAT }}
       # Single bot identity. DON_PETRY_BOT_GH_PAT authenticates as BOT_USER; that
       # account owns/has-access-to the personal repos scanned by list-prs.sh,
       # signs the cascade's escalation comments, and is filtered out of the

--- a/.github/workflows/repair-pr-approvals.yml
+++ b/.github/workflows/repair-pr-approvals.yml
@@ -22,5 +22,7 @@ jobs:
 
       - name: Repair PR approvals
         env:
-          GH_TOKEN: ${{ secrets.DON_PETRY_BOT_GH_PAT }}
+          # Prefer the classic PAT (approvals need addPullRequestReview, which
+          # fails for fine-grained PATs); fall back to fine-grained if unset.
+          GH_TOKEN: ${{ secrets.DON_PETRY_BOT_GH_PAT_CLASSIC || secrets.DON_PETRY_BOT_GH_PAT }}
         run: bash scripts/repair-pr-approvals.sh "${{ inputs.dry_run }}"

--- a/docs/pr-review-agent/machine-user-setup.md
+++ b/docs/pr-review-agent/machine-user-setup.md
@@ -22,6 +22,15 @@ the bot is in the team listed in `CODEOWNERS`.
 > `repo` scope work; fine-grained ones do not. If you ever see the error above
 > in a workflow log, the secret is holding a fine-grained token — generate a
 > classic one and replace it.
+>
+> **Dual-secret setup (current):** the approval-path workflows read
+> `${{ secrets.DON_PETRY_BOT_GH_PAT_CLASSIC || secrets.DON_PETRY_BOT_GH_PAT }}` —
+> i.e. they **prefer the classic PAT** in `DON_PETRY_BOT_GH_PAT_CLASSIC` (scopes
+> `repo`, `workflow`, `read:org`) and fall back to the fine-grained
+> `DON_PETRY_BOT_GH_PAT` only if it is unset. This lets the bot keep a
+> least-privilege fine-grained token for read/scan workflows while using the
+> classic token solely where `addPullRequestReview` requires it. To enable
+> approvals, set `DON_PETRY_BOT_GH_PAT_CLASSIC`.
 
 ## Why a machine user
 


### PR DESCRIPTION
Fixes the root cause found during ring-0 validation: the bot's review job died at `verify-auth-scopes` because `DON_PETRY_BOT_GH_PAT` is a **fine-grained** PAT, which cannot `gh pr review --approve` (`addPullRequestReview`) — so the agent never approved at green CI (the stuck-PR root cause).

**Change:** approval-path workflows now read `${{ secrets.DON_PETRY_BOT_GH_PAT_CLASSIC || secrets.DON_PETRY_BOT_GH_PAT }}` — prefer the classic PAT, fall back to fine-grained. Keeps the least-privilege FG token for read/scan workflows; uses classic only where approval requires it.
- `pr-review.yml`: declare `DON_PETRY_BOT_GH_PAT_CLASSIC` (workflow_call secret) + GH_TOKEN prefers it
- `repair-pr-approvals.yml`: same fallback
- `machine-user-setup.md`: document the dual-secret setup

`DON_PETRY_BOT_GH_PAT_CLASSIC` is set as an org secret (classic, repo/workflow/read:org). After merge I'll cut `pr-review/v1.3.0`, move `stable`, and re-validate ring 0. Part of #497 · epic #495.