### PR TITLE
fix(dev-lead): self-host pin to @dev-lead/stable + agent_ref (#535)

### DIFF
--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -43,7 +43,14 @@ jobs:
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@main
+    # Self-host pin (#535/#506): run the known-good dev-lead/stable channel, not
+    # @main, so a broken change to dev-lead on main can no longer gate its own
+    # fix (the circular dependency). Promotion = moving the dev-lead/stable tag
+    # centrally; this caller is never edited on release. agent_ref pins the
+    # dev-lead scripts/prompts checkout to the same channel.
+    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable
+    with:
+      agent_ref: dev-lead/stable
     secrets: inherit
     permissions:
       contents: write

--- a/tests/dev-lead/integration/test_dev_lead_stub.sh
+++ b/tests/dev-lead/integration/test_dev_lead_stub.sh
@@ -22,12 +22,14 @@ if [ ! -f "$WORKFLOW" ]; then
   exit 1
 fi
 
-# 2. Must contain a `uses:` line that calls dev-lead-reusable.yml@main.
-#    This is the structural signature of a thin caller stub.
-if grep -qF 'dev-lead-reusable.yml@main' "$WORKFLOW"; then
-  pass "dev-lead.yml delegates to dev-lead-reusable.yml@main"
+# 2. Must contain a `uses:` line that calls dev-lead-reusable.yml at some ref.
+#    Accepted: @main or a first-party channel tag (@dev-lead/stable, etc.).
+#    See AGENTS.md §"Release channel tags & the mutable-ref exception".
+if grep -qE 'dev-lead-reusable\.yml@\S+' "$WORKFLOW"; then
+  ref=$(grep -oE 'dev-lead-reusable\.yml@\S+' "$WORKFLOW" | head -1)
+  pass "dev-lead.yml delegates to ${ref} (thin caller stub)"
 else
-  fail "dev-lead.yml does not call dev-lead-reusable.yml@main — it must be a thin caller stub"
+  fail "dev-lead.yml does not call dev-lead-reusable.yml — it must be a thin caller stub delegating to @main or a channel tag"
 fi
 
 # 3. Must NOT contain inline job steps (run: blocks with bash scripts).


### PR DESCRIPTION
## What
Pin `.github-private`'s own `dev-lead.yml` trigger stub from `dev-lead-reusable.yml@main` → `@dev-lead/stable`, and thread `agent_ref: dev-lead/stable` so the dev-lead scripts/prompts checkout runs at the pinned version too (#506).

## Why
Closes dev-lead's ring-0 **self-hosting circular dependency**: previously a broken change to dev-lead on `main` was instantly live for .github-private's own dev-lead duty, so it could gate the fix for its own breakage. Now ring-0 runs the known-good `dev-lead/stable` channel; promotion = moving the tag centrally, never editing this caller. Mirrors the validated pr-review self-host pattern (#497/#523).

## Safe-by-construction
`dev-lead/stable` was first advanced **v1.1.0 → v1.2.0** (= current main) so this pin does **not** regress ring-0 — v1.1.0 was 84 lines behind, missing #488's ci-relay `commits-to-pulls` fallback and exit-code-2 soft-skip handling. v1.2.0 includes them.

## Audit note
No inline→stub reconciliation was needed: `dev-lead.yml` is already a thin trigger stub and `dev-lead-reusable.yml` holds the logic. The split pre-existed; this PR is purely the version pin.

Part of #535 (ring-0). Consumer fan-out to `@dev-lead/stable` is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development workflow configuration to use a stable reference channel for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->