### PR TITLE
feat(initiatives): idea-triage + BMAD Scrum Master initiative-planner

### DIFF
--- a/.github/workflows/idea-triage.yml
+++ b/.github/workflows/idea-triage.yml
@@ -1,0 +1,148 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Idea Triage — weekly ripeness shortlist for the Ideas backlog
+#
+# Scans every open Ideas Discussion (human- and ideation-bot-authored), scores
+# how ripe each is for promotion (evidence strength, prerequisites met,
+# alignment with active initiatives, not already covered by an open epic), and
+# rewrites a single "Idea Promotion Queue" tracking issue with the ranked
+# shortlist + a pre-drafted promotion note for the top candidates.
+#
+# It NEVER approves anything. A maintainer reads the queue and blesses an idea
+# by adding `idea:approved` to its Discussion, which fires initiative-planner.yml.
+#
+# Pipeline position:
+#   feature-ideation (Discussions) -> THIS (shortlist) -> ★ human adds idea:approved
+#   -> initiative-planner (epic + DAG) -> ★ human adds initiative:auto
+#   -> initiative-driver -> dev-lead
+# ─────────────────────────────────────────────────────────────────────────────
+name: Idea Triage (Promotion Queue)
+
+on:
+  schedule:
+    - cron: '0 13 * * 1' # Monday 13:00 UTC (after the Fri ideation run lands)
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Log the intended queue update to an artifact instead of writing the tracking issue'
+        required: false
+        default: false
+        type: boolean
+      model:
+        description: 'Anthropic model id for triage'
+        required: false
+        default: 'claude-sonnet-4-6'
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: idea-triage
+  cancel-in-progress: false
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read       # checkout
+      issues: write        # create/update the Idea Promotion Queue issue
+      discussions: read    # read the Ideas backlog
+      id-token: write       # claude-code-action OIDC
+    env:
+      REPO: ${{ github.repository }}
+      DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}
+    steps:
+      - name: Checkout agent repo
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set temp paths
+        run: |
+          echo "DRY_RUN_LOG=${{ runner.temp }}/dry-run.jsonl" >> "$GITHUB_ENV"
+          echo "CONTEXT_PATH=${{ runner.temp }}/ideas-context.json" >> "$GITHUB_ENV"
+          echo "QUEUE_BODY_PATH=${{ runner.temp }}/queue-body.md" >> "$GITHUB_ENV"
+
+      - name: Gather Ideas backlog
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/idea-triage/gather-ideas.sh
+
+      - name: Rank ripeness and refresh the queue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: |
+            --model ${{ inputs.model || 'claude-sonnet-4-6' }}
+            --allowedTools Bash,Read,Glob,Grep
+          prompt: |
+            You are an **idea-triage analyst** for the ${{ github.repository }} repo.
+            Your job: decide which open Ideas are RIPE to promote into a tracked
+            initiative, and refresh the promotion-queue tracking issue. You do NOT
+            approve anything — a human reads your queue and adds `idea:approved`.
+
+            ## Input
+
+            The Ideas backlog + signals is at `$CONTEXT_PATH` (JSON): every open
+            Ideas Discussion (number, title, excerpt, labels, comment count,
+            timestamps) plus the open `initiative` epics. Read it:
+
+            ```bash
+            cat "$CONTEXT_PATH" | jq .
+            ```
+
+            Use Read/Grep/Glob on the checkout (`AGENTS.md`, `docs/initiatives/`,
+            `scripts/`, `.github/workflows/`) to judge feasibility and whether an
+            idea is already covered.
+
+            ## Scoring
+
+            Rank each idea into one of: **Ripe** / **Soon** / **Not yet**, judged on:
+            - **Evidence** — is the idea concrete and grounded, or still vague?
+            - **Prerequisites** — are blocking issues it depends on resolved?
+            - **Alignment** — does it advance an active initiative / org priority?
+            - **Coverage** — is it already covered by an open epic (then: not ripe,
+              note the epic)?
+            - **Freshness** — recent human engagement is a positive signal.
+
+            Already carries `idea:approved` → it's past triage; list it under a
+            short "Already approved" section, don't re-rank it.
+
+            ## Output
+
+            Write the full tracking-issue body (GitHub Markdown) to
+            `$QUEUE_BODY_PATH`. Structure:
+            - A one-line generated-on note and a legend.
+            - **🟢 Ripe to promote** — a table: idea (linked #), why now, and a
+              1–2 sentence pre-drafted promotion note (what the initiative would
+              deliver). These are the human's pick-list for `idea:approved`.
+            - **🟡 Soon** — table: idea, what's missing before it's ripe.
+            - **⚪ Not yet / covered** — terse list with the reason (or covering epic).
+            - A footer explaining: add `idea:approved` to a Discussion to fire the
+              BMAD Scrum Master initiative-planner.
+
+            Keep it scannable. Be decisive — at most ~5 ideas in "Ripe".
+
+            ## Publish
+
+            Upsert the single tracking issue (idempotent; honors `$DRY_RUN`):
+
+            ```bash
+            REPO="${{ github.repository }}" QUEUE_BODY_PATH="$QUEUE_BODY_PATH" \
+            bash scripts/idea-triage/upsert-queue.sh
+            ```
+
+            Finish with a 2–3 line summary of how many ideas you marked Ripe/Soon.
+
+      - name: Upload dry-run queue log
+        if: ${{ env.DRY_RUN == '1' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: idea-triage-dry-run
+          path: |
+            ${{ runner.temp }}/dry-run.jsonl
+            ${{ runner.temp }}/queue-body.md
+          if-no-files-found: warn

--- a/.github/workflows/initiative-planner.yml
+++ b/.github/workflows/initiative-planner.yml
@@ -1,0 +1,186 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Initiative Planner — BMAD Scrum Master (Bob)
+#
+# Turns ONE curated & approved idea (an Ideas Discussion) into a well-defined
+# initiative: a GitHub epic + a sub-issue DAG (native sub-issues + blocked_by),
+# each story prepared to dev-lead's "ready" bar. The epic is created INERT
+# (labelled `initiative`, NOT `initiative:auto`). A maintainer reviews the real
+# epic/DAG and adds `initiative:auto` to hand it to initiative-driver.yml for
+# auto-implementation.
+#
+# Pipeline position:
+#   feature-ideation (Discussions) -> idea-triage (shortlist) -> ★ human approves
+#   -> THIS (epic + story DAG, inert) -> ★ human adds initiative:auto
+#   -> initiative-driver -> dev-lead
+#
+# This is org-private automation (like initiative-driver.yml), not a thin caller.
+# All tooling + the vendored Bob persona live in this repo and are unit-tested
+# (scripts/initiative-planner/, prompts/bmad/scrum-master.md).
+# ─────────────────────────────────────────────────────────────────────────────
+name: Initiative Planner (BMAD Scrum Master)
+
+on:
+  workflow_dispatch:
+    inputs:
+      discussion:
+        description: 'Ideas Discussion number to plan into an initiative'
+        required: true
+        type: string
+      dry_run:
+        description: 'Plan only — log intended issue/DAG mutations to an artifact instead of creating them'
+        required: false
+        default: true
+        type: boolean
+      model:
+        description: 'Anthropic model id for the planner'
+        required: false
+        default: 'claude-opus-4-8'
+        type: string
+  # Approve an idea by labelling its Discussion `idea:approved`; that fires here.
+  discussion:
+    types: [labeled]
+
+permissions: {}
+
+concurrency:
+  # One plan per discussion at a time; never cancel an in-flight planning run.
+  group: initiative-planner-${{ github.event.inputs.discussion || github.event.discussion.number }}
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    # Skip discussion-label events unless the label added is exactly idea:approved.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'discussion' && github.event.label.name == 'idea:approved')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read       # checkout, read AGENTS.md/scripts/docs
+      issues: write        # create epic + story sub-issues, link DAG, set blocked_by
+      discussions: write   # post the plan summary back to the idea
+      id-token: write       # claude-code-action OIDC
+    env:
+      REPO: ${{ github.repository }}
+      DISCUSSION_NUMBER: ${{ github.event.inputs.discussion || github.event.discussion.number }}
+      DRY_RUN: ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run == true) && '1' || '0' }}
+      TOOLING_DIR: ${{ github.workspace }}/scripts/initiative-planner
+    steps:
+      - name: Checkout agent repo
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set temp paths
+        run: |
+          echo "DRY_RUN_LOG=${{ runner.temp }}/dry-run.jsonl" >> "$GITHUB_ENV"
+          echo "CONTEXT_PATH=${{ runner.temp }}/planning-context.json" >> "$GITHUB_ENV"
+          echo "PLAN_PATH=${{ runner.temp }}/plan.json" >> "$GITHUB_ENV"
+
+      - name: Install Python jsonschema
+        run: pip install --quiet 'jsonschema>=4'
+
+      - name: Gather planning context
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/initiative-planner/gather-context.sh
+
+      - name: Plan the initiative (BMAD Scrum Master)
+        id: bob
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # CRITICAL (same gotcha as feature-ideation): pass the workflow's
+          # GITHUB_TOKEN explicitly so the job-level issues/discussions write
+          # grants apply. The action's own app token lacks them and mutations
+          # would fail silently.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: |
+            --model ${{ github.event.inputs.model || 'claude-opus-4-8' }}
+            --allowedTools Bash,Read,Glob,Grep
+          prompt: |
+            You are **Bob**, the BMAD Scrum Master, running as an automated,
+            non-interactive initiative planner for the ${{ github.repository }} repo.
+
+            ## Method — follow the vendored BMAD skills (by path)
+
+            This repo vendors the real BMAD Method skills agent-agnostically under
+            `frameworks/` (v6.8.0 + Test Architect v1.19.0). Read the orchestration
+            wrapper and follow every step — it points you at the exact skill files
+            (`frameworks/bmad-method/src/bmm-skills/4-implementation/` for
+            sprint-planning + create-story, and `frameworks/bmad-test-architecture/`
+            for the Test Architect) and how to adapt them to this repo's
+            non-interactive, GitHub-issues output:
+
+            ```bash
+            cat prompts/bmad/scrum-master.md
+            ```
+
+            Use the BMAD skills for their real method, templates, and checklists —
+            do not paraphrase them. The create-story template is the required story
+            shape; its checklist is the readiness bar each story clears.
+
+            ## Your input
+
+            The approved idea + repo context is at `$CONTEXT_PATH` (JSON): the
+            Discussion title/body/comments, the open `initiative` epics, and the
+            issues the idea references (likely prerequisites). Read it, then ground
+            stories in the checked-out repo with Read/Grep/Glob (`AGENTS.md`,
+            `CLAUDE.md`, `scripts/`, `.github/workflows/`, `docs/initiatives/`):
+
+            ```bash
+            cat "$CONTEXT_PATH" | jq .
+            ```
+
+            ## Your output
+
+            Emit a single **initiative plan** JSON to `$PLAN_PATH` conforming to
+            `scripts/initiative-planner/plan.schema.json` (it mirrors the BMAD
+            create-story template field-for-field: `user_story`,
+            `acceptance_criteria`, `tasks` with `ac_refs`, `dev_notes`,
+            `project_structure_notes`, `references`, plus `id`/`title`/`size`/
+            `blocked_by`/`blocked_by_existing_issues`/`hands_off`). Typically 3–8
+            stories. `[Phase N]` title prefixes when ordered.
+
+            ## Validate, then materialize
+
+            ```bash
+            python3 scripts/initiative-planner/validate-plan.py "$PLAN_PATH"
+            ```
+
+            Fix and re-validate until it passes (unique ids, acyclic DAG, an entry
+            point, no dangling edges). THEN materialize the epic + sub-issue DAG —
+            this honors `$DRY_RUN` (when `DRY_RUN=1` it logs intended mutations to
+            `$DRY_RUN_LOG` instead of writing to GitHub):
+
+            ```bash
+            REPO="${{ github.repository }}" \
+            PLAN_PATH="$PLAN_PATH" \
+            DISCUSSION_NUMBER="$DISCUSSION_NUMBER" \
+            DISCUSSION_NODE_ID="$DISCUSSION_NODE_ID" \
+            bash scripts/initiative-planner/apply-plan.sh
+            ```
+
+            ## Hard constraints
+
+            - NEVER apply the `initiative:auto` label. The epic must be created
+              inert; activation is a human decision. apply-plan.sh enforces this —
+              do not work around it with direct `gh` calls.
+            - Go through apply-plan.sh for all issue/DAG mutations; do not call
+              `gh issue create` or the sub_issues/dependencies APIs directly.
+            - Keep the plan grounded. No invented acceptance criteria.
+
+            Finish with a 3–5 line summary: the epic, the story count, the
+            dependency shape, and any open questions.
+
+      - name: Upload dry-run plan log
+        if: ${{ env.DRY_RUN == '1' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: initiative-plan-dry-run
+          path: |
+            ${{ runner.temp }}/dry-run.jsonl
+            ${{ runner.temp }}/plan.json
+          if-no-files-found: warn

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install bats
         run: sudo apt-get install -y bats
 
+      - name: Install Python jsonschema (initiative-planner validator tests)
+        run: pip3 install --quiet 'jsonschema>=4'
+
       - name: Run tests
         run: |
           bats \
@@ -46,7 +49,9 @@ jobs:
             tests/test_verify_auth_scopes.bats \
             tests/test_initiative_driver.bats \
             tests/test_cut_release.bats \
-            tests/test_pr_review_health.bats
+            tests/test_pr_review_health.bats \
+            tests/test_initiative_planner.bats \
+            tests/test_idea_triage.bats
 
   validate-agent-profiles:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -397,3 +397,6 @@ __pycache__/
 
 # Vendor-specific Claude Code skill projections — BMAD lives in frameworks/ (agent-agnostic).
 .claude/skills/
+
+# gitleaks scanner binary — downloaded fresh in CI, never committed
+/gitleaks

--- a/.gitignore
+++ b/.gitignore
@@ -390,3 +390,10 @@ private.yml
 # ============================================================================
 # End of petry-projects secrets baseline
 # ============================================================================
+
+# Python bytecode
+__pycache__/
+*.pyc
+
+# Vendor-specific Claude Code skill projections — BMAD lives in frameworks/ (agent-agnostic).
+.claude/skills/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -40,6 +40,17 @@ regexes = [
 ]
 
 [[allowlists]]
+# Historical bmad-test-architecture subtree (removed in same cleanup as other frameworks) ships
+# api-testing-patterns.md across 9 agent/workflow subdirectories; each copy has the same dummy
+# JWT stub 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...' at line 681 as an example expired-token
+# fixture.  condition="AND" binds the pattern to its file paths so a real secret here would
+# still be caught.
+description = "Suppress dummy JWT stub in historical bmad-test-architecture api-testing-patterns.md copies"
+condition = "AND"
+paths = ['''^frameworks/bmad-test-architecture/.*/api-testing-patterns\.md$''']
+regexes = ['''eyJhbGciOiJIUzI1NiIs''']
+
+[[allowlists]]
 # test-key: BRAVE_API_KEY = 'test-key' stub at lines 1335-1405
 # 03-VERIFICATION.md: path.join(..., '03-api', '03-VERIFICATION.md') at line 759 triggers
 #   generic-api-key because '03-api' contains the keyword 'api' followed by the 19-char

--- a/docs/initiatives/idea-to-initiative-pipeline.md
+++ b/docs/initiatives/idea-to-initiative-pipeline.md
@@ -1,0 +1,100 @@
+# Idea → Initiative pipeline
+
+How a raw idea becomes auto-implementable work, and where the human gates are.
+
+```
+feature-ideation.yml        (weekly, automated)   ──>  Ideas DISCUSSIONS
+  BMAD Analyst "Mary"                                   (proposals)
+        │
+        ▼
+idea-triage.yml             (weekly, automated)    ──>  "🧭 Idea Promotion Queue"
+  ranks ripeness; never approves                        tracking issue (shortlist)
+        │
+   ★ HUMAN — add `idea:approved` to a Discussion
+        │
+        ▼
+initiative-planner.yml      (on approval / dispatch, automated)
+  BMAD Scrum Master "Bob"   sprint-planning + create-story
+        │                   creates an EPIC + sub-issue DAG (blocked_by),
+        │                   labelled `initiative` — INERT (no `initiative:auto`)
+        │                   posts the plan back to the Discussion
+        ▼
+   ★ HUMAN — review the epic/DAG, then add `initiative:auto` to the epic
+        │
+        ▼
+initiative-driver.yml       (on issues:closed + cron, automated)
+  releases each ready story (blockers closed) by labelling it `dev-lead`
+        ▼
+dev-lead.yml  ──>  PR  ──>  pr-review  ──>  merge  ──>  "Closes #N"
+        └──────────── closing a story unblocks its successors ───────────┘
+```
+
+Two automated stages were added to close the gap between "idea" and
+"in-flight": **idea-triage** (shortlist) and **initiative-planner** (the BMAD
+Scrum Master). Each is bounded by a human gate, so judgement stays with a
+maintainer:
+
+| Gate | Signal | Who |
+|------|--------|-----|
+| Idea is worth planning | add `idea:approved` to the Discussion | human |
+| Initiative is ready to build | add `initiative:auto` to the epic | human |
+
+## The two new workflows
+
+Both are **org-private automation** (like `initiative-driver.yml`), not thin
+caller stubs. Tooling and the vendored BMAD personas live in this repo and are
+unit-tested.
+
+### `idea-triage.yml` — weekly ripeness shortlist
+- Scans every open **Ideas** Discussion, scores each **Ripe / Soon / Not yet**
+  on evidence, prerequisites, alignment, coverage, and freshness.
+- Rewrites a single **Idea Promotion Queue** tracking issue (label
+  `idea-triage`) with the ranked list and a pre-drafted promotion note per ripe
+  idea. It **never** applies `idea:approved` — that's the human's pick.
+- Tooling: `scripts/idea-triage/{gather-ideas,upsert-queue}.sh`.
+
+### `initiative-planner.yml` — BMAD Scrum Master "Bob"
+- Trigger: a Discussion gets labelled `idea:approved`, or manual
+  `workflow_dispatch` with a discussion number (`dry_run` defaults to **true**).
+- **Follows the real BMAD Method skills, vendored agent-agnostically under
+  `frameworks/`** (BMM v6.8.0 at `frameworks/bmad-method/` + **Test Architect**
+  v1.19.0 at `frameworks/bmad-test-architecture/`; `src/` skill trees only, see
+  `prompts/bmad/README.md`). The planner reads the skills **by path** (not via any
+  vendor-specific `.<tool>/skills` dir), following `bmad-sprint-planning` +
+  `bmad-create-story` (and the Test Architect "Murat"/`testarch` where useful) —
+  not a paraphrase. Stories are emitted in the canonical BMAD **create-story
+  template** (Story / Acceptance Criteria / Tasks-Subtasks / Dev Notes / Project
+  Structure Notes / References) and self-checked against the create-story
+  **checklist**.
+- Reads the approved idea + repo context, runs sprint-planning + create-story,
+  and emits a schema-validated **initiative plan** (`plan.schema.json`, which
+  mirrors the BMAD template field-for-field): an epic + 3–8 PR-sized stories
+  with testable acceptance criteria, AC-referencing tasks, grounded Dev Notes,
+  sizes, and a `blocked_by` DAG. Prerequisites already tracked as issues become
+  `blocked_by_existing_issues` edges, not new stories.
+- Materializes the epic + native sub-issue DAG via `apply-plan.sh`, labelled
+  `initiative` only. **It never applies `initiative:auto`** — the epic is created
+  inert and a human activates it after review. `hands_off` stories also get
+  `dev-lead:hands-off` + `initiative:hold` so the driver never auto-releases them.
+- Tooling: `scripts/initiative-planner/` (persona: `prompts/bmad/scrum-master.md`).
+
+## Labels the pipeline relies on
+
+| Label | On | Meaning |
+|-------|----|---------|
+| `idea:approved` | Discussion | Human blessed this idea for planning → fires the planner |
+| `idea-triage` | Issue | Marks the Idea Promotion Queue tracking issue |
+| `initiative` | Epic + stories | Part of a tracked initiative |
+| `initiative:auto` | Epic | Human activated auto-implementation (driver may release) |
+| `initiative:hold` / `dev-lead:hands-off` | Story | Never auto-released; needs a human |
+
+## Safety properties
+
+- **Two human gates**, both opt-in labels. Nothing reaches `dev-lead` without a
+  maintainer adding `idea:approved` then `initiative:auto`.
+- **Dry-run first.** The planner defaults `dry_run: true` on manual dispatch and
+  logs every intended mutation to an artifact; triage supports the same.
+- **Auto is never self-applied.** `apply-plan.sh` cannot emit `initiative:auto`
+  (enforced by `tests/test_initiative_planner.bats`).
+- **DAG is validated** (acyclic, has an entry point, no dangling edges) before
+  any issue is created.

--- a/prompts/bmad/README.md
+++ b/prompts/bmad/README.md
@@ -1,0 +1,38 @@
+# BMAD Method — Scrum Master orchestration
+
+The initiative-planner runs the **real BMAD Method** skills, vendored
+**agent-agnostically** under `frameworks/` (not in a vendor-specific
+`.<tool>/skills` directory). Per the repo standard, installed agentic frameworks
+live under `frameworks/` (`CLAUDE.md`, `AGENTS.md`).
+
+## Where the skills live
+
+| Path | Source (pinned) | Contents |
+|------|-----------------|----------|
+| `frameworks/bmad-method/` | `bmad-code-org/BMAD-METHOD` @ v6.8.0 | `src/bmm-skills` + `src/core-skills` (Scrum Master, create-story, sprint-planning, …) |
+| `frameworks/bmad-test-architecture/` | `bmad-code-org/bmad-method-test-architecture-enterprise` @ v1.19.0 | `src/` — the Test Architect ("Murat") + `testarch` workflows |
+
+Only the upstream `src/` skill trees are vendored (no website/docs/build tooling);
+see each dir's `VENDOR.md` for provenance and the refresh command. The trees are
+marked `linguist-vendored` (`.gitattributes`) and excluded from markdownlint;
+a path-scoped gitleaks allowlist covers the Test Architect's illustrative auth
+examples.
+
+## How the planner consumes it (vendor-neutral)
+
+`.github/workflows/initiative-planner.yml` runs `claude-code-action`, but the
+skills are consumed **by path** — plain markdown read with Read/Bash — so the
+approach is not tied to any single agent runtime. [`scrum-master.md`](./scrum-master.md)
+is the orchestration wrapper: it has Bob follow the vendored
+sprint-planning + create-story skills (and the Test Architect where useful) and
+emit our `plan.json` (→ `apply-plan.sh`) instead of the skills' default
+interactive, file-writing output.
+
+> A per-tool projection (e.g. Claude Code's `.claude/skills/`) is intentionally
+> **not committed** (gitignored) — it's a generated, vendor-specific artifact.
+> The canonical, agent-agnostic source of truth is `frameworks/`.
+
+## Updating
+
+Re-vendor from a newer upstream tag (see each `VENDOR.md`); commit the result.
+Do not hand-edit files under `frameworks/`.

--- a/prompts/bmad/scrum-master.md
+++ b/prompts/bmad/scrum-master.md
@@ -1,0 +1,94 @@
+# Bob — BMAD Scrum Master (initiative-planner orchestration)
+
+This wraps the **vendored BMAD Method skills** (kept agent-agnostic under
+`frameworks/`, not a vendor-specific `.<tool>/skills` dir) so they run
+non-interactively against our input (an approved Ideas Discussion) and output
+(a GitHub epic + sub-issue DAG). You consume the skill files **by path** — they
+are plain markdown, readable by any agent runtime. Provenance + refresh in
+`frameworks/bmad-method/VENDOR.md` and `frameworks/bmad-test-architecture/VENDOR.md`.
+
+Vendored skill locations:
+- Scrum Master / story skills: `frameworks/bmad-method/src/bmm-skills/4-implementation/`
+- Test Architect ("Murat") + testarch workflows: `frameworks/bmad-test-architecture/src/`
+
+## Step 1 — Become Bob (Scrum Master)
+
+You are **Bob** 🏃 — Technical Scrum Master, crisp and checklist-driven, zero
+tolerance for ambiguity, whose job is to set the `dev-lead` developer agent up to
+succeed.
+
+## Step 2 — Sprint planning (sequence the work)
+
+Read and follow the sprint-planning skill, applied to our input (the approved
+idea + repo context at `$CONTEXT_PATH`):
+
+```bash
+cat frameworks/bmad-method/src/bmm-skills/4-implementation/bmad-sprint-planning/SKILL.md
+cat frameworks/bmad-method/src/bmm-skills/4-implementation/bmad-sprint-planning/checklist.md
+```
+
+Decompose into the **smallest set of stories** (typically 3–8), each a single
+PR-sized unit for `dev-lead`, sequenced by a minimal `blocked_by` DAG (true
+ordering only; acyclic, with an entry point). Prerequisites already tracked as
+repo issues (see `referenced_issues`) become `blocked_by_existing_issues`, not
+new stories.
+
+## Step 3 — Create each story (BMAD create-story method)
+
+Read and follow the create-story skill. Its template is the required story shape;
+its checklist is the readiness bar each story clears:
+
+```bash
+cat frameworks/bmad-method/src/bmm-skills/4-implementation/bmad-create-story/SKILL.md
+cat frameworks/bmad-method/src/bmm-skills/4-implementation/bmad-create-story/template.md
+cat frameworks/bmad-method/src/bmm-skills/4-implementation/bmad-create-story/checklist.md
+```
+
+Ground every story in the actual repo (Read/Grep/Glob on `AGENTS.md`, `CLAUDE.md`,
+`scripts/`, `.github/workflows/`, `docs/initiatives/`). The implementer sees
+**only the story**, so its **Dev Notes** must carry the architecture constraints,
+the source-tree components to touch, and the testing standards — with
+**References** citing real paths (e.g. `scripts/engine.sh`).
+
+> Adaptation: these skills normally write a story **file** and may elicit
+> interactively. Here you run **non-interactively** and the output is GitHub
+> **issues**, so use the skills for their method, templates, and checklists — but
+> capture the result into `$PLAN_PATH` (below), and never block on prompts.
+
+## Step 4 — (optional) Test strategy via the Test Architect
+
+For stories with non-trivial test surface, consult the Test Architect ("Murat")
+and its test-design workflow to sharpen acceptance criteria / Dev Notes testing
+guidance:
+
+```bash
+cat frameworks/bmad-test-architecture/src/agents/bmad-tea/*.md 2>/dev/null | head -120
+ls frameworks/bmad-test-architecture/src/workflows/testarch/
+```
+
+Keep it lightweight — this is planning, not test authoring.
+
+## Step 5 — Emit the plan JSON (the machine contract)
+
+Translate your sequenced, checklist-passing stories into the plan object at
+`$PLAN_PATH`, conforming to `scripts/initiative-planner/plan.schema.json`, which
+mirrors the BMAD create-story template field-for-field:
+
+- `user_story` → `As a / I want / so that`
+- `acceptance_criteria` → numbered, testable AC
+- `tasks` → Tasks/Subtasks, each citing the AC indices it satisfies (`ac_refs`)
+- `dev_notes` → architecture / source-tree / testing guidance
+- `project_structure_notes`, `references` → as in the template
+- plus `id`, `title` (`[Phase N]` prefix when ordered), `size`, `blocked_by`,
+  `blocked_by_existing_issues`, `hands_off`
+
+`apply-plan.sh` renders the issue body from these in exact template order.
+
+## Hard rules
+
+- Output only the plan JSON — no prose outside it. The schema is the contract.
+- Never apply `initiative:auto`; the epic is created inert (apply-plan enforces).
+- Don't invent acceptance criteria or Dev Notes you can't tie to the idea or the
+  repo. Unresolved items go in `open_questions`, not guesses.
+- Don't duplicate an open epic from `open_epics`; if already covered, say so in a
+  single story + `open_questions` referencing that epic.

--- a/scripts/idea-triage/gather-ideas.sh
+++ b/scripts/idea-triage/gather-ideas.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# gather-ideas.sh — assemble context for the weekly idea-triage pass: every open
+# Ideas Discussion plus the signals needed to judge "ripeness" (open initiative
+# epics it might already be covered by, and open issues it might reference).
+#
+# Emits $CONTEXT_PATH (JSON). The triage agent reads it, ranks the ideas, and
+# refreshes the "Idea Promotion Queue" tracking issue.
+#
+# Env: REPO, CONTEXT_PATH (required); GH_TOKEN.
+set -euo pipefail
+
+REPO="${REPO:?REPO required}"
+CONTEXT_PATH="${CONTEXT_PATH:?CONTEXT_PATH required}"
+
+owner="${REPO%/*}"
+name="${REPO#*/}"
+
+all_ideas="[]"
+cursor=""
+has_next="true"
+
+while [[ "$has_next" = "true" ]]; do
+  extra_args=()
+  [[ -n "$cursor" ]] && extra_args+=(-F after="$cursor")
+
+  page="$(gh api graphql \
+    -f query='
+      query($owner:String!,$name:String!,$after:String){
+        repository(owner:$owner,name:$name){
+          discussions(first:50, after:$after, orderBy:{field:UPDATED_AT, direction:DESC}){
+            pageInfo{ hasNextPage endCursor }
+            nodes{
+              number title url createdAt updatedAt
+              category{ name }
+              labels(first:20){ nodes{ name } }
+              comments{ totalCount }
+              bodyText
+            }
+          }
+        }
+      }' \
+    -F owner="$owner" -F name="$name" "${extra_args[@]}")"
+
+  nodes="$(printf '%s' "$page" \
+    | jq '[.data.repository.discussions.nodes[]
+           | select(.category.name == "Ideas")
+           | {number, title, url, createdAt, updatedAt,
+              comments: .comments.totalCount,
+              labels: [.labels.nodes[].name],
+              excerpt: (.bodyText[0:600])}]')"
+  all_ideas="$(jq -n --argjson a "$all_ideas" --argjson b "$nodes" '$a + $b')"
+
+  has_next="$(printf '%s' "$page" | jq -r '.data.repository.discussions.pageInfo.hasNextPage')"
+  cursor="$(printf '%s' "$page" | jq -r '.data.repository.discussions.pageInfo.endCursor // ""')"
+done
+
+ideas="$all_ideas"
+
+if ! epics="$(gh issue list --repo "$REPO" --label initiative --state open \
+  --json number,title --jq '[.[] | {number, title}]' 2>/dev/null)"; then
+  echo "::error::failed to fetch open initiative epics for ${REPO}" >&2
+  exit 1
+fi
+
+jq -n --argjson ideas "$ideas" --argjson epics "$epics" --arg repo "$REPO" \
+  '{repo: $repo, open_ideas: $ideas, open_epics: $epics}' >"$CONTEXT_PATH"
+
+echo "context written to ${CONTEXT_PATH} (ideas=$(printf '%s' "$ideas" | jq 'length'), epics=$(printf '%s' "$epics" | jq 'length'))"

--- a/scripts/idea-triage/upsert-queue.sh
+++ b/scripts/idea-triage/upsert-queue.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# upsert-queue.sh — find-or-create the single "Idea Promotion Queue" tracking
+# issue and replace its body with the freshly-ranked shortlist. Idempotent:
+# one issue, rewritten each run. Honors DRY_RUN.
+#
+# The queue issue is purely informational — a human reads it and decides which
+# ideas to bless by adding `idea:approved` to the corresponding Discussion
+# (which then fires initiative-planner.yml). Triage never auto-approves.
+#
+# Env:
+#   REPO             owner/repo (required)
+#   QUEUE_BODY_PATH  file holding the new issue body markdown (required)
+#   QUEUE_TITLE      tracking issue title (default below)
+#   QUEUE_LABEL      tracking issue label (default: idea-triage)
+#   DRY_RUN / DRY_RUN_LOG  "1" => log instead of mutate
+set -euo pipefail
+
+REPO="${REPO:?REPO required}"
+QUEUE_BODY_PATH="${QUEUE_BODY_PATH:?QUEUE_BODY_PATH required}"
+QUEUE_TITLE="${QUEUE_TITLE:-🧭 Idea Promotion Queue}"
+QUEUE_LABEL="${QUEUE_LABEL:-idea-triage}"
+
+[[ -s "$QUEUE_BODY_PATH" ]] || { echo "::error::queue body '$QUEUE_BODY_PATH' missing or empty" >&2; exit 1; }
+
+_is_dry_run() { [[ "${DRY_RUN:-0}" = "1" ]]; }
+_dry_log() { printf '%s\n' "$1" >>"${DRY_RUN_LOG:-./dry-run.jsonl}"; }
+
+# Locate an existing open queue issue by exact title (scoped by label).
+existing=""
+if ! _is_dry_run; then
+  if ! existing="$(gh issue list --repo "$REPO" --label "$QUEUE_LABEL" --state open \
+    --json number,title --jq \
+    --arg t "$QUEUE_TITLE" 'map(select(.title == $t)) | (.[0].number // "")' 2>/dev/null)"; then
+    echo "::error::failed to query existing queue issues in ${REPO}" >&2
+    exit 1
+  fi
+fi
+
+if _is_dry_run; then
+  _dry_log "$(jq -nc --arg op upsert_queue --arg title "$QUEUE_TITLE" \
+    --arg label "$QUEUE_LABEL" --rawfile body "$QUEUE_BODY_PATH" \
+    '{op:$op, title:$title, label:$label, body_len:($body|length)}')"
+  echo "[dry-run] would upsert queue issue '${QUEUE_TITLE}'"
+  exit 0
+fi
+
+if [[ -n "$existing" ]]; then
+  gh issue edit "$existing" --repo "$REPO" --body-file "$QUEUE_BODY_PATH" >/dev/null
+  echo "updated queue issue #${existing}"
+else
+  # Ensure the label exists (ignore failure if it already does).
+  gh label create "$QUEUE_LABEL" --repo "$REPO" \
+    --description "Idea-triage tracking issue" --color ededed 2>/dev/null || true
+  url="$(gh issue create --repo "$REPO" --title "$QUEUE_TITLE" \
+    --label "$QUEUE_LABEL" --body-file "$QUEUE_BODY_PATH")"
+  echo "created queue issue ${url}"
+fi

--- a/scripts/initiative-planner/README.md
+++ b/scripts/initiative-planner/README.md
@@ -1,0 +1,44 @@
+# initiative-planner tooling
+
+Backs `.github/workflows/initiative-planner.yml` — the BMAD Scrum Master ("Bob")
+that turns one approved idea (an Ideas Discussion) into a GitHub epic + sub-issue
+DAG, ready for `initiative-driver` → `dev-lead`. See the full pipeline in
+[`docs/initiatives/idea-to-initiative-pipeline.md`](../../docs/initiatives/idea-to-initiative-pipeline.md).
+
+Bob follows the **real BMAD Method skills, vendored agent-agnostically under
+`frameworks/`** (v6.8.0 + Test Architect v1.19.0; see
+[`prompts/bmad/`](../../prompts/bmad/README.md)) — `bmad-sprint-planning` +
+`bmad-create-story`, read by path. Stories are emitted in the canonical BMAD
+create-story template, which `plan.schema.json` mirrors field-for-field.
+
+| File | Role |
+|------|------|
+| `gather-context.sh` | Fetch the approved Discussion + repo context → `$CONTEXT_PATH`; export `DISCUSSION_NODE_ID`. |
+| `plan.schema.json` | The plan contract Bob must emit (epic + stories + `blocked_by`). |
+| `validate-plan.py` | Schema + semantic checks: unique ids, acyclic DAG, an entry point, no dangling edges. |
+| `lib/mutations.sh` | DRY_RUN-aware GitHub helpers (create issue, link sub-issue, add `blocked_by`, comment on Discussion). |
+| `apply-plan.sh` | Materialize a validated plan. Creates issues labelled `initiative` only — **never** `initiative:auto`. |
+
+Tests: `tests/test_initiative_planner.bats` (run via `lint.yml`).
+
+## Local dry run
+
+```bash
+# 1. Author or fetch a plan.json (see the schema), then:
+python3 scripts/initiative-planner/validate-plan.py plan.json
+
+# 2. Dry-run apply — logs intended mutations, touches nothing:
+DRY_RUN=1 DRY_RUN_LOG=/tmp/plan.jsonl \
+REPO=petry-projects/.github-private \
+DISCUSSION_NUMBER=413 DISCUSSION_NODE_ID=D_xxx \
+PLAN_PATH=plan.json \
+bash scripts/initiative-planner/apply-plan.sh
+cat /tmp/plan.jsonl | jq .
+```
+
+## Invariants (enforced by tests)
+
+- `apply-plan.sh` can never apply `initiative:auto` — activation is a human step.
+- `hands_off` stories also get `dev-lead:hands-off` + `initiative:hold`.
+- A dependency cycle, a missing entry point, or a dangling `blocked_by` fails
+  validation before any issue is created.

--- a/scripts/initiative-planner/apply-plan.sh
+++ b/scripts/initiative-planner/apply-plan.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# apply-plan.sh — materialize a validated initiative plan as a GitHub epic +
+# sub-issue DAG. Honors DRY_RUN (see lib/mutations.sh).
+#
+# What it creates:
+#   - 1 epic issue           labelled `initiative`
+#   - N story sub-issues      labelled `initiative` (hands_off stories also get
+#                             `dev-lead:hands-off` + `initiative:hold`)
+#   - native sub-issue links  (each story under the epic)
+#   - native blocked_by edges (intra-plan ordering + existing-issue prereqs)
+#   - a summary comment back on the source Discussion
+#
+# What it deliberately does NOT do:
+#   - apply `initiative:auto`. The epic is created INERT. A human reviews the
+#     real epic/DAG and adds `initiative:auto` to hand it to initiative-driver.
+#
+# Env:
+#   REPO                 owner/repo (required)
+#   PLAN_PATH            path to validated plan.json (required)
+#   DISCUSSION_NUMBER    source discussion number (for the summary text)
+#   DISCUSSION_NODE_ID   source discussion GraphQL node id (optional; if set,
+#                        the plan summary is posted back as a comment)
+#   DRY_RUN / DRY_RUN_LOG  see lib/mutations.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/mutations.sh
+. "${SCRIPT_DIR}/lib/mutations.sh"
+
+REPO="${REPO:?REPO required}"
+PLAN_PATH="${PLAN_PATH:?PLAN_PATH required}"
+DISCUSSION_NUMBER="${DISCUSSION_NUMBER:-}"
+DISCUSSION_NODE_ID="${DISCUSSION_NODE_ID:-}"
+
+[ -s "$PLAN_PATH" ] || { echo "::error::plan file '$PLAN_PATH' missing or empty" >&2; exit 1; }
+
+# ── epic ──────────────────────────────────────────────────────────────────────
+epic_title="$(jq -r '.epic.title' "$PLAN_PATH")"
+epic_body="$(jq -r '.epic.body' "$PLAN_PATH")"
+src="$(jq -r '.source_discussion // empty' "$PLAN_PATH")"
+[ -n "$src" ] || src="$DISCUSSION_NUMBER"
+if [ -n "$src" ]; then
+  epic_body="${epic_body}"$'\n\n'"---"$'\n'"Planned from idea discussion #${src} by the BMAD Scrum Master initiative-planner. **Inert until a maintainer adds \`initiative:auto\`.**"
+fi
+
+epic_out="$(create_issue "$REPO" "$epic_title" "$epic_body" "initiative")"
+read -r epic_number epic_id <<< "$epic_out"
+echo "epic: #${epic_number} (id ${epic_id}) — ${epic_title}"
+
+# ── stories (id order) ────────────────────────────────────────────────────────
+# Map: local story id -> created issue number (used to thread blocked_by edges).
+declare -A NUM_BY_LOCAL=()
+
+story_count="$(jq '.stories | length' "$PLAN_PATH")"
+mapfile -t local_ids < <(jq -r '.stories | sort_by(.id) | .[].id' "$PLAN_PATH")
+
+for lid in "${local_ids[@]}"; do
+  title="$(jq -r --argjson i "$lid" '.stories[] | select(.id==$i) | .title' "$PLAN_PATH")"
+  hands_off="$(jq -r --argjson i "$lid" '.stories[] | select(.id==$i) | .hands_off // false' "$PLAN_PATH")"
+  # Compose the story body in the BMAD create-story template order:
+  # Story / Acceptance Criteria / Tasks-Subtasks / Dev Notes / Project Structure
+  # Notes / References. (See prompts/bmad/skills/create-story/template.md.)
+  body="$(jq -r --argjson i "$lid" '
+    .stories[] | select(.id==$i)
+    | "## Story\n"
+      + "As a " + .user_story.role + ",\nI want " + .user_story.action + ",\nso that " + .user_story.benefit + ".\n"
+      + "\n## Acceptance Criteria\n"
+      + ([.acceptance_criteria | to_entries[] | "\(.key + 1). \(.value)"] | join("\n"))
+      + "\n\n## Tasks / Subtasks\n"
+      + ([.tasks[]
+          | "- [ ] " + .task
+            + (if (.ac_refs // []) | length > 0 then " (AC: " + ([.ac_refs[] | "#\(.)"] | join(", ")) + ")" else "" end)
+            + (if (.subtasks // []) | length > 0 then "\n" + ([.subtasks[] | "  - [ ] " + .] | join("\n")) else "" end)
+         ] | join("\n"))
+      + "\n\n## Dev Notes\n" + ([.dev_notes[] | "- " + .] | join("\n"))
+      + (if .project_structure_notes then "\n\n### Project Structure Notes\n" + .project_structure_notes else "" end)
+      + (if (.references // []) | length > 0 then "\n\n### References\n" + ([.references[] | "- " + .] | join("\n")) else "" end)
+      + (if (.target_surface // []) | length > 0 then "\n\n### Likely target surface\n" + ([.target_surface[] | "- `" + . + "`"] | join("\n")) else "" end)
+  ' "$PLAN_PATH")"
+  body="${body}"$'\n\n'"_Story prepared by the BMAD Scrum Master (Bob) for epic #${epic_number}. Status: ready-for-dev._"
+
+  labels="initiative"
+  if [ "$hands_off" = "true" ]; then
+    labels="initiative,dev-lead:hands-off,initiative:hold"
+  fi
+
+  story_out="$(create_issue "$REPO" "$title" "$body" "$labels")"
+  read -r s_number s_id <<< "$story_out"
+  NUM_BY_LOCAL[$lid]="$s_number"
+  echo "  story[$lid]: #${s_number} (id ${s_id}) — ${title}$(if [ "$hands_off" = "true" ]; then echo ' [hands-off]'; fi)"
+
+  link_sub_issue "$REPO" "$epic_number" "$s_id"
+done
+
+# ── dependency edges ──────────────────────────────────────────────────────────
+for lid in "${local_ids[@]}"; do
+  issue_num="${NUM_BY_LOCAL[$lid]}"
+
+  # intra-plan blockers (local ids -> created numbers)
+  while IFS= read -r dep_local; do
+    [ -n "$dep_local" ] || continue
+    add_blocked_by "$REPO" "$issue_num" "${NUM_BY_LOCAL[$dep_local]}"
+    echo "  edge: #${issue_num} blocked_by #${NUM_BY_LOCAL[$dep_local]} (plan-local ${lid}<-${dep_local})"
+  done < <(jq -r --argjson i "$lid" '.stories[] | select(.id==$i) | (.blocked_by // [])[]' "$PLAN_PATH")
+
+  # existing-issue prerequisites (real numbers as-is)
+  while IFS= read -r dep_existing; do
+    [ -n "$dep_existing" ] || continue
+    add_blocked_by "$REPO" "$issue_num" "$dep_existing"
+    echo "  edge: #${issue_num} blocked_by existing #${dep_existing}"
+  done < <(jq -r --argjson i "$lid" '.stories[] | select(.id==$i) | (.blocked_by_existing_issues // [])[]' "$PLAN_PATH")
+done
+
+# ── post the plan back to the discussion ──────────────────────────────────────
+if [ -n "$DISCUSSION_NODE_ID" ]; then
+  rows=""
+  for lid in "${local_ids[@]}"; do
+    t="$(jq -r --argjson i "$lid" '.stories[] | select(.id==$i) | .title' "$PLAN_PATH")"
+    sz="$(jq -r --argjson i "$lid" '.stories[] | select(.id==$i) | .size' "$PLAN_PATH")"
+    rows="${rows}- #${NUM_BY_LOCAL[$lid]} (${sz}) — ${t}"$'\n'
+  done
+  oq="$(jq -r '(.open_questions // []) | if length>0 then "\n**Open questions for review:**\n" + ([.[] | "- " + .] | join("\n")) else "" end' "$PLAN_PATH")"
+  comment="$(printf '<!-- initiative-planner -->\n**📋 Initiative planned by the BMAD Scrum Master (Bob).**\n\nEpic **#%s** — %s\n\n%s stories created (inert — labelled `initiative`, NOT `initiative:auto`):\n\n%s\n%s\n---\nReview the epic and its sub-issue DAG, adjust as needed, then add **`initiative:auto`** to epic #%s to hand it to `initiative-driver` for auto-implementation.' \
+    "$epic_number" "$epic_title" "$story_count" "$rows" "$oq" "$epic_number")"
+  comment_on_discussion "$DISCUSSION_NODE_ID" "$comment"
+  echo "posted plan summary to discussion #${DISCUSSION_NUMBER:-?}"
+fi
+
+# ── step summary ──────────────────────────────────────────────────────────────
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "## Initiative plan applied$(if [ "${DRY_RUN:-0}" = "1" ]; then echo " (DRY_RUN)"; fi)"
+    echo "- Epic: #${epic_number} — ${epic_title}"
+    echo "- Stories: ${story_count}"
+    echo "- Epic is **inert** (no \`initiative:auto\`); add it manually to activate."
+  } >>"$GITHUB_STEP_SUMMARY"
+fi
+
+echo "done. epic=#${epic_number} stories=${story_count} dry_run=${DRY_RUN:-0}"

--- a/scripts/initiative-planner/gather-context.sh
+++ b/scripts/initiative-planner/gather-context.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# gather-context.sh — assemble the planning context for the BMAD Scrum Master.
+#
+# Discussions are not part of the git checkout, so we fetch the approved idea
+# (title/body/first 50 comments + GraphQL node id) here and hand it to the agent as a
+# single JSON file. We also surface the open `initiative` epics (so Bob can
+# avoid duplicating one) and the issue numbers the idea references (likely
+# prerequisites). The agent reads everything else (AGENTS.md, scripts, docs)
+# straight from the checkout with its own tools.
+#
+# Emits:
+#   - $CONTEXT_PATH (JSON)               the planning context
+#   - DISCUSSION_NODE_ID -> $GITHUB_ENV  so apply-plan can comment back
+#
+# Env: REPO, DISCUSSION_NUMBER, CONTEXT_PATH (all required); GH_TOKEN.
+set -euo pipefail
+
+REPO="${REPO:?REPO required}"
+DISCUSSION_NUMBER="${DISCUSSION_NUMBER:?DISCUSSION_NUMBER required}"
+CONTEXT_PATH="${CONTEXT_PATH:?CONTEXT_PATH required}"
+
+owner="${REPO%/*}"
+name="${REPO#*/}"
+
+# ── the approved idea (GraphQL: discussion is not in the REST issues space) ────
+disc="$(gh api graphql -f query='
+  query($owner:String!,$name:String!,$num:Int!){
+    repository(owner:$owner,name:$name){
+      discussion(number:$num){
+        id title body url
+        category{ name }
+        comments(first:50){ nodes{ author{login} body createdAt } }
+      }
+    }
+  }' -F owner="$owner" -F name="$name" -F num="$DISCUSSION_NUMBER")"
+
+node_id="$(printf '%s' "$disc" | jq -r '.data.repository.discussion.id')"
+category="$(printf '%s' "$disc" | jq -r '.data.repository.discussion.category.name // ""')"
+if [[ -z $node_id ]] || [[ $node_id = "null" ]]; then
+  echo "::error::discussion #${DISCUSSION_NUMBER} not found in ${REPO}" >&2
+  exit 1
+fi
+if [[ $category != "Ideas" ]]; then
+  echo "::warning::discussion #${DISCUSSION_NUMBER} is in category '${category}', not 'Ideas' — planning anyway."
+fi
+printf 'DISCUSSION_NODE_ID=%s\n' "$node_id" >>"${GITHUB_ENV:-/dev/null}"
+
+# ── existing open epics (avoid duplicate initiatives) ─────────────────────────
+if ! epics="$(gh issue list --repo "$REPO" --label initiative --state open \
+  --json number,title --jq '[.[] | {number, title}]' 2>/dev/null)"; then
+  echo "::error::failed to fetch open initiative epics for ${REPO}" >&2
+  exit 1
+fi
+
+# ── issue numbers referenced by the idea (likely prerequisites) ───────────────
+refs="$(printf '%s' "$disc" \
+  | jq -r '.data.repository.discussion | ((.body // "") + " " + ([.comments.nodes[].body // empty] | join(" ")))' \
+  | grep -oE '#[0-9]+' | tr -d '#' | sort -un | head -30 || true)"
+ref_json='[]'
+if [[ -n $refs ]]; then
+  ref_json="$(while IFS= read -r n; do
+      [[ -n $n ]] || continue
+      gh api "repos/${REPO}/issues/${n}" --jq '{number, title, state}' 2>/dev/null \
+        || { echo "::error::failed to fetch issue ${n} from ${REPO}" >&2; exit 1; }
+    done <<<"$refs" | jq -sc '.')"
+fi
+
+# ── assemble ──────────────────────────────────────────────────────────────────
+jq -n \
+  --argjson disc "$disc" \
+  --argjson epics "$epics" \
+  --argjson refs "$ref_json" \
+  --arg repo "$REPO" \
+  --argjson num "$DISCUSSION_NUMBER" \
+  '{
+     repo: $repo,
+     discussion: ($disc.data.repository.discussion | {number: $num, title, body, url, category: .category.name, comments: [.comments.nodes[] | {author: .author.login, body, createdAt}]}),
+     open_epics: $epics,
+     referenced_issues: $refs
+   }' >"$CONTEXT_PATH"
+
+echo "context written to ${CONTEXT_PATH} (node=${node_id}, refs=$(printf '%s' "$ref_json" | jq 'length'), epics=$(printf '%s' "$epics" | jq 'length'))"

--- a/scripts/initiative-planner/lib/mutations.sh
+++ b/scripts/initiative-planner/lib/mutations.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# mutations.sh — GitHub issue/sub-issue/dependency mutations for the initiative
+# planner, with a DRY_RUN switch. Mirrors the feature-ideation
+# discussion-mutations.sh contract: when DRY_RUN=1 every mutating call logs a
+# structured "planned action" JSONL entry instead of touching GitHub, so the
+# planner can be smoke-tested and audited before it writes anything.
+#
+# Native GitHub APIs used (verified against this repo's existing epics):
+#   - sub-issues:    POST repos/{repo}/issues/{epic}/sub_issues   {sub_issue_id}
+#   - dependencies:  POST repos/{repo}/issues/{n}/dependencies/blocked_by {issue_id}
+# Both take the issue's REST id (not its number); create_issue returns both.
+#
+# IMPORTANT: this library NEVER applies the `initiative:auto` label. Activation
+# of auto-implementation is a deliberate human step (see apply-plan.sh).
+#
+# Env:
+#   DRY_RUN      "1" => log instead of execute
+#   DRY_RUN_LOG  JSONL log path (default: ./dry-run.jsonl)
+#   GH_TOKEN     required when not in DRY_RUN (gh reads it)
+
+set -euo pipefail
+
+_is_dry_run() { [[ "${DRY_RUN:-0}" == "1" ]]; }
+
+_dry_log() {
+  printf '%s\n' "$1" >>"${DRY_RUN_LOG:-./dry-run.jsonl}"
+}
+
+# Synthetic, monotonically-increasing number/id for dry runs so blocked_by edges
+# still thread distinct values. Backed by a file (not a shell var) because
+# create_issue is called inside process-substitution subshells, where a mutated
+# global would not persist back to the caller.
+_next_dry_id() {
+  local f="${DRY_RUN_LOG:-./dry-run.jsonl}.seq" n
+  n="$(cat "$f" 2>/dev/null || printf '900000')"
+  n=$((n + 1))
+  printf '%s' "$n" >"$f"
+  printf '%s' "$n"
+}
+
+# create_issue <repo> <title> <body> <labels_csv>
+# Prints "<number> <id>" (space-separated) on stdout.
+create_issue() {
+  if [[ "$#" -ne 4 ]]; then
+    printf '[create_issue] expected 4 args (repo title body labels_csv), got %d\n' "$#" >&2
+    return 64
+  fi
+  local repo="$1" title="$2" body="$3" labels="$4"
+
+  if _is_dry_run; then
+    local n
+    n="$(_next_dry_id)"
+    _dry_log "$(jq -nc \
+      --arg op create_issue --arg title "$title" --arg labels "$labels" --arg body "$body" \
+      --argjson number "$n" \
+      '{op:$op, number:$number, title:$title, labels:($labels|split(",")|map(select(length>0))), body:$body}')"
+    printf '%s %s\n' "$n" "$n"
+    return 0
+  fi
+
+  local payload resp number id
+  payload="$(jq -nc --arg t "$title" --arg b "$body" --arg l "$labels" \
+    '{title:$t, body:$b, labels:($l|split(",")|map(select(length>0)))}')"
+  resp="$(printf '%s' "$payload" | gh api "repos/${repo}/issues" -X POST --input -)"
+  number="$(printf '%s' "$resp" | jq -r '.number')"
+  id="$(printf '%s' "$resp" | jq -r '.id')"
+  printf '%s %s\n' "$number" "$id"
+}
+
+# issue_id <repo> <number> — resolve an existing issue's REST id (live only).
+issue_id() {
+  local repo="$1" number="$2"
+  gh api "repos/${repo}/issues/${number}" --jq '.id'
+}
+
+# link_sub_issue <repo> <epic_number> <child_id>
+link_sub_issue() {
+  local repo="$1" epic="$2" child_id="$3"
+  if _is_dry_run; then
+    _dry_log "$(jq -nc --arg op add_sub_issue \
+      --argjson epic "$epic" --argjson child "$child_id" \
+      '{op:$op, epic:$epic, sub_issue_id:$child}')"
+    return 0
+  fi
+  gh api "repos/${repo}/issues/${epic}/sub_issues" -X POST -F sub_issue_id="${child_id}" >/dev/null
+}
+
+# add_blocked_by <repo> <issue_number> <blocker_number>
+# Resolves the blocker's REST id at call time (live); logs by number (dry).
+add_blocked_by() {
+  local repo="$1" issue="$2" blocker="$3"
+  if _is_dry_run; then
+    _dry_log "$(jq -nc --arg op add_blocked_by \
+      --argjson issue "$issue" --argjson blocker "$blocker" \
+      '{op:$op, issue:$issue, blocked_by:$blocker}')"
+    return 0
+  fi
+  local blocker_id
+  blocker_id="$(issue_id "$repo" "$blocker")"
+  gh api "repos/${repo}/issues/${issue}/dependencies/blocked_by" \
+    -X POST -F issue_id="${blocker_id}" >/dev/null
+}
+
+# comment_on_discussion <discussion_node_id> <body>
+comment_on_discussion() {
+  local node_id="$1" body="$2"
+  if _is_dry_run; then
+    _dry_log "$(jq -nc --arg op comment_on_discussion \
+      --arg id "$node_id" --arg body "$body" \
+      '{op:$op, discussion_id:$id, body:$body}')"
+    return 0
+  fi
+  gh api graphql -f query='
+    mutation($id:ID!,$b:String!){ addDiscussionComment(input:{discussionId:$id, body:$b}){ comment{ url } } }
+  ' -f id="$node_id" -f b="$body" --jq '.data.addDiscussionComment.comment.url'
+}

--- a/scripts/initiative-planner/plan.schema.json
+++ b/scripts/initiative-planner/plan.schema.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Initiative Plan",
+  "description": "Output contract for the BMAD Scrum Master initiative planner. apply-plan.sh consumes this to create the epic + sub-issue DAG.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["epic", "stories"],
+  "properties": {
+    "source_discussion": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Discussion number this plan was generated from."
+    },
+    "epic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["title", "body"],
+      "properties": {
+        "title": { "type": "string", "minLength": 8 },
+        "body": { "type": "string", "minLength": 30 }
+      }
+    },
+    "stories": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 20,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "title", "user_story", "acceptance_criteria", "tasks", "dev_notes", "size"],
+        "description": "A story in the BMAD create-story template shape (Story / AC / Tasks-Subtasks / Dev Notes). apply-plan.sh renders the issue body in that order.",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Local 1-based index, unique within the plan. Used only to express blocked_by edges."
+          },
+          "title": { "type": "string", "minLength": 8 },
+          "user_story": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["role", "action", "benefit"],
+            "description": "BMAD story statement: As a {role}, I want {action}, so that {benefit}.",
+            "properties": {
+              "role": { "type": "string", "minLength": 2 },
+              "action": { "type": "string", "minLength": 5 },
+              "benefit": { "type": "string", "minLength": 5 }
+            }
+          },
+          "acceptance_criteria": {
+            "type": "array",
+            "minItems": 1,
+            "description": "Numbered, testable outcomes. Tasks reference these by 1-based index.",
+            "items": { "type": "string", "minLength": 5 }
+          },
+          "tasks": {
+            "type": "array",
+            "minItems": 1,
+            "description": "BMAD Tasks / Subtasks breakdown; each task cites the AC indices it satisfies.",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["task"],
+              "properties": {
+                "task": { "type": "string", "minLength": 5 },
+                "ac_refs": {
+                  "type": "array",
+                  "items": { "type": "integer", "minimum": 1 },
+                  "description": "1-based indices into acceptance_criteria."
+                },
+                "subtasks": { "type": "array", "items": { "type": "string" } }
+              }
+            }
+          },
+          "dev_notes": {
+            "type": "array",
+            "minItems": 1,
+            "description": "BMAD Dev Notes: architecture patterns/constraints, source-tree components to touch, testing standards. The implementer (dev-lead) sees ONLY the story, so ground it here.",
+            "items": { "type": "string", "minLength": 5 }
+          },
+          "project_structure_notes": {
+            "type": "string",
+            "description": "Alignment with the repo's structure; any conflicts/variances with rationale."
+          },
+          "references": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Source citations, e.g. 'scripts/engine.sh#tier-routing', 'AGENTS.md#standards'."
+          },
+          "target_surface": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Files/scripts/workflows the implementer will likely touch."
+          },
+          "size": { "type": "string", "enum": ["S", "M", "L"] },
+          "blocked_by": {
+            "type": "array",
+            "items": { "type": "integer", "minimum": 1 },
+            "description": "Local story ids this story depends on.",
+            "default": []
+          },
+          "blocked_by_existing_issues": {
+            "type": "array",
+            "items": { "type": "integer", "minimum": 1 },
+            "description": "Existing repo issue numbers this story depends on (e.g. a prerequisite bug).",
+            "default": []
+          },
+          "hands_off": {
+            "type": "boolean",
+            "default": false,
+            "description": "True => a human must do this; never auto-released to dev-lead."
+          }
+        }
+      }
+    },
+    "open_questions": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Things the planner could not resolve from context; surfaced for the human reviewer."
+    }
+  }
+}

