### PR TITLE
feat: implement issue #577 — advisory-bot gate strands PRs forever: pushedDate=null disables both absent-bot timeout fallbacks

### DIFF
--- a/scripts/lib/advisory-review-gate.sh
+++ b/scripts/lib/advisory-review-gate.sh
@@ -84,6 +84,23 @@ get_advisory_bot_states() {
   }
 }
 
+# Get the committer date of the PR's head commit via REST API.
+# Uses committer.date (not author.date) so that cherry-picked commits reflect
+# when the cherry-pick was applied (≈push time) rather than the original author
+# date — preserving the cherry-pick guard without relying on pushedDate, which
+# is deprecated in GitHub's GraphQL API and now returns null.
+# Returns empty string on any API failure.
+_get_head_committer_date() {
+  local pr_url="$1"
+  local head_sha repo_path
+  head_sha=$(gh pr view "$pr_url" --json headRefOid --jq '.headRefOid' 2>/dev/null) || head_sha=""
+  [[ -z "$head_sha" ]] && return 0
+  repo_path=$(echo "$pr_url" | sed 's|https://github\.com/||;s|/pull/.*||')
+  [[ -z "$repo_path" ]] && return 0
+  gh api "/repos/${repo_path}/commits/${head_sha}" \
+    --jq '.commit.committer.date // empty' 2>/dev/null || true
+}
+
 # Format bot states for display
 format_bot_status() {
   local bot="$1" state="$2"
@@ -169,42 +186,34 @@ check_advisory_reviews() {
 
     head_age_sec=0
     head_time_raw=""  # Initialize before conditional to prevent set -u abort
-    # Use pushedDate (when the commit arrived on GitHub) not committedDate (author
-    # timestamp) so that old cherry-picked commits don't bypass the gate immediately.
-    # pushedDate is deprecated in GitHub's GraphQL schema but still populated;
-    # do NOT fall back to committedDate — an old commit's authored time can be
-    # hours before its push, which would bypass the gate for cherry-picks.
-    # If pushedDate is unavailable, head_age stays 0 and the fallback is disabled.
-    # $url in the query string is a GraphQL variable, not a shell variable.
-    # shellcheck disable=SC2016
-    local _gql='query($url:URI!){resource(url:$url){...on PullRequest{commits(last:1){nodes{commit{pushedDate}}}}}}'
-    head_time=$(gh api graphql -f query="$_gql" -f url="$PR_URL" \
-      --jq '.data.resource.commits.nodes[0].commit.pushedDate // empty' \
-      2>/dev/null) || head_time=""
+    # Use the head commit's committer date (via REST) to determine push age.
+    # committer.date reflects when a cherry-pick or rebase was applied, not the
+    # original author date, so recently cherry-picked commits do not bypass the
+    # gate. pushedDate was previously used for this purpose but now returns null
+    # in GitHub's GraphQL API (deprecated and no longer populated).
+    head_time=$(_get_head_committer_date "$PR_URL") || head_time=""
     if [[ -n "$head_time" ]]; then
       head_time_raw=$(date -u -d "$head_time" +%s 2>/dev/null) || head_time_raw=""
       [[ -n "$head_time_raw" ]] && head_age_sec=$((now - head_time_raw))
     fi
 
     time_since_last_sub=0
-    # Quiescence is only reliable when we know the current head push time.
-    # If head_time_raw is empty (GraphQL failed), stale submissions from a
-    # previous HEAD could already be >10 min old, which would fire the fallback
-    # and approve before the advisory bots have reviewed the new head.
-    # Guard: only compute time_since_last_sub when head_time_raw is available.
     # -s (slurp) is required: current_states is a newline-delimited object
     # stream. Without slurping, `.[].time` iterates each object's scalar
     # values and jq errors — leaving latest_sub_at empty, time_since_last_sub
     # at 0, and the quiescence fallback permanently disarmed.
     latest_sub_at=$(echo "$current_states" | jq -rs '[.[].time] | sort | last // empty' 2>/dev/null) || latest_sub_at=""
-    if [[ -n "$latest_sub_at" && -n "$head_time_raw" ]]; then
+    if [[ -n "$latest_sub_at" ]]; then
       latest_sub_raw=$(date -u -d "$latest_sub_at" +%s 2>/dev/null) || latest_sub_raw=""
       if [[ -n "$latest_sub_raw" ]]; then
         # Anchor quiescence to the later of head-push and latest submission so that
         # stale submissions from a previous HEAD don't satisfy the fallback for a
         # fresh commit (a new push resets the quiescence timer to the head-push time).
+        # When head_time_raw is unavailable, anchor to latest_sub_at alone — this
+        # loses the cherry-pick protection for quiescence but avoids indefinite
+        # stranding when the commit API is unreachable.
         local quiescence_anchor
-        if [[ "$head_time_raw" -gt "$latest_sub_raw" ]]; then
+        if [[ -n "$head_time_raw" && "$head_time_raw" -gt "$latest_sub_raw" ]]; then
           quiescence_anchor=$head_time_raw
         else
           quiescence_anchor=$latest_sub_raw

--- a/scripts/lib/advisory-review-gate.sh
+++ b/scripts/lib/advisory-review-gate.sh
@@ -84,7 +84,7 @@ get_advisory_bot_states() {
   }
 }
 
-# Get the committer date of the PR's head commit via REST API.
+# Get the committer date of the PR's head commit via a single GraphQL query.
 # Uses committer.date (not author.date) so that cherry-picked commits reflect
 # when the cherry-pick was applied (≈push time) rather than the original author
 # date — preserving the cherry-pick guard without relying on pushedDate, which
@@ -92,13 +92,10 @@ get_advisory_bot_states() {
 # Returns empty string on any API failure.
 _get_head_committer_date() {
   local pr_url="$1"
-  local head_sha repo_path
-  head_sha=$(gh pr view "$pr_url" --json headRefOid --jq '.headRefOid' 2>/dev/null) || head_sha=""
-  [[ -z "$head_sha" ]] && return 0
-  repo_path=$(echo "$pr_url" | sed 's|https://github\.com/||;s|/pull/.*||')
-  [[ -z "$repo_path" ]] && return 0
-  gh api "/repos/${repo_path}/commits/${head_sha}" \
-    --jq '.commit.committer.date // empty' 2>/dev/null || true
+  # shellcheck disable=SC2016  # $url is a GraphQL variable placeholder, not a shell variable
+  local _gql='query($url:URI!){resource(url:$url){...on PullRequest{commits(last:1){nodes{commit{committer{date}}}}}}}'
+  gh api graphql -f query="$_gql" -f url="$pr_url" \
+    --jq '.data.resource.commits.nodes[0].commit.committer.date // empty' 2>/dev/null || true
 }
 
 # Format bot states for display
@@ -186,7 +183,7 @@ check_advisory_reviews() {
 
     head_age_sec=0
     head_time_raw=""  # Initialize before conditional to prevent set -u abort
-    # Use the head commit's committer date (via REST) to determine push age.
+    # Use the head commit's committer date (via GraphQL) to determine push age.
     # committer.date reflects when a cherry-pick or rebase was applied, not the
     # original author date, so recently cherry-picked commits do not bypass the
     # gate. pushedDate was previously used for this purpose but now returns null

--- a/tests/dev-lead/unit/test_advisory_review_gate.bats
+++ b/tests/dev-lead/unit/test_advisory_review_gate.bats
@@ -183,11 +183,9 @@ _make_mock_gh_dir() {
   cat > "$tmpdir/gh" << MOCK_EOF
 #!/usr/bin/env bash
 args="\$*"
-if [[ "\$args" == *"reviews,comments"* && "\$args" != *"headRefOid"* ]]; then
+if [[ "\$args" == *"reviews,comments"* ]]; then
   printf '%s\n' '$json_reviews_comments'
-elif [[ "\$args" == *"headRefOid"* ]]; then
-  printf 'abc123fakehead\n'
-elif [[ "\$args" == *"/commits/"* ]]; then
+elif [[ "\$args" == *"graphql"* ]]; then
   # Return a timestamp 30 minutes ago (well past the 20-minute push-age timeout)
   date -u -d '30 minutes ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
     || date -u -v-30M '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
@@ -205,12 +203,10 @@ _make_mock_gh_dir_recent() {
   cat > "$tmpdir/gh" << MOCK_EOF
 #!/usr/bin/env bash
 args="\$*"
-if [[ "\$args" == *"reviews,comments"* && "\$args" != *"headRefOid"* ]]; then
+if [[ "\$args" == *"reviews,comments"* ]]; then
   printf '%s\n' '$json_reviews_comments'
-elif [[ "\$args" == *"headRefOid"* ]]; then
-  printf 'abc123fakehead\n'
-elif [[ "\$args" == *"/commits/"* ]]; then
-  # Return current time (commit was committed just now, within the 20-minute window)
+elif [[ "\$args" == *"graphql"* ]]; then
+  # Return current time (cherry-pick/commit was applied just now, within the 20-minute window)
   date -u '+%Y-%m-%dT%H:%M:%SZ'
 fi
 MOCK_EOF
@@ -220,7 +216,7 @@ MOCK_EOF
 
 # Mock for the cherry-picked commit scenario:
 # A commit with an old author date was cherry-picked just now.
-# committer.date (REST) = now (recent) — this is what the gate must use.
+# committer.date (GraphQL) = now (recent) — this is what the gate must use.
 # If the gate mistakenly used author.date (old), head_age_sec would be large
 # and the timeout would fire immediately, bypassing the gate.
 _make_mock_gh_dir_old_commit_recent_push() {
@@ -230,11 +226,9 @@ _make_mock_gh_dir_old_commit_recent_push() {
   cat > "$tmpdir/gh" << MOCK_EOF
 #!/usr/bin/env bash
 args="\$*"
-if [[ "\$args" == *"reviews,comments"* && "\$args" != *"headRefOid"* ]]; then
+if [[ "\$args" == *"reviews,comments"* ]]; then
   printf '%s\n' '$json_reviews_comments'
-elif [[ "\$args" == *"headRefOid"* ]]; then
-  printf 'abc123fakehead\n'
-elif [[ "\$args" == *"/commits/"* ]]; then
+elif [[ "\$args" == *"graphql"* ]]; then
   # committer.date is current time — the cherry-pick was applied just now.
   # (author.date would be 2+ hours ago, but the gate uses committer.date.)
   date -u '+%Y-%m-%dT%H:%M:%SZ'
@@ -320,10 +314,10 @@ MOCK_EOF
 }
 
 @test "Gate runtime: returns 1 for recently-pushed old cherry-picked commit" {
-  # Regression test: head_age_sec must use push time (pushedDate via graphql),
-  # not the commit's own committedDate.  An old cherry-picked commit has a
-  # far-past committedDate but was pushed moments ago; using committedDate
-  # would make head_age_sec exceed 20 min immediately and bypass the gate.
+  # Regression test: head_age_sec must use committer.date (time the cherry-pick
+  # was applied), not the commit's own author.date. An old cherry-picked commit
+  # has a far-past author.date but committer.date ≈ now; using author.date would
+  # make head_age_sec exceed 20 min immediately and bypass the gate.
   local one_bot_json
   one_bot_json='{"reviews":[{"author":{"login":"gemini-code-assist"},"state":"COMMENTED","submittedAt":"2099-01-01T00:00:00Z"}],"comments":[]}'
   local tmpdir
@@ -337,9 +331,8 @@ MOCK_EOF
   [ "$status" -eq 1 ]
 }
 
-# Mock for the pushedDate=null scenario (current broken state):
-# graphql call returns empty (simulating null pushedDate), but REST API
-# provides committer date via headRefOid + /commits/{sha}.
+# Mock where GraphQL returns the committer date directly (30 minutes ago).
+# Used to verify the head-age timeout fires for PRs with partial bot coverage.
 _make_mock_gh_dir_null_pushed_date() {
   local json_reviews_comments="$1"
   local tmpdir
@@ -347,15 +340,10 @@ _make_mock_gh_dir_null_pushed_date() {
   cat > "$tmpdir/gh" << MOCK_EOF
 #!/usr/bin/env bash
 args="\$*"
-if [[ "\$args" == *"reviews,comments"* && "\$args" != *"headRefOid"* ]]; then
+if [[ "\$args" == *"reviews,comments"* ]]; then
   printf '%s\n' '$json_reviews_comments'
 elif [[ "\$args" == *"graphql"* ]]; then
-  # Simulate pushedDate=null: return empty output (as GitHub's API now does)
-  printf '\n'
-elif [[ "\$args" == *"headRefOid"* ]]; then
-  printf 'abc123fakehead\n'
-elif [[ "\$args" == *"/commits/"* ]]; then
-  # Committer date is 30 minutes ago — well past the 20-minute timeout
+  # Return committer date 30 minutes ago — head-age timeout fires
   date -u -d '30 minutes ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
     || date -u -v-30M '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
     || printf '2000-01-01T00:00:00Z\n'
@@ -366,7 +354,7 @@ MOCK_EOF
 }
 
 # Mock for the scenario where head time is completely unavailable
-# (REST commit API also fails — headRefOid returns empty).
+# (GraphQL API returns empty — no committer date available).
 # Used to verify quiescence fires from latest_sub_at alone.
 _make_mock_gh_dir_no_head_time() {
   local json_reviews_comments="$1"
@@ -375,14 +363,10 @@ _make_mock_gh_dir_no_head_time() {
   cat > "$tmpdir/gh" << MOCK_EOF
 #!/usr/bin/env bash
 args="\$*"
-if [[ "\$args" == *"reviews,comments"* && "\$args" != *"headRefOid"* ]]; then
+if [[ "\$args" == *"reviews,comments"* ]]; then
   printf '%s\n' '$json_reviews_comments'
-elif [[ "\$args" == *"headRefOid"* ]]; then
-  # Return empty SHA to simulate head time being unavailable
-  printf '\n'
-elif [[ "\$args" == *"/commits/"* ]]; then
-  printf '\n'
 elif [[ "\$args" == *"graphql"* ]]; then
+  # Return empty to simulate GraphQL being unreachable / head time unavailable
   printf '\n'
 fi
 MOCK_EOF
@@ -390,10 +374,10 @@ MOCK_EOF
   echo "$tmpdir"
 }
 
-@test "Gate runtime: recovers when pushedDate is null — uses committer date (REST) for head age" {
+@test "Gate runtime: head-age timeout fires when GraphQL returns old committer date" {
   # Regression test for issue #577: pushedDate now returns null from GitHub's GraphQL API.
-  # The gate must use the head commit's committer date (from REST) so that the head-age
-  # timeout fallback still fires for PRs with partial bot coverage.
+  # The gate fetches the head commit's committer date directly via GraphQL so that the
+  # head-age timeout fallback fires for PRs with partial bot coverage.
   local one_bot_json
   one_bot_json='{"reviews":[{"author":{"login":"gemini-code-assist"},"state":"COMMENTED","submittedAt":"2026-06-07T10:00:00Z"}],"comments":[]}'
   local tmpdir
@@ -404,12 +388,12 @@ MOCK_EOF
     check_advisory_reviews 'https://github.com/owner/repo/pull/123'
   "
   rm -rf "$tmpdir"
-  # Committer date is 30 min old → head_age_sec > 1200 → timeout fires → proceed
+  # GraphQL returns committer date 30 min old → head_age_sec > 1200 → timeout fires → proceed
   [ "$status" -eq 0 ]
 }
 
 @test "Gate runtime: quiescence fallback fires when head time unavailable and submissions are old" {
-  # When the REST commit API is unreachable (head_time_raw empty), the quiescence
+  # When the GraphQL API is unreachable (head_time empty), the quiescence
   # fallback must still fire from latest_sub_at alone, preventing indefinite stranding.
   local one_bot_json
   # Submission timestamp is in the past (well over 10 min ago)

--- a/tests/dev-lead/unit/test_advisory_review_gate.bats
+++ b/tests/dev-lead/unit/test_advisory_review_gate.bats
@@ -183,9 +183,11 @@ _make_mock_gh_dir() {
   cat > "$tmpdir/gh" << MOCK_EOF
 #!/usr/bin/env bash
 args="\$*"
-if [[ "\$args" == *"reviews,comments"* ]]; then
+if [[ "\$args" == *"reviews,comments"* && "\$args" != *"headRefOid"* ]]; then
   printf '%s\n' '$json_reviews_comments'
-elif [[ "\$args" == *"graphql"* ]]; then
+elif [[ "\$args" == *"headRefOid"* ]]; then
+  printf 'abc123fakehead\n'
+elif [[ "\$args" == *"/commits/"* ]]; then
   # Return a timestamp 30 minutes ago (well past the 20-minute push-age timeout)
   date -u -d '30 minutes ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
     || date -u -v-30M '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
@@ -203,10 +205,12 @@ _make_mock_gh_dir_recent() {
   cat > "$tmpdir/gh" << MOCK_EOF
 #!/usr/bin/env bash
 args="\$*"
-if [[ "\$args" == *"reviews,comments"* ]]; then
+if [[ "\$args" == *"reviews,comments"* && "\$args" != *"headRefOid"* ]]; then
   printf '%s\n' '$json_reviews_comments'
-elif [[ "\$args" == *"graphql"* ]]; then
-  # Return current time (commit was pushed just now, within the 20-minute window)
+elif [[ "\$args" == *"headRefOid"* ]]; then
+  printf 'abc123fakehead\n'
+elif [[ "\$args" == *"/commits/"* ]]; then
+  # Return current time (commit was committed just now, within the 20-minute window)
   date -u '+%Y-%m-%dT%H:%M:%SZ'
 fi
 MOCK_EOF
@@ -215,8 +219,10 @@ MOCK_EOF
 }
 
 # Mock for the cherry-picked commit scenario:
-# push time (graphql) = now (recent), but committedDate (commits) = 2+ hours ago.
-# Used to verify the gate uses pushedDate, not committedDate, for head_age_sec.
+# A commit with an old author date was cherry-picked just now.
+# committer.date (REST) = now (recent) — this is what the gate must use.
+# If the gate mistakenly used author.date (old), head_age_sec would be large
+# and the timeout would fire immediately, bypassing the gate.
 _make_mock_gh_dir_old_commit_recent_push() {
   local json_reviews_comments="$1"
   local tmpdir
@@ -224,19 +230,14 @@ _make_mock_gh_dir_old_commit_recent_push() {
   cat > "$tmpdir/gh" << MOCK_EOF
 #!/usr/bin/env bash
 args="\$*"
-if [[ "\$args" == *"reviews,comments"* ]]; then
+if [[ "\$args" == *"reviews,comments"* && "\$args" != *"headRefOid"* ]]; then
   printf '%s\n' '$json_reviews_comments'
-elif [[ "\$args" == *"graphql"* ]]; then
-  # Differentiate pushedDate (recent) from committedDate (old) so the regression
-  # test fails if the gate switches to using only committedDate.
-  # The gate's --jq includes "pushedDate" when correct; if broken it would not.
-  if [[ "\$args" == *"pushedDate"* ]]; then
-    date -u '+%Y-%m-%dT%H:%M:%SZ'
-  else
-    date -u -d '2 hours ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
-      || date -u -v-2H '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
-      || echo '2000-01-01T00:00:00Z'
-  fi
+elif [[ "\$args" == *"headRefOid"* ]]; then
+  printf 'abc123fakehead\n'
+elif [[ "\$args" == *"/commits/"* ]]; then
+  # committer.date is current time — the cherry-pick was applied just now.
+  # (author.date would be 2+ hours ago, but the gate uses committer.date.)
+  date -u '+%Y-%m-%dT%H:%M:%SZ'
 fi
 MOCK_EOF
   chmod +x "$tmpdir/gh"
@@ -334,6 +335,95 @@ MOCK_EOF
   "
   rm -rf "$tmpdir"
   [ "$status" -eq 1 ]
+}
+
+# Mock for the pushedDate=null scenario (current broken state):
+# graphql call returns empty (simulating null pushedDate), but REST API
+# provides committer date via headRefOid + /commits/{sha}.
+_make_mock_gh_dir_null_pushed_date() {
+  local json_reviews_comments="$1"
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  cat > "$tmpdir/gh" << MOCK_EOF
+#!/usr/bin/env bash
+args="\$*"
+if [[ "\$args" == *"reviews,comments"* && "\$args" != *"headRefOid"* ]]; then
+  printf '%s\n' '$json_reviews_comments'
+elif [[ "\$args" == *"graphql"* ]]; then
+  # Simulate pushedDate=null: return empty output (as GitHub's API now does)
+  printf '\n'
+elif [[ "\$args" == *"headRefOid"* ]]; then
+  printf 'abc123fakehead\n'
+elif [[ "\$args" == *"/commits/"* ]]; then
+  # Committer date is 30 minutes ago — well past the 20-minute timeout
+  date -u -d '30 minutes ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+    || date -u -v-30M '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+    || printf '2000-01-01T00:00:00Z\n'
+fi
+MOCK_EOF
+  chmod +x "$tmpdir/gh"
+  echo "$tmpdir"
+}
+
+# Mock for the scenario where head time is completely unavailable
+# (REST commit API also fails — headRefOid returns empty).
+# Used to verify quiescence fires from latest_sub_at alone.
+_make_mock_gh_dir_no_head_time() {
+  local json_reviews_comments="$1"
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  cat > "$tmpdir/gh" << MOCK_EOF
+#!/usr/bin/env bash
+args="\$*"
+if [[ "\$args" == *"reviews,comments"* && "\$args" != *"headRefOid"* ]]; then
+  printf '%s\n' '$json_reviews_comments'
+elif [[ "\$args" == *"headRefOid"* ]]; then
+  # Return empty SHA to simulate head time being unavailable
+  printf '\n'
+elif [[ "\$args" == *"/commits/"* ]]; then
+  printf '\n'
+elif [[ "\$args" == *"graphql"* ]]; then
+  printf '\n'
+fi
+MOCK_EOF
+  chmod +x "$tmpdir/gh"
+  echo "$tmpdir"
+}
+
+@test "Gate runtime: recovers when pushedDate is null — uses committer date (REST) for head age" {
+  # Regression test for issue #577: pushedDate now returns null from GitHub's GraphQL API.
+  # The gate must use the head commit's committer date (from REST) so that the head-age
+  # timeout fallback still fires for PRs with partial bot coverage.
+  local one_bot_json
+  one_bot_json='{"reviews":[{"author":{"login":"gemini-code-assist"},"state":"COMMENTED","submittedAt":"2026-06-07T10:00:00Z"}],"comments":[]}'
+  local tmpdir
+  tmpdir=$(_make_mock_gh_dir_null_pushed_date "$one_bot_json")
+  local gate_script="$SCRIPT_DIR/lib/advisory-review-gate.sh"
+  run env PATH="$tmpdir:$PATH" bash -c "
+    source '$gate_script'
+    check_advisory_reviews 'https://github.com/owner/repo/pull/123'
+  "
+  rm -rf "$tmpdir"
+  # Committer date is 30 min old → head_age_sec > 1200 → timeout fires → proceed
+  [ "$status" -eq 0 ]
+}
+
+@test "Gate runtime: quiescence fallback fires when head time unavailable and submissions are old" {
+  # When the REST commit API is unreachable (head_time_raw empty), the quiescence
+  # fallback must still fire from latest_sub_at alone, preventing indefinite stranding.
+  local one_bot_json
+  # Submission timestamp is in the past (well over 10 min ago)
+  one_bot_json='{"reviews":[{"author":{"login":"gemini-code-assist"},"state":"COMMENTED","submittedAt":"2026-06-07T10:00:00Z"}],"comments":[]}'
+  local tmpdir
+  tmpdir=$(_make_mock_gh_dir_no_head_time "$one_bot_json")
+  local gate_script="$SCRIPT_DIR/lib/advisory-review-gate.sh"
+  run env PATH="$tmpdir:$PATH" bash -c "
+    source '$gate_script'
+    check_advisory_reviews 'https://github.com/owner/repo/pull/123'
+  "
+  rm -rf "$tmpdir"
+  # latest_sub_at is old (>10 min) → quiescence fires even without head time → proceed
+  [ "$status" -eq 0 ]
 }
 
 @test "Gate runtime: returns 2 when gh command fails (API error, not normal wait)" {


### PR DESCRIPTION
Closes #577

Implemented by dev-lead agent. Please review.