### PR TITLE
fix(pr-review): checkout agent repo explicitly for consumer callers (#536)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -174,10 +174,14 @@ jobs:
       - name: Checkout agent repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          # Empty agent_ref => default checkout (unchanged behaviour). A pinned
-          # channel (e.g. pr-review/stable) makes the agent's own scripts run at
-          # that version regardless of which branch triggered the run (#506).
-          ref: ${{ inputs.agent_ref }}
+          # Always check out the AGENT repo (.github-private) for the scripts —
+          # NOT the caller's repo. When invoked from a consumer (e.g. markets),
+          # the default checkout would clone the consumer at `agent_ref`, which
+          # has no such ref → failure. .github-private is public, so the default
+          # token can read it. `agent_ref` (e.g. pr-review/stable) pins the
+          # scripts to the known-good channel; empty defaults to main (#506/#536).
+          repository: petry-projects/.github-private
+          ref: ${{ inputs.agent_ref || 'main' }}
 
       - name: Cache claude-code CLI
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5


### PR DESCRIPTION
**Caught by ring-1 (markets).** The reusable's 'Checkout agent repo' step had `ref: agent_ref` but no `repository:`, so it cloned the **caller's** repo — fine for self-host (caller is .github-private), but for a consumer (markets) it tried `markets@pr-review/stable` (no such ref) → checkout failure.

Fix: `repository: petry-projects/.github-private` (public → default token reads it) + `ref: agent_ref || 'main'`. Scripts always come from the agent repo; review-one-pr.sh uses the gh API, no target checkout needed. No self-host change.

After merge: cut `pr-review/v1.5.0`, move `stable`, re-validate markets#261. Part of #536 · #497 · epic #495.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration to improve default branch handling for agent scripts during pull request reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->