--- a/scripts/initiative-planner/validate-plan.py
+++ b/scripts/initiative-planner/validate-plan.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Validate an initiative plan JSON against plan.schema.json.
+
+Beyond JSON-Schema structural checks, enforces the semantic invariants the
+downstream sub-issue/blocked_by DAG depends on:
+
+  - story ids are unique
+  - every blocked_by edge references a story id that exists in the plan
+  - no story blocks itself
+  - the blocked_by graph is acyclic (a cycle = a deadlock the driver can
+    never release)
+  - at least one story has no blockers (an entry point the driver can start)
+
+Usage: validate-plan.py <plan.json> [schema.json]
+Exit 0 on success; non-zero with a message on failure.
+"""
+import json
+import sys
+from pathlib import Path
+from typing import NoReturn
+
+
+def fail(msg: str) -> NoReturn:
+    # stdout (not stderr) so the reason is visible in workflow logs and capturable
+    # by tests; the ::error:: prefix still renders as a GitHub annotation.
+    print(f"::error::initiative plan invalid: {msg}")
+    sys.exit(1)
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        fail("usage: validate-plan.py <plan.json> [schema.json]")
+    plan_path = Path(sys.argv[1])
+    schema_path = Path(sys.argv[2]) if len(sys.argv) > 2 else Path(__file__).with_name("plan.schema.json")
+
+    try:
+        plan = json.loads(plan_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        fail(f"could not read/parse {plan_path}: {exc}")
+
+    try:
+        import jsonschema
+    except ImportError:
+        fail("jsonschema not installed (pip install 'jsonschema>=4')")
+
+    try:
+        schema = json.loads(schema_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        fail(f"could not read/parse schema {schema_path}: {exc}")
+    try:
+        jsonschema.validate(plan, schema)
+    except jsonschema.ValidationError as exc:
+        loc = "/".join(str(p) for p in exc.absolute_path) or "<root>"
+        fail(f"schema violation at {loc}: {exc.message}")
+
+    stories = plan["stories"]
+    ids = [s["id"] for s in stories]
+    if len(ids) != len(set(ids)):
+        fail("story ids are not unique")
+    id_set = set(ids)
+
+    graph = {}
+    for s in stories:
+        deps = s.get("blocked_by", []) or []
+        for d in deps:
+            if d == s["id"]:
+                fail(f"story {s['id']} blocks itself")
+            if d not in id_set:
+                fail(f"story {s['id']} blocked_by {d}, which is not a story id in this plan")
+        graph[s["id"]] = list(deps)
+
+    has_startable_entry = any(not graph[i] for i in graph)
+    if not has_startable_entry:
+        fail("no entry-point story (every story has a blocker) — the initiative can never start")
+
+    # Cycle detection via DFS colouring.
+    WHITE, GREY, BLACK = 0, 1, 2
+    color = {i: WHITE for i in graph}
+
+    def visit(node: int, stack: list) -> None:
+        color[node] = GREY
+        stack.append(node)
+        for nxt in graph[node]:
+            if color[nxt] == GREY:
+                cycle = " -> ".join(str(x) for x in stack[stack.index(nxt):] + [nxt])
+                fail(f"blocked_by graph has a cycle: {cycle}")
+            if color[nxt] == WHITE:
+                visit(nxt, stack)
+        stack.pop()
+        color[node] = BLACK
+
+    for i in graph:
+        if color[i] == WHITE:
+            visit(i, [])
+
+    print(f"plan OK: {len(stories)} stories, "
+          f"{sum(1 for i in graph if not graph[i])} entry-point(s), acyclic.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_idea_triage.bats
+++ b/tests/test_idea_triage.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+# Tests for the idea-triage queue upsert (scripts/idea-triage/upsert-queue.sh).
+# Only the DRY_RUN path is exercised (no network).
+
+setup() {
+  ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  TRIAGE_DIR="$ROOT/scripts/idea-triage"
+  TMP="$(mktemp -d)"
+  BODY="$TMP/body.md"
+  LOG="$TMP/dry.jsonl"
+  printf '# Idea Promotion Queue\n\nRipe: #562\n' >"$BODY"
+}
+
+teardown() { rm -rf "$TMP"; }
+
+@test "upsert-queue (DRY_RUN) logs the intended upsert with a non-empty body" {
+  DRY_RUN=1 DRY_RUN_LOG="$LOG" REPO="petry-projects/.github-private" \
+    QUEUE_BODY_PATH="$BODY" run bash "$TRIAGE_DIR/upsert-queue.sh"
+  [ "$status" -eq 0 ]
+  grep -q '"op":"upsert_queue"' "$LOG"
+  # body_len recorded and > 0
+  [ "$(jq -r 'select(.op=="upsert_queue") | .body_len' "$LOG")" -gt 0 ]
+}
+
+@test "upsert-queue fails on a missing/empty body" {
+  DRY_RUN=1 DRY_RUN_LOG="$LOG" REPO="petry-projects/.github-private" \
+    QUEUE_BODY_PATH="$TMP/does-not-exist.md" run bash "$TRIAGE_DIR/upsert-queue.sh"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"missing or empty"* ]]
+}

--- a/tests/test_initiative_planner.bats
+++ b/tests/test_initiative_planner.bats
@@ -1,0 +1,131 @@
+#!/usr/bin/env bats
+# Tests for the initiative-planner tooling (scripts/initiative-planner/).
+# The DRY_RUN path touches no network, so the full apply-plan flow runs offline.
+
+setup() {
+  ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  PLANNER_DIR="$ROOT/scripts/initiative-planner"
+  TMP="$(mktemp -d)"
+  PLAN="$TMP/plan.json"
+  LOG="$TMP/dry.jsonl"
+  cat >"$PLAN" <<'JSON'
+{
+  "source_discussion": 413,
+  "epic": { "title": "Initiative: wire new model tiers", "body": "Epic body long enough to pass schema minimums." },
+  "stories": [
+    { "id": 1, "title": "[Phase 1] Fix inert tier routing",
+      "user_story": { "role": "dev-lead operator", "action": "the engine to route by task complexity", "benefit": "higher tiers run only when warranted" },
+      "acceptance_criteria": ["engine.sh routes by complexity", "rate-limit failover detected"],
+      "tasks": [ { "task": "Route writer calls by complexity", "ac_refs": [1], "subtasks": ["map intent to tier"] }, { "task": "Restore failover detection", "ac_refs": [2] } ],
+      "dev_notes": ["Routing is inert today; all intents hit ENGINE_ACTION_MODEL", "Testing: extend tests/model_pricing.bats"],
+      "target_surface": ["scripts/engine.sh"], "size": "M", "blocked_by": [], "blocked_by_existing_issues": [195] },
+    { "id": 2, "title": "[Phase 2] Wire Opus 4.8 behind fallback",
+      "user_story": { "role": "dev-lead operator", "action": "Opus 4.8 wired behind a per-tier fallback", "benefit": "the audit tier uses the strongest model with a safe fallback" },
+      "acceptance_criteria": ["AUDIT tier offers opus-4-8"],
+      "tasks": [ { "task": "Add opus-4-8 to the AUDIT chain", "ac_refs": [1] } ],
+      "dev_notes": ["Add to CLAUDE_AUDIT_MODEL_CHAIN with fallback to 4.7"],
+      "size": "S", "blocked_by": [1] },
+    { "id": 3, "title": "[Phase 2] Human ring-0 soak sign-off",
+      "user_story": { "role": "release manager", "action": "to sign off after a ring-0 soak", "benefit": "promotion is gated on proven health" },
+      "acceptance_criteria": ["soak window documented"],
+      "tasks": [ { "task": "Document and run the soak window" } ],
+      "dev_notes": ["Manual gate; no auto-release"],
+      "size": "S", "blocked_by": [2], "hands_off": true }
+  ],
+  "open_questions": ["Confirm Fable 5 pricing before wiring the apex tier."]
+}
+JSON
+}
+
+teardown() { rm -rf "$TMP"; }
+
+@test "validate-plan accepts a well-formed acyclic plan" {
+  run python3 "$PLANNER_DIR/validate-plan.py" "$PLAN"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"plan OK"* ]]
+}
+
+@test "validate-plan rejects a self-blocking story" {
+  jq '.stories[0].blocked_by = [1]' "$PLAN" >"$TMP/bad.json"
+  run python3 "$PLANNER_DIR/validate-plan.py" "$TMP/bad.json"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"blocks itself"* ]]
+}
+
+@test "validate-plan rejects a dependency cycle (with an entry point present)" {
+  jq '.stories[1].blocked_by = [3] | .stories[2].blocked_by = [2]' "$PLAN" >"$TMP/cycle.json"
+  run python3 "$PLANNER_DIR/validate-plan.py" "$TMP/cycle.json"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cycle"* ]]
+}
+
+@test "validate-plan rejects a dangling blocked_by reference" {
+  jq '.stories[1].blocked_by = [99]' "$PLAN" >"$TMP/dangle.json"
+  run python3 "$PLANNER_DIR/validate-plan.py" "$TMP/dangle.json"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not a story id"* ]]
+}
+
+@test "validate-plan rejects a plan with no entry point" {
+  jq '.stories[0].blocked_by = [2]' "$PLAN" | jq '.stories[1].blocked_by = [1]' >"$TMP/noentry.json"
+  run python3 "$PLANNER_DIR/validate-plan.py" "$TMP/noentry.json"
+  [ "$status" -ne 0 ]
+}
+
+@test "apply-plan (DRY_RUN) creates epic + stories + edges and posts comment" {
+  DRY_RUN=1 DRY_RUN_LOG="$LOG" REPO="petry-projects/.github-private" \
+    DISCUSSION_NUMBER=413 DISCUSSION_NODE_ID="D_test" PLAN_PATH="$PLAN" \
+    run bash "$PLANNER_DIR/apply-plan.sh"
+  [ "$status" -eq 0 ]
+  [ "$(grep -c '"op":"create_issue"' "$LOG")" -eq 4 ]
+  [ "$(grep -c '"op":"add_sub_issue"' "$LOG")" -eq 3 ]
+  [ "$(grep -c '"op":"add_blocked_by"' "$LOG")" -eq 3 ]
+  grep -q '"op":"comment_on_discussion"' "$LOG"
+}
+
+@test "apply-plan threads distinct issue numbers in dry-run" {
+  DRY_RUN=1 DRY_RUN_LOG="$LOG" REPO="petry-projects/.github-private" \
+    DISCUSSION_NUMBER=413 DISCUSSION_NODE_ID="D_test" PLAN_PATH="$PLAN" \
+    bash "$PLANNER_DIR/apply-plan.sh"
+  # 4 distinct synthetic issue numbers (epic + 3 stories), not all the same
+  distinct="$(grep '"op":"create_issue"' "$LOG" | jq -r '.number' | sort -u | wc -l)"
+  [ "$distinct" -eq 4 ]
+}
+
+@test "apply-plan NEVER applies initiative:auto to any created issue" {
+  DRY_RUN=1 DRY_RUN_LOG="$LOG" REPO="petry-projects/.github-private" \
+    DISCUSSION_NUMBER=413 DISCUSSION_NODE_ID="D_test" PLAN_PATH="$PLAN" \
+    bash "$PLANNER_DIR/apply-plan.sh"
+  created_labels="$(grep '"op":"create_issue"' "$LOG" | jq -r '.labels[]')"
+  ! grep -qx 'initiative:auto' <<<"$created_labels"
+}
+
+@test "apply-plan marks hands_off story with hold + hands-off labels" {
+  DRY_RUN=1 DRY_RUN_LOG="$LOG" REPO="petry-projects/.github-private" \
+    DISCUSSION_NUMBER=413 DISCUSSION_NODE_ID="D_test" PLAN_PATH="$PLAN" \
+    bash "$PLANNER_DIR/apply-plan.sh"
+  grep '"op":"create_issue"' "$LOG" | grep -q 'dev-lead:hands-off'
+  grep '"op":"create_issue"' "$LOG" | grep -q 'initiative:hold'
+}
+
+@test "existing-issue prerequisite edge references the real issue number" {
+  DRY_RUN=1 DRY_RUN_LOG="$LOG" REPO="petry-projects/.github-private" \
+    DISCUSSION_NUMBER=413 DISCUSSION_NODE_ID="D_test" PLAN_PATH="$PLAN" \
+    bash "$PLANNER_DIR/apply-plan.sh"
+  grep '"op":"add_blocked_by"' "$LOG" | grep -q '"blocked_by":195'
+}
+
+@test "story bodies are rendered in the BMAD create-story template" {
+  DRY_RUN=1 DRY_RUN_LOG="$LOG" REPO="petry-projects/.github-private" \
+    DISCUSSION_NUMBER=413 DISCUSSION_NODE_ID="D_test" PLAN_PATH="$PLAN" \
+    bash "$PLANNER_DIR/apply-plan.sh"
+  # the rendered Phase-1 story body carries the canonical BMAD sections
+  body="$(grep '"op":"create_issue"' "$LOG" | jq -r 'select(.title|startswith("[Phase 1]")) | .body')"
+  [[ "$body" == *"## Story"* ]]
+  [[ "$body" == *"As a dev-lead operator,"* ]]
+  [[ "$body" == *"## Acceptance Criteria"* ]]
+  [[ "$body" == *"## Tasks / Subtasks"* ]]
+  [[ "$body" == *"(AC: #1)"* ]]
+  [[ "$body" == *"## Dev Notes"* ]]
+  [[ "$body" == *"Status: ready-for-dev"* ]]
+}


### PR DESCRIPTION
## What
The **idea → auto-implementable initiative** pipeline (code only). Two org-private workflows, each bounded by a human gate:

- **`idea-triage.yml`** (weekly) — ranks open Ideas by ripeness, refreshes an "Idea Promotion Queue" tracking issue. Never auto-approves.
- **`initiative-planner.yml`** (on `idea:approved` / dispatch) — the BMAD Scrum Master "Bob" turns one approved idea into a GitHub **epic + sub-issue `blocked_by` DAG**, labelled `initiative` only (inert until a human adds `initiative:auto`). It follows the real BMAD skills (sprint-planning + create-story; Test Architect where useful), **read by path** from `frameworks/`.

Output is exactly what `initiative-driver` + `dev-lead` consume.

## Split from the framework install
The BMAD Method framework itself (`frameworks/`, ~885 files) is vendored in a **companion PR #575** — separated because GitHub's diff API caps at 300 files, which otherwise blocks pr-review from reviewing this PR's code. **Merge #575 first**, then this.

## Safety
Two opt-in human gates (`idea:approved` → `initiative:auto`); planner `dry_run` defaults true on manual dispatch; DAG validated (acyclic, entry point, no dangling edges) before any issue is created; `apply-plan.sh` cannot emit `initiative:auto` (test-enforced); `hands_off` stories also get `dev-lead:hands-off` + `initiative:hold`.

## Tests
13 bats (`tests/test_initiative_planner.bats`, `tests/test_idea_triage.bats`) wired into `lint.yml`; all shellcheck `--severity=warning -x` clean; actions pinned to verified SHAs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated weekly idea triage workflow that ranks and prioritizes ideas into a promotion queue
  * Added initiative planning workflow that converts approved ideas into structured task plans with dependencies
  * Both workflows support dry-run mode to preview changes before applying them

* **Documentation**
  * Added comprehensive guide for the idea-to-initiative automation pipeline
  * Added BMAD method documentation for orchestrated planning

<!-- end of auto-generated comment: release notes by coderabbit.ai -->