### PR TITLE
feat: implement issue #608 — pr-review CI gate treats CANCELLED checks as failing — dev-lead's concurrency-cancelled jobs falsely block reviews

### DIFF
--- a/scripts/lib/ci-status.sh
+++ b/scripts/lib/ci-status.sh
@@ -13,10 +13,19 @@
 # Outputs (stdout): one of "passing", "pending", "failing"
 #
 # Classification rules (after filtering own checks):
-#   passing — empty rollup, or every item is SUCCESS/SKIPPED/NEUTRAL/SUCCESS state
+#   passing — empty rollup, or every item is SUCCESS/SKIPPED/NEUTRAL/CANCELLED
+#             conclusion or SUCCESS state
 #   pending — any item is IN_PROGRESS/QUEUED/WAITING/PENDING/EXPECTED or
 #             COMPLETED with null/empty conclusion
 #   failing — anything else (FAILURE, ACTION_REQUIRED, TIMED_OUT, etc.)
+#
+# CANCELLED is treated as non-blocking, not failing (issue #608). dev-lead's
+# orchestration jobs (dev-lead / dispatch, dev-lead / ci-relay) are routinely
+# cancelled by dev-lead's own concurrency when a run is superseded, leaving
+# terminal CANCELLED check-runs on the PR. A cancelled check is not a failed
+# check, so it must not block the review gate. It is non-blocking rather than
+# pending because a superseded check never completes — classifying it pending
+# would leave the PR perpetually un-reviewable.
 #
 # Own-check filter — excludes entries belonging to the PR Review cascade.
 #   `gh pr view --json statusCheckRollup` exposes the check/job *name* but not
@@ -48,6 +57,11 @@ compute_ci_status() {
     def is_success:
       .conclusion == "SUCCESS" or .conclusion == "SKIPPED" or .conclusion == "NEUTRAL" or
       .state == "SUCCESS";
+    # CANCELLED checks are non-blocking, not failing (issue #608): superseded
+    # dev-lead orchestration jobs leave terminal CANCELLED check-runs that are
+    # not a real merge-readiness signal.
+    def is_cancelled:
+      .conclusion == "CANCELLED";
     def is_own_check:
       (.name // .context // "") as $n |
       (.workflowName // "") as $wf |
@@ -67,7 +81,7 @@ compute_ci_status() {
       (map(select(is_own_check | not))) as $ext |
       if ($ext | length) == 0 then "passing"
       elif ([$ext[] | select(is_pending)] | length) > 0 then "pending"
-      elif ([$ext[] | select(is_success)] | length) == ($ext | length) then "passing"
+      elif ([$ext[] | select(is_success or is_cancelled)] | length) == ($ext | length) then "passing"
       else "failing"
       end
     end

--- a/scripts/lib/ci-status.sh
+++ b/scripts/lib/ci-status.sh
@@ -81,7 +81,7 @@ compute_ci_status() {
       (map(select(is_own_check | not))) as $ext |
       if ($ext | length) == 0 then "passing"
       elif ([$ext[] | select(is_pending)] | length) > 0 then "pending"
-      elif ([$ext[] | select(is_success or is_cancelled)] | length) == ($ext | length) then "passing"
+      elif all($ext[]; is_success or is_cancelled) then "passing"
       else "failing"
       end
     end

--- a/tests/test_ci_status.bats
+++ b/tests/test_ci_status.bats
@@ -354,6 +354,81 @@ rollup() {
 }
 
 # ---------------------------------------------------------------------------
+# CANCELLED checks are non-blocking (issue #608)
+# dev-lead's orchestration jobs (dispatch, ci-relay) are routinely CANCELLED by
+# dev-lead's own concurrency when a run is superseded. A cancelled check is not a
+# failed check, so it must not classify the PR as failing. It is treated as
+# non-blocking (success-equivalent), not pending — a superseded check never
+# completes, so pending would leave the PR perpetually un-reviewable.
+# ---------------------------------------------------------------------------
+
+@test "single external CANCELLED check returns passing" {
+  local r
+  r=$(rollup "$(check_run "Build" "COMPLETED" "CANCELLED")")
+  run compute_ci_status "$r"
+  [ "$output" = "passing" ]
+}
+
+@test "CANCELLED dev-lead 'dispatch' check returns passing" {
+  local r
+  r=$(rollup "$(check_run "dispatch" "COMPLETED" "CANCELLED")")
+  run compute_ci_status "$r"
+  [ "$output" = "passing" ]
+}
+
+@test "CANCELLED 'dev-lead / dispatch' check returns passing" {
+  local r
+  r=$(rollup "$(check_run "dev-lead / dispatch" "COMPLETED" "CANCELLED")")
+  run compute_ci_status "$r"
+  [ "$output" = "passing" ]
+}
+
+@test "CANCELLED check alongside external passing → passing" {
+  local r
+  r=$(rollup \
+    "$(check_run "dev-lead / dispatch" "COMPLETED" "CANCELLED")" \
+    "$(check_run "CI / build" "COMPLETED" "SUCCESS")")
+  run compute_ci_status "$r"
+  [ "$output" = "passing" ]
+}
+
+@test "CANCELLED check alongside external FAILURE → failing (regression guard)" {
+  local r
+  r=$(rollup \
+    "$(check_run "dev-lead / dispatch" "COMPLETED" "CANCELLED")" \
+    "$(check_run "CI / build" "COMPLETED" "FAILURE")")
+  run compute_ci_status "$r"
+  [ "$output" = "failing" ]
+}
+
+@test "CANCELLED check alongside external IN_PROGRESS → pending (regression guard)" {
+  local r
+  r=$(rollup \
+    "$(check_run "dev-lead / dispatch" "COMPLETED" "CANCELLED")" \
+    "$(check_run "CI / build" "IN_PROGRESS")")
+  run compute_ci_status "$r"
+  [ "$output" = "pending" ]
+}
+
+@test "rollup of only CANCELLED dev-lead orchestration checks → passing (issue #608 repro)" {
+  local r
+  r=$(rollup \
+    "$(check_run "dev-lead / dispatch" "COMPLETED" "CANCELLED")" \
+    "$(check_run "dev-lead / ci-relay" "COMPLETED" "CANCELLED")")
+  run compute_ci_status "$r"
+  [ "$output" = "passing" ]
+}
+
+@test "status context CANCELLED-equivalent: real TIMED_OUT conclusion still → failing" {
+  # Guards that only CANCELLED is whitelisted — other non-success terminal
+  # conclusions (e.g. TIMED_OUT) must still block.
+  local r
+  r=$(rollup "$(check_run "Build" "COMPLETED" "TIMED_OUT")")
+  run compute_ci_status "$r"
+  [ "$output" = "failing" ]
+}
+
+# ---------------------------------------------------------------------------
 # StatusContext checks are unaffected by the own-check filter
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #608

Implemented by dev-lead agent. Please review.