### PR TITLE
fix(ci-status): filter nested 'review / review' own-check (#497/#469)

### DIFF
--- a/scripts/lib/ci-status.sh
+++ b/scripts/lib/ci-status.sh
@@ -30,6 +30,11 @@
 #   to race an in-progress branch-mutating run.
 #   Matched:
 #   • Bare job name: "review"
+#   • Nested job form "review / review" — produced once the cascade is invoked
+#     via the trigger stub (pr-review-trigger.yml → reusable pr-review.yml@
+#     pr-review/stable), where the rollup name becomes "callerJob / reusableJob"
+#     rather than the bare job name (#497 self-host). Matched exactly (not by a
+#     "/ review" suffix) so a genuine external "Build / review" is NOT filtered.
 #   • "PR Review Agent / *"
 #   • "PR Review Reusable / *"
 #   • "PR Review — Mention Trigger / *"
@@ -46,6 +51,7 @@ compute_ci_status() {
     def is_own_check:
       (.name // .context // "") as $n |
       ($n == "review") or
+      ($n == "review / review") or
       ($n | test("^PR Review (Agent|Reusable) /")) or
       ($n | test("^PR Review — Mention Trigger /"));
     if (. == null or (type != "array")) then "passing"

--- a/tests/test_ci_status.bats
+++ b/tests/test_ci_status.bats
@@ -164,6 +164,30 @@ rollup() {
   [ "$output" = "passing" ]
 }
 
+# #497 self-host: invoked via the trigger stub, the cascade's own check appears
+# as the nested "review / review" — must still be filtered so a stale/failed own
+# check never blocks the agent from re-reviewing.
+@test "nested 'review / review' (FAILURE) is filtered out → passing" {
+  local r
+  r=$(rollup "$(check_run "review / review" "COMPLETED" "FAILURE")")
+  run compute_ci_status "$r"
+  [ "$output" = "passing" ]
+}
+
+@test "nested 'review / review' FAILURE alongside an external pass → passing" {
+  local r
+  r=$(rollup "$(check_run "review / review" "COMPLETED" "FAILURE")" "$(check_run "SonarCloud" "COMPLETED" "SUCCESS")")
+  run compute_ci_status "$r"
+  [ "$output" = "passing" ]
+}
+
+@test "a genuinely external failing check still → failing (regression guard)" {
+  local r
+  r=$(rollup "$(check_run "review / review" "COMPLETED" "FAILURE")" "$(check_run "SonarCloud" "COMPLETED" "FAILURE")")
+  run compute_ci_status "$r"
+  [ "$output" = "failing" ]
+}
+
 # ---------------------------------------------------------------------------
 # Dev-lead and generic workflow/job-suffix checks are NOT filtered
 # Dev-lead can commit back to the PR branch, so it must remain a real CI gate.


### PR DESCRIPTION
**Second-order fix from ring-0 validation.** After the self-host flip, the agent's own check appears as the nested `review / review` (stub → reusable), which the #469 own-check filter (bare `review` only) missed. A stale failed own-check therefore classified clean PRs as `ci-failing`, so the agent skipped its entire approval backlog and never re-reviewed.

Fix: match `review / review` **exactly** (not a `/ review` suffix — that would wrongly filter a real external `Build / review`). +3 regression tests; existing external-check guard still green (35/35 bats).

After merge: cut `pr-review/v1.4.0`, move `stable`, re-validate that the agent now reviews+approves the backlog. Part of #497 · epic #495.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CI status computation to correctly classify certain check types in the review workflow.

* **Tests**
  * Added test coverage for CI status computation with various job configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->