### PR TITLE
fix(dev-lead): multiline INTENT_BODY corrupts $GITHUB_ENV (#559)

### DIFF
--- a/.github/workflows/dev-lead-reusable.yml
+++ b/.github/workflows/dev-lead-reusable.yml
@@ -147,7 +147,18 @@ jobs:
           echo "INTENT_CHECKS=$(echo "$ctx"       | jq -c '.checks // []')"       >> "$GITHUB_ENV"
           echo "INTENT_ISSUE_NUMBER=$(echo "$ctx" | jq -r '.issue_number // ""')" >> "$GITHUB_ENV"
           echo "INTENT_ACTOR=$(echo "$ctx"        | jq -r '.actor // ""')"        >> "$GITHUB_ENV"
-          echo "INTENT_BODY=$(echo "$ctx"         | jq -r '.body // ""')"         >> "$GITHUB_ENV"
+          # INTENT_BODY is free text (review/comment bodies) and is frequently
+          # multiline — e.g. CodeRabbit reviews. A plain `KEY=value` write spills
+          # the 2nd+ lines into $GITHUB_ENV as invalid entries and fails the step
+          # ("Unable to process file command 'env'"). Use the heredoc form with a
+          # RANDOM delimiter so newlines are preserved and a crafted body cannot
+          # inject extra env vars by embedding the delimiter (it is unguessable).
+          body_delim="INTENT_BODY_EOF_$(openssl rand -hex 16)"
+          {
+            printf 'INTENT_BODY<<%s\n' "$body_delim"
+            echo "$ctx" | jq -r '.body // ""'
+            printf '%s\n' "$body_delim"
+          } >> "$GITHUB_ENV"
 
       - name: Skip — log reason
         if: env.INTENT_TYPE == 'skip'


### PR DESCRIPTION
## Problem (#559)
`dev-lead-reusable.yml`'s **Parse intent context fields** step writes the comment body to `$GITHUB_ENV` with a plain `KEY=value` line. A **multiline** body (CodeRabbit reviews, etc.) spills its 2nd+ lines into the env file as invalid entries and fails the step — so dev-lead fails on every multiline bot/review-comment pickup, **fleet-wide** (the bug is in the shared reusable = `dev-lead/stable` v1.2.0).

```
##[error]Unable to process file command 'env' successfully.
##[error]Invalid format '**Use `@v1` tag literal...'
```

Found by the post-implementation health check of the #535/#557 rollout (ContentTwin run 27307983783).

## Fix
Write `INTENT_BODY` with the heredoc form `INTENT_BODY<<DELIM … DELIM` using a **random** delimiter (`openssl rand -hex 16`) so newlines are preserved and a crafted body can't inject extra env vars by embedding the delimiter. Single-line fields unchanged.

## Validation
Simulated locally with a multiline CodeRabbit-style body (code fences, `@v1`, diff block): the value is written as one well-formed multiline env entry, delimiter balanced, nothing spills. YAML parses.

## Rollout
On merge: cut `dev-lead/v1.2.1` and promote `dev-lead/stable` (exercises the release runbook). Closes #559.

🤖 Generated with [Claude Code](https://claude.com/claude-code)