### PR TITLE
feat(ci): adopt feature-ideation standard (BMAD Analyst) in .github-private

### DIFF
--- a/.github/feature-ideation-sources.md
+++ b/.github/feature-ideation-sources.md
@@ -1,0 +1,174 @@
+# Feature Ideation — Reputable Source List
+
+> **Purpose:** A starter list of reputable web pages, RSS feeds, podcasts,
+> and YouTube channels that the BMAD Analyst (Mary) consults during
+> **Phase 2: Market Research** of the
+> [Feature Ideation workflow](../.github/workflows/feature-ideation-reusable.yml).
+>
+> **How it is used:** This file is a **template**. Each adopting repo copies
+> it to `.github/feature-ideation-sources.md` (or the path configured via
+> the `sources_file` workflow input) and customises it for their project.
+> The reusable workflow reads the repo-local copy — it does **not** read
+> this file directly. Mary treats the local list as her starting set for
+> web research, supplementing it with targeted searches as needed.
+>
+> **Curation rules:**
+>
+> - Only sources with a track record of accurate, technically-grounded
+>   content. No SEO farms, no anonymous aggregators with no editorial
+>   standards.
+> - Prefer **primary sources** (vendor changelogs, research labs, official
+>   blogs) over secondary commentary.
+> - RSS / Atom feed URLs are listed where available — they let Mary fetch
+>   structured "what is new since last scan" data instead of scraping HTML.
+> - YouTube and podcast feeds are included because release announcements,
+>   conference talks, and engineering deep-dives often appear there before
+>   (or instead of) blog posts.
+> - Every entry has a one-line note explaining **why it is on this list** —
+>   if you cannot justify it in one line, it should not be here.
+>
+> **Maintenance:** Each repo owns its own copy — add or remove entries via
+> PR in that repo. To update the shared starter template, open a PR here;
+> existing repos with their own copy will not be affected automatically.
+
+---
+
+## 1. AI / ML — Vendor & Lab Primary Sources
+
+Release notes, model launches, capability changes. These are usually the
+**first** place a new feature surfaces, weeks before commentary catches up.
+
+| Source | URL | Feed | Why it's here |
+|--------|-----|------|---------------|
+| Anthropic News | <https://www.anthropic.com/news> | <https://www.anthropic.com/rss.xml> | Model releases, safety research, API changes |
+| OpenAI Blog | <https://openai.com/blog> | <https://openai.com/blog/rss.xml> | Model releases, API updates, research |
+| Google DeepMind Blog | <https://deepmind.google/discover/blog/> | — | Research breakthroughs, Gemini updates |
+| Google AI Blog | <https://ai.googleblog.com/> | <https://ai.googleblog.com/feeds/posts/default> | Applied AI research and product updates |
+| Meta AI Blog | <https://ai.meta.com/blog/> | — | LLaMA releases, research |
+| Mistral Blog | <https://mistral.ai/news/> | — | Open-weight model releases |
+| HuggingFace Blog | <https://huggingface.co/blog> | <https://huggingface.co/blog/feed.xml> | Model releases, dataset news, community trends |
+| Cohere Blog | <https://cohere.com/blog> | — | Enterprise LLM API updates |
+| xAI Blog | <https://x.ai/blog> | — | Grok model updates |
+
+## 2. AI / ML — Research & Trends
+
+Pre-prints, paper trackers, and analyst commentary. Useful for spotting
+emerging capabilities **before** they hit vendor APIs.
+
+| Source | URL | Feed | Why it's here |
+|--------|-----|------|---------------|
+| arXiv cs.AI | <https://arxiv.org/list/cs.AI/recent> | <https://export.arxiv.org/rss/cs.AI> | Daily AI pre-prints |
+| arXiv cs.CL | <https://arxiv.org/list/cs.CL/recent> | <https://export.arxiv.org/rss/cs.CL> | NLP / language model pre-prints |
+| arXiv cs.LG | <https://arxiv.org/list/cs.LG/recent> | <https://export.arxiv.org/rss/cs.LG> | Machine learning pre-prints |
+| Papers with Code — Trending | <https://paperswithcode.com/> | — | Papers ranked by community attention with reference implementations |
+| Import AI (Jack Clark) | <https://importai.substack.com/> | <https://importai.substack.com/feed> | Weekly research roundup with policy + capability framing |
+| The Gradient | <https://thegradient.pub/> | <https://thegradient.pub/rss/> | Long-form ML research essays |
+
+## 3. Developer Tooling, DevEx & Platform Changelogs
+
+Platform features that unlock new product capabilities. GitHub's changelog
+in particular is the **single most important feed** for any project hosted
+on GitHub.
+
+| Source | URL | Feed | Why it's here |
+|--------|-----|------|---------------|
+| GitHub Changelog | <https://github.blog/changelog/> | <https://github.blog/changelog/feed/> | GitHub product feature releases |
+| GitHub Engineering | <https://github.blog/engineering/> | <https://github.blog/engineering/feed/> | Deep-dives on GitHub's own engineering decisions |
+| GitLab Blog | <https://about.gitlab.com/blog/> | <https://about.gitlab.com/atom.xml> | DevOps platform changes |
+| Vercel Blog | <https://vercel.com/blog> | — | Frontend/edge platform updates |
+| Cloudflare Blog | <https://blog.cloudflare.com/> | <https://blog.cloudflare.com/rss/> | Edge, Workers, security product updates |
+| AWS What's New | <https://aws.amazon.com/new/> | <https://aws.amazon.com/about-aws/whats-new/recent/feed/> | AWS service launches and updates |
+| GCP Blog | <https://cloud.google.com/blog/> | <https://cloud.google.com/feeds/gcp-release-notes.xml> | GCP release notes |
+| Stack Overflow Blog | <https://stackoverflow.blog/> | <https://stackoverflow.blog/feed/> | Developer survey data, industry trends |
+| The Pragmatic Engineer | <https://newsletter.pragmaticengineer.com/> | — | Engineering leadership and tooling trends |
+
+## 4. Security & Compliance
+
+Vulnerabilities, supply chain threats, and compliance changes that may
+surface as feature requirements.
+
+| Source | URL | Feed | Why it's here |
+|--------|-----|------|---------------|
+| GitHub Security Blog | <https://github.blog/security/> | <https://github.blog/security/feed/> | GitHub's own security advisories and features |
+| GitHub Advisory Database | <https://github.com/advisories> | — | Known vulnerabilities in open-source packages |
+| CISA Known Exploited Vulnerabilities | <https://www.cisa.gov/known-exploited-vulnerabilities-catalog> | <https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json> | US government KEV feed |
+| OpenSSF Blog | <https://openssf.org/blog/> | <https://openssf.org/blog/feed/> | Supply chain security standards |
+| Snyk Blog | <https://snyk.io/blog/> | <https://snyk.io/blog/feed/> | Vulnerability research and DevSecOps trends |
+| Krebs on Security | <https://krebsonsecurity.com/> | <https://krebsonsecurity.com/feed/> | Investigative security journalism |
+
+## 5. Software Engineering Practice & Industry Analysis
+
+Long-form analysis of engineering decisions, industry shifts, and
+developer trends.
+
+| Source | URL | Feed | Why it's here |
+|--------|-----|------|---------------|
+| Hacker News — Top | <https://news.ycombinator.com/> | <https://hnrss.org/frontpage> | Community signal on what engineers care about |
+| Lobsters | <https://lobste.rs/> | <https://lobste.rs/rss> | Curated engineering discussion |
+| Martin Fowler | <https://martinfowler.com/> | <https://martinfowler.com/feed.atom> | Software design patterns and architecture |
+| Latent Space (substack) | <https://www.latent.space/> | <https://www.latent.space/feed> | AI engineering deep-dives |
+| Simon Willison's Weblog | <https://simonwillison.net/> | <https://simonwillison.net/atom/entries/> | Practical LLM applications and web tech |
+| Stratechery | <https://stratechery.com/> | — | Tech strategy and business model analysis |
+| Increment | <https://increment.com/> | <https://increment.com/feed.xml> | Long-form engineering practice essays |
+
+## 6. Newsletters
+
+Curated weekly signal with low noise. Prefer fetching the RSS feed if
+listed over the web version.
+
+| Source | URL | Feed | Why it's here |
+|--------|-----|------|---------------|
+| TLDR | <https://tldr.tech/> | <https://tldr.tech/rss/tech> | High-signal daily tech summary |
+| Ben's Bites | <https://bensbites.beehiiv.com/> | <https://bensbites.beehiiv.com/feed> | Daily AI product and research digest |
+| The Rundown AI | <https://www.therundown.ai/> | — | AI tools and model updates for practitioners |
+| Bytes (JS) | <https://bytes.dev/> | — | JavaScript/TypeScript ecosystem news |
+| Python Weekly | <https://www.pythonweekly.com/> | — | Python ecosystem packages and tutorials |
+| DevOps Weekly | <https://www.devopsweekly.com/> | — | DevOps tooling and practices |
+
+## 7. Podcasts
+
+Engineering and product insights that often precede written coverage.
+Subscribe to the RSS feed and look for recent episode titles/descriptions.
+
+| Source | URL | Feed | Why it's here |
+|--------|-----|------|---------------|
+| Latent Space Podcast | <https://www.latent.space/podcast> | <https://www.latent.space/feed> | AI engineering interviews with practitioners |
+| The Changelog | <https://changelog.com/podcast> | <https://changelog.com/podcast/feed> | Open-source and developer tooling |
+| Practical AI | <https://changelog.com/practicalai> | <https://changelog.com/practicalai/feed> | Applied ML and AI products |
+| a16z Podcast | <https://a16z.com/podcasts/> | <https://a16z.com/feed/podcast/> | Tech and startup strategy |
+| The Cognitive Revolution | <https://www.cognitiverevolution.ai/> | — | AI capability and safety interviews |
+| Lex Fridman Podcast | <https://lexfridman.com/podcast/> | <https://lexfridman.com/feed/podcast/> | Long-form researcher/founder interviews |
+| Software Engineering Daily | <https://softwareengineeringdaily.com/> | <https://softwareengineeringdaily.com/feed/podcast/> | Engineering deep-dives |
+
+## 8. YouTube Channels
+
+Conference talks and product launches often land on YouTube before
+blog posts. Fetch the channel's RSS feed to see recent video titles.
+
+| Source | Channel URL | RSS Feed | Why it's here |
+|--------|-------------|----------|---------------|
+| Fireship | <https://www.youtube.com/@Fireship> | <https://www.youtube.com/feeds/videos.xml?channel_id=UCsBjURrPoezykLs9EqgamOA> | Quick-hit tech trends and new tool releases |
+| ThePrimeagen | <https://www.youtube.com/@ThePrimeagen> | <https://www.youtube.com/feeds/videos.xml?channel_id=UC8ENHE5xdFSwx71WHd9LCvg> | Developer tooling opinions and Rust/Go/TS trends |
+| Two Minute Papers | <https://www.youtube.com/@TwoMinutePapers> | <https://www.youtube.com/feeds/videos.xml?channel_id=UCbfYPyITQ-7l4upoX8nvctg> | Accessible ML research summaries |
+| Yannic Kilcher | <https://www.youtube.com/@YannicKilcher> | <https://www.youtube.com/feeds/videos.xml?channel_id=UCZHmQk67mSJgfCCTn7xBfew> | Deep ML paper walkthroughs |
+| AI Explained | <https://www.youtube.com/@aiexplained-official> | <https://www.youtube.com/feeds/videos.xml?channel_id=UCNJ1Ymd5yFuUPtn21xtRbbw> | LLM capability updates |
+| Matthew Berman | <https://www.youtube.com/@matthew_berman> | <https://www.youtube.com/feeds/videos.xml?channel_id=UCnUYZLuoy1rq1aVMwx4aTzw> | AI tool demos and model comparisons |
+| GitHub on YouTube | <https://www.youtube.com/@GitHub> | <https://www.youtube.com/feeds/videos.xml?channel_id=UC7c3Kb6jYCRj4JOHHZTxKsQ> | GitHub product demos and Universe talks |
+| AWS Events | <https://www.youtube.com/@AWSEventsChannel> | <https://www.youtube.com/feeds/videos.xml?channel_id=UCdoadna9HFHDqnC9lBaxd3w> | re:Invent, re:Inforce session recordings |
+
+## 9. Conferences
+
+Major annual events where product announcements and research previews
+cluster. Monitor the conference site and YouTube channel in the weeks
+before and after each event.
+
+| Conference | Typical date | URL | Why it's here |
+|------------|-------------|-----|---------------|
+| GitHub Universe | Oct | <https://githubuniverse.com/> | GitHub roadmap and ecosystem announcements |
+| KubeCon / CloudNativeCon | Mar + Nov | <https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/> | Cloud-native platform shifts |
+| AWS re:Invent | Nov–Dec | <https://reinvent.awsevents.com/> | AWS service launches |
+| Google Cloud Next | Apr | <https://cloud.withgoogle.com/next> | GCP and Workspace announcements |
+| NeurIPS | Dec | <https://neurips.cc/> | Top-tier ML research |
+| ICML | Jul | <https://icml.cc/> | Machine learning research trends |
+| ICLR | May | <https://iclr.cc/> | Deep learning and representation learning |
+| Strange Loop (archive) | — | <https://www.thestrangeloop.com/> | Engineering practice talks (archived; still valuable) |

--- a/.github/feature-ideation-sources.md
+++ b/.github/feature-ideation-sources.md
@@ -3,7 +3,7 @@
 > **Purpose:** A starter list of reputable web pages, RSS feeds, podcasts,
 > and YouTube channels that the BMAD Analyst (Mary) consults during
 > **Phase 2: Market Research** of the
-> [Feature Ideation workflow](../.github/workflows/feature-ideation-reusable.yml).
+> [Feature Ideation workflow](workflows/feature-ideation.yml).
 >
 > **How it is used:** This file is a **template**. Each adopting repo copies
 > it to `.github/feature-ideation-sources.md` (or the path configured via

--- a/.github/feature-ideation-sources.md
+++ b/.github/feature-ideation-sources.md
@@ -5,12 +5,10 @@
 > **Phase 2: Market Research** of the
 > [Feature Ideation workflow](workflows/feature-ideation.yml).
 >
-> **How it is used:** This file is a **template**. Each adopting repo copies
-> it to `.github/feature-ideation-sources.md` (or the path configured via
-> the `sources_file` workflow input) and customises it for their project.
-> The reusable workflow reads the repo-local copy — it does **not** read
-> this file directly. Mary treats the local list as her starting set for
-> web research, supplementing it with targeted searches as needed.
+> **How it is used:** The reusable workflow reads this file directly during
+> **Phase 2: Market Research** — this is the repo-local copy it consumes.
+> Mary treats the list below as her starting set for web research,
+> supplementing it with targeted searches as needed.
 >
 > **Curation rules:**
 >
@@ -27,9 +25,9 @@
 > - Every entry has a one-line note explaining **why it is on this list** —
 >   if you cannot justify it in one line, it should not be here.
 >
-> **Maintenance:** Each repo owns its own copy — add or remove entries via
-> PR in that repo. To update the shared starter template, open a PR here;
-> existing repos with their own copy will not be affected automatically.
+> **Maintenance:** Add or remove entries via PR against this file in this
+> repo. Changes take effect on the next scheduled or manually triggered
+> Feature Ideation run.
 
 ---
 

--- a/.github/workflows/feature-ideation.yml
+++ b/.github/workflows/feature-ideation.yml
@@ -1,6 +1,6 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # SOURCE OF TRUTH: petry-projects/.github/standards/workflows/feature-ideation.yml
-# Standard:        petry-projects/.github/standards/ci-standards.md#8-feature-ideation-feature-ideationyml--bmad-method-repos
+# Standard:        petry-projects/.github/standards/ci-standards.md#9-feature-ideation-feature-ideationyml--bmad-method-repos
 # Reusable:        petry-projects/.github/.github/workflows/feature-ideation-reusable.yml
 #
 # AGENTS — READ BEFORE EDITING:

--- a/.github/workflows/feature-ideation.yml
+++ b/.github/workflows/feature-ideation.yml
@@ -1,0 +1,99 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/feature-ideation.yml
+# Standard:        petry-projects/.github/standards/ci-standards.md#8-feature-ideation-feature-ideationyml--bmad-method-repos
+# Reusable:        petry-projects/.github/.github/workflows/feature-ideation-reusable.yml
+#
+# AGENTS — READ BEFORE EDITING:
+#   • This file is a THIN CALLER STUB. The 5-phase ideation pipeline, the
+#     Opus 4.6 model selection, the github_token override, and the
+#     ANTHROPIC_MODEL env var all live in the reusable workflow above.
+#   • You MAY change: the `project_context` value (the only required edit
+#     per repo), and optionally the cron schedule.
+#   • You MUST NOT change: trigger event shape, the `uses:` line, the
+#     job-level `permissions:` block, or the `secrets:` block — these are
+#     required for the reusable to work.
+#   • If you need different behaviour, open a PR against the reusable in
+#     the central repo. The change will propagate everywhere on next run.
+# ─────────────────────────────────────────────────────────────────────────────
+name: Feature Research & Ideation (BMAD Analyst)
+
+on:
+  schedule:
+    - cron: '0 7 * * 5' # Friday 07:00 UTC (3 AM EDT / 2 AM EST)
+  workflow_dispatch:
+    inputs:
+      focus_area:
+        description: 'Optional focus area (e.g., "agent cost routing", "CI security")'
+        required: false
+        type: string
+      research_depth:
+        description: 'Research depth'
+        required: false
+        default: 'standard'
+        type: choice
+        options:
+          - quick
+          - standard
+          - deep
+      dry_run:
+        description: 'Skip Discussion mutations and log them to a JSONL artifact instead. Use this to smoke-test before going live.'
+        required: false
+        default: false
+        type: boolean
+
+permissions: {}
+
+concurrency:
+  group: feature-ideation
+  cancel-in-progress: false
+
+jobs:
+  ideate:
+    # Permissions cascade from the calling job to the reusable workflow.
+    # The reusable workflow's two jobs (gather-signals + analyze) need:
+    #   - contents:      read   (checkout, file reads)
+    #   - issues:        read   (signal collection)
+    #   - pull-requests: read   (signal collection)
+    #   - discussions:   write  (CRITICAL — create/update Discussion threads)
+    #   - id-token:      write  (claude-code-action OIDC for GitHub App token)
+    #   - actions:       read   (feed checkpoint — last successful run query)
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+      discussions: write
+      id-token: write
+      actions: read
+    uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@d3d768dabb7f28cc63283cdfe48630da53700e50 # v1
+    with:
+      # === CUSTOMISE THIS PER REPO — the only required edit ===
+      project_context: |
+        petry-projects/.github-private is the org-level private automation
+        repository for the petry-projects GitHub organisation. It owns the org's
+        agentic CI/CD operations: the dev-lead autonomous engineering agent, the
+        multi-stage PR-review pipeline, scheduled health and actions-fleet
+        monitors, dependency-audit and release-notes automation, Copilot custom
+        agent profiles (agents/), prompt libraries (prompts/), and the shell
+        orchestration (scripts/) executed by GitHub Actions. It complements the
+        public petry-projects/.github standards repo by hosting the private
+        execution logic and the self-hosting agent harness — engine.sh tier
+        routing and channel-tag release rings. Downstream consumers are internal
+        product repos (Broodly, TalkTerm, markets) plus the org's own agent
+        fleet. Key trends Mary should research: agentic software-engineering
+        automation (autonomous PR fix/review bots, multi-agent orchestration),
+        LLM model and cost routing for agent harnesses (capability-vs-price tier
+        selection, adaptive thinking, new Claude/Gemini tiers), GitHub Actions
+        platform advances (reusable-workflow versioning, OIDC, larger runners,
+        merge queues), prompt-injection and least-privilege hardening for
+        agent workflows (agent-shield threat models, supply-chain pinning), and
+        safe self-hosting release strategies (canary and ring rollouts for
+        agents that modify their own infrastructure). No public users — this is
+        internal DevX and agent-operations infrastructure.
+      # === OPTIONAL: repo-local reputable source list ===
+      # This repo ships .github/feature-ideation-sources.md, which is the
+      # reusable workflow's default path — so no sources_file override is needed.
+      focus_area: ${{ inputs.focus_area || '' }}
+      research_depth: ${{ inputs.research_depth || 'standard' }}
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## What

Adopts the org **Feature Research & Ideation (BMAD Analyst)** standard (ci-standards.md §9) in `.github-private`, which previously ran only against `petry-projects/.github`.

Two files:
- **`.github/workflows/feature-ideation.yml`** — thin caller stub delegating to `petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@v1` (pinned to live v1 SHA `d3d768d`, looked up via the GitHub API). `project_context` is tailored to this repo (agentic CI/CD ops, LLM model/cost routing, agent-shield hardening, safe self-hosting release rings).
- **`.github/feature-ideation-sources.md`** — repo-local reputable source list at the reusable's default path, so no `sources_file` override is needed.

## Why

The ideation pipeline writes "Ideas" Discussions to the repo that *calls* it. With no caller here, `.github-private` never received automated ideation — surfaced while investigating why the "enhanced model selection" discussion wasn't getting refreshed direction.

## Prerequisites (verified)

- ✅ Discussions enabled with an **Ideas** category in `.github-private`
- ✅ `CLAUDE_CODE_OAUTH_TOKEN` available as an org-level secret (ALL repos)
- ✅ BMAD tooling/pipeline lives in the reusable (checked out from `petry-projects/.github` at run time) — no local BMAD artifacts required in the caller repo

## Behaviour

- Schedule: weekly, **Friday 07:00 UTC** + manual `workflow_dispatch` (`focus_area`, `research_depth`, `dry_run`)
- Output: one Discussion per surviving proposal in the **Ideas** category; subsequent runs comment deltas on existing threads
- Model: Opus 4.6 (set inside the reusable), ~\$2–3 per standard-depth run

Conforms to the thin-caller-stub rule (`check_centralized_workflow_stubs`): no edits to trigger shape, `uses:`, job `permissions:`, or `secrets:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)