### PR TITLE
fix(pr-review): stop cancelling racing same-PR review runs (#534)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -88,7 +88,18 @@ concurrency:
            || github.event.check_suite.pull_requests[0].url)
       || 'pr-review-batch'
     }}
-  cancel-in-progress: true
+  # cancel-in-progress is intentionally FALSE (#534). The per-PR group means
+  # the four trigger event types (check_suite, pull_request,
+  # pull_request_review, repository_dispatch) all land in the same slot for a
+  # given PR; with cancellation on, each new event killed the in-flight review,
+  # so reviews never completed and left a trail of `cancelled` check runs (the
+  # long-standing ~34% cancel rate). Same-head-SHA reviews are idempotent — the
+  # agent's marker makes a redundant run a fast no-op — so racing runs are safe
+  # to QUEUE rather than cancel: the first reviews, the rest no-op. No lost work,
+  # no cancelled-check noise. (Future refinement: key the group by head SHA so a
+  # new push doesn't queue behind a now-stale review; deferred because the SHA
+  # isn't in every trigger payload, e.g. workflow_dispatch's pr_url.)
+  cancel-in-progress: false
 
 jobs:
   review:


### PR DESCRIPTION
## Problem (#534)
`pr-review.yml`'s per-PR concurrency group used `cancel-in-progress: true`. All four trigger event types (`check_suite`, `pull_request`, `pull_request_review`, `repository_dispatch`) for a given PR share that one slot, so each new event **killed the in-flight review**. Reviews frequently never completed, producing the long-standing **~34% cancel rate** and a trail of `cancelled` check runs — which *also* tripped the agent's own CI gate (it counts cancelled non-required checks as ci-failing), blocking self-approval.

## Fix
Set `cancel-in-progress: false`. Same-head-SHA reviews are **idempotent** — the agent's marker makes a redundant run a fast no-op — so racing runs are safe to **queue** rather than cancel: the first reviews, the rest no-op. No lost work, no cancelled-check noise.

## Notes
- `dev-lead-reusable.yml` already uses `cancel-in-progress: false`, so this is the last cancel-thrash source.
- Future refinement (deferred): key the group by head SHA so a new push doesn't queue behind a now-stale review — the SHA isn't in every trigger payload (e.g. `workflow_dispatch`'s `pr_url`), so it needs more care.
- This is a change to the versioned reusable; it reaches consumers only after a release is cut and `pr-review/stable` is moved (dogfooded on ring-0 first).

Closes #534.

🤖 Generated with [Claude Code](https://claude.com/claude-code)