### PR TITLE
fix(ci-status): filter own-checks by workflowName (consumer formats) (#536)

### DIFF
--- a/scripts/lib/ci-status.sh
+++ b/scripts/lib/ci-status.sh
@@ -50,6 +50,14 @@ compute_ci_status() {
       .state == "SUCCESS";
     def is_own_check:
       (.name // .context // "") as $n |
+      (.workflowName // "") as $wf |
+      # Primary, robust signal: any check produced by a PR Review cascade
+      # workflow (PR Review Agent, the Trigger stub, PR Review Reusable, the
+      # Mention Trigger), regardless of the job-name format the rollup reports
+      # (#536: a consumer old check "pr-review / review" had workflowName
+      # "PR Review Agent"). Falls back to name patterns when the rollup does
+      # not expose workflowName.
+      ($wf | test("^PR Review")) or
       ($n == "review") or
       ($n == "review / review") or
       ($n | test("^PR Review (Agent|Reusable) /")) or

--- a/tests/test_ci_status.bats
+++ b/tests/test_ci_status.bats
@@ -25,6 +25,19 @@ check_run() {
   fi
 }
 
+# check_run_wf <name> <workflowName> <status> [conclusion]
+# Models a CheckRun that also carries a workflowName (as the real rollup does).
+check_run_wf() {
+  local name="$1" wf="$2" status="$3" conclusion="${4:-null}"
+  if [ "$conclusion" = "null" ]; then
+    jq -n --arg name "$name" --arg wf "$wf" --arg status "$status" \
+      '{name: $name, workflowName: $wf, status: $status, conclusion: null}'
+  else
+    jq -n --arg name "$name" --arg wf "$wf" --arg status "$status" --arg conclusion "$conclusion" \
+      '{name: $name, workflowName: $wf, status: $status, conclusion: $conclusion}'
+  fi
+}
+
 # status_ctx <context> <state>
 # Models a commit StatusContext in the statusCheckRollup array.
 status_ctx() {
@@ -184,6 +197,23 @@ rollup() {
 @test "a genuinely external failing check still → failing (regression guard)" {
   local r
   r=$(rollup "$(check_run "review / review" "COMPLETED" "FAILURE")" "$(check_run "SonarCloud" "COMPLETED" "FAILURE")")
+  run compute_ci_status "$r"
+  [ "$output" = "failing" ]
+}
+
+# #536 consumer fan-out: a consumer's OLD pr-review check appears as
+# "pr-review / review" with workflowName "PR Review Agent" — filtered by
+# workflowName so a stale failed own-check doesn't block re-review.
+@test "consumer 'pr-review / review' (workflowName PR Review Agent, FAILURE) is filtered → passing" {
+  local r
+  r=$(rollup "$(check_run_wf "pr-review / review" "PR Review Agent" "COMPLETED" "FAILURE")")
+  run compute_ci_status "$r"
+  [ "$output" = "passing" ]
+}
+
+@test "workflowName filter does NOT swallow an external failing check" {
+  local r
+  r=$(rollup "$(check_run_wf "pr-review / review" "PR Review Agent" "COMPLETED" "FAILURE")" "$(check_run_wf "Backend CI" "Backend CI" "COMPLETED" "FAILURE")")
   run compute_ci_status "$r"
   [ "$output" = "failing" ]
 }


### PR DESCRIPTION
Ring-1 (markets) found that a consumer's **old** pr-review check is named `pr-review / review` with `workflowName: PR Review Agent` — the job-name filter missed it, so a stale failed own-check made the agent skip clean consumer PRs as `ci-failing`.

Fix: filter any check whose **`workflowName` starts with `PR Review`** (the cascade workflows) — robust to any job-name format. Falls back to name patterns when workflowName is absent (unit tests), preserving the external `Build / review` guard. +2 tests (37/37). Promote via pr-review/stable. Part of #536.