### PR TITLE
fix(dev-lead): force-with-lease retry when a rebase rewrites branch history (#647)

### DIFF
--- a/scripts/lib/auto-merge.sh
+++ b/scripts/lib/auto-merge.sh
@@ -129,6 +129,27 @@ push_with_merge_guard() {
     _AM_HEAD_SHA=$(git rev-parse HEAD 2>/dev/null || true)
     return 0
   fi
+
+  # A non-fast-forward rejection while the local branch has diverged from its
+  # upstream means the engine rewrote history — e.g. it resolved a rebase under
+  # an intent (on-mention, review-changes) whose plain push can never publish
+  # the rewritten branch. Retry once with --force-with-lease, which still aborts
+  # if the remote ref advanced under us (the lease = our remote-tracking ref, so
+  # a concurrent push by someone else is never clobbered). This mirrors the
+  # dedicated rebase intent's own force-push (prompts/dev-lead/rebase.md).
+  local upstream
+  upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)
+  if grep -qiE 'non-fast-forward|\[rejected\]|fetch first' "$errf" \
+     && [ -n "$upstream" ] \
+     && ! git merge-base --is-ancestor "$upstream" HEAD 2>/dev/null; then
+    echo "::notice::push rejected (non-fast-forward) and HEAD has diverged from ${upstream} — history was rewritten (likely a rebase); retrying with --force-with-lease" >&2
+    if git push --force-with-lease "$@" 2>>"$errf"; then
+      rm -f "$errf"
+      _AM_HEAD_SHA=$(git rev-parse HEAD 2>/dev/null || true)
+      return 0
+    fi
+  fi
+
   cat "$errf" >&2
   rm -f "$errf"
 

--- a/tests/dev-lead/unit/test_auto_merge.bats
+++ b/tests/dev-lead/unit/test_auto_merge.bats
@@ -185,6 +185,61 @@ EOF
   [[ "$output" == *"git push failed"* ]]
 }
 
+# ── push_with_merge_guard — force-with-lease retry on rewritten history ────────
+
+# git stub for the rebase/force-push path. $1 = "diverged" | "not-diverged"
+# controls whether merge-base --is-ancestor reports the upstream as reachable
+# from HEAD (i.e. whether history was rewritten). The plain push always reports a
+# non-fast-forward rejection; the force-with-lease push succeeds.
+_install_git_stub_force() {
+  cat > "$STUB_BIN_DIR/git" <<EOF
+#!/usr/bin/env bash
+case "\$1" in
+  push)
+    shift
+    for a in "\$@"; do
+      [ "\$a" = "--force-with-lease" ] && exit 0
+    done
+    echo "  ! [rejected]        feature -> feature (non-fast-forward)" >&2
+    exit 1
+    ;;
+  rev-parse)
+    case "\$*" in
+      *"@{u}"*) echo "origin/feature" ;;
+      *)        echo "deadbeefcafe" ;;
+    esac
+    exit 0
+    ;;
+  merge-base)
+    # --is-ancestor <upstream> HEAD: 0 = upstream reachable (not diverged),
+    # 1 = diverged (history rewritten by a rebase).
+    [ "${1:-}" = "diverged" ] && exit 1 || exit 0
+    ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "$STUB_BIN_DIR/git"
+}
+
+@test "push_with_merge_guard: force-with-lease retry succeeds when history was rewritten (rebase)" {
+  source "$LIB"
+  _install_git_stub_force diverged
+  PR_STATE="open"
+  run push_with_merge_guard
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--force-with-lease"* ]]
+}
+
+@test "push_with_merge_guard: does NOT force-push when branch is not diverged (remote advanced legitimately)" {
+  source "$LIB"
+  _install_git_stub_force not-diverged
+  PR_STATE="open"
+  run push_with_merge_guard
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"git push failed"* ]]
+  [[ "$output" != *"retrying with --force-with-lease"* ]]
+}
+
 # ── hold_auto_merge — commit text capture ─────────────────────────────────────
 
 @test "hold_auto_merge: captures commit title and message when auto-merge is on" {


### PR DESCRIPTION
Closes #647

## Problem

`push_with_merge_guard` (`scripts/lib/auto-merge.sh`) ran a plain `git push`. When an engine resolved a **rebase under a non-rebase intent** (`on-mention`, `review-changes`), the rewritten branch history could never be published — the push was rejected non-fast-forward and the whole run failed red, even though the rebase and conflict resolution succeeded.

Observed in run [#27471503333](https://github.com/petry-projects/.github-private/actions/runs/27471503333) (`@dev-lead - resolve the rebase main conflict` on PR #624), which left **PR #624 stuck `dirty` for a day**. Only the dedicated `rebase` intent worked, because `prompts/dev-lead/rebase.md` has the engine force-push itself.

## Fix

When the plain push is rejected **non-fast-forward** *and* `HEAD` has **diverged from its upstream** (i.e. history was rewritten), retry once with `--force-with-lease`:

- The lease (our remote-tracking ref) makes the retry **abort if the remote advanced under us**, so a concurrent push by someone else is never clobbered.
- A normal non-fast-forward where the branch is *not* diverged (remote legitimately advanced) still fails exactly as before — no force.
- All callers invoke `push_with_merge_guard` with no args, so the behavior change is scoped to the rejected-push path only.

This mirrors the established force-push in the dedicated rebase intent.

## Tests

`tests/dev-lead/unit/test_auto_merge.bats` — added 2 cases (force-with-lease retry succeeds on rewritten history; no force-push when branch isn't diverged). Full suite: **25/25 pass**, `shellcheck --severity=warning -x` clean.

---
Note: the original symptom (PR #624 stuck) was already resolved manually by rebasing + force-pushing it; #624 has since merged and closed #573. This PR fixes the underlying push path so it can't recur.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTcE5pAvrmNqkatFUTAetF)_