### PR TITLE
fix(initiative-driver): auto-drive every initiative:auto epic, not just #495

### DIFF
--- a/.github/workflows/initiative-driver.yml
+++ b/.github/workflows/initiative-driver.yml
@@ -8,28 +8,36 @@ name: Initiative Driver
 # Mechanics, gates, and the PAT requirement are documented in
 # scripts/initiative-driver.sh and docs/initiatives/agentic-release-strategy-orchestration.md.
 #
-# SAFETY: the driver no-ops unless the epic carries the `initiative:auto` label,
-# so Phase 1 stays human-driven. Flip it on for Phase 2 by adding that label to
-# the epic (#495). Per-issue `dev-lead:hands-off` / `initiative:hold` are never
-# released.
+# SAFETY: the driver no-ops unless an epic carries the `initiative:auto` label,
+# so initiatives stay human-driven until a maintainer opts in. Per-issue
+# `dev-lead:hands-off` / `initiative:hold` are never released.
+#
+# EPIC selection: the automatic triggers (schedule / issues:closed /
+# issues:labeled) run in SWEEP mode (no epic input) — the driver script
+# discovers EVERY open epic carrying `initiative:auto` and drives each, so it is
+# no longer pinned to one hard-coded epic. `workflow_dispatch` accepts an
+# optional `epic` to target a single one (leave blank to sweep).
 
 on:
   issues:
-    types: [closed] # a close may unblock successors — re-evaluate the DAG
+    # closed: a close may unblock successors — re-evaluate the DAG.
+    # labeled: arming an epic with `initiative:auto` starts it immediately
+    #          (the job below filters to that label).
+    types: [closed, labeled]
   schedule:
     - cron: "23 */6 * * *" # safety net for missed close events
   workflow_dispatch:
     inputs:
       epic:
-        description: "Epic issue number to drive"
+        description: "Epic issue number to drive (blank = sweep all initiative:auto epics)"
         required: false
-        default: "495"
+        default: ""
       dry_run:
         description: "Log decisions but do not apply labels"
         required: false
         default: "false"
       max_in_flight:
-        description: "Max sub-issues released at once"
+        description: "Max sub-issues released at once (per epic)"
         required: false
         default: "2"
 
@@ -37,18 +45,29 @@ permissions:
   contents: read  # actions/checkout; all issue mutations use the PAT (GH_TOKEN)
 
 concurrency:
-  group: initiative-driver-${{ github.event.inputs.epic || '495' }}
+  # One global lane: sweeps and close events serialize so concurrent runs cannot
+  # race on label application. cancel-in-progress=false so queued work is not dropped.
+  group: initiative-driver
   cancel-in-progress: false
 
 env:
   REPO: ${{ github.repository }}
-  EPIC: ${{ github.event.inputs.epic || '495' }}
-  CLOSED_ISSUE: ${{ github.event.issue.number }}
+  # Single-epic only when explicitly dispatched with a number; otherwise blank ⇒ sweep.
+  EPIC: ${{ github.event.inputs.epic || '' }}
+  # CLOSED_ISSUE is only meaningful on a close event — never pass the labeled
+  # issue's number here (it would be mistaken for a closed sub-issue).
+  CLOSED_ISSUE: ${{ github.event.action == 'closed' && github.event.issue.number || '' }}
   DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
   MAX_IN_FLIGHT: ${{ github.event.inputs.max_in_flight || '2' }}
 
 jobs:
   drive:
+    # On a `labeled` event, only proceed when the label added is the gate label —
+    # otherwise every label change in the repo would trigger a full sweep.
+    if: >-
+      github.event_name != 'issues' ||
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'initiative:auto'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/docs/initiatives/agentic-release-strategy-orchestration.md
+++ b/docs/initiatives/agentic-release-strategy-orchestration.md
@@ -21,7 +21,10 @@ automate.
 dev-lead merges a PR ──► "Closes #N" closes issue #N
         │
         ▼
-initiative-driver  (on: issues:[closed]  +  safety-net cron  +  workflow_dispatch)
+initiative-driver  (on: issues:[closed] / issues:[labeled initiative:auto]
+                       +  safety-net cron  +  workflow_dispatch)
+        │   sweep: for each OPEN epic carrying `initiative:auto`
+        │   (workflow_dispatch may target a single epic instead)
         │   gate: epic carries `initiative:auto`?  ── no ─► no-op (human-driven)
         │   for each OPEN sub-issue of the epic:
         │     • all `blocked_by` deps CLOSED?
@@ -35,6 +38,11 @@ initiative-driver  (on: issues:[closed]  +  safety-net cron  +  workflow_dispatc
   the issue UI and queried via `…/issues/{n}/dependencies/blocked_by`.
 - **Event-driven, self-propelling.** A merge closes an issue, which fires the driver, which releases
   the now-unblocked successors. The cron (`23 */6 * * *`) is only a backstop for missed events.
+- **Arming starts it.** Adding `initiative:auto` to an epic fires the driver via `issues:[labeled]`,
+  so the first ready wave is released immediately — no waiting for the next cron tick.
+- **Epic-agnostic.** The automatic triggers run in *sweep* mode: the driver discovers **every** open
+  epic carrying `initiative:auto` and drives each, so it is not pinned to one hard-coded epic. A
+  `workflow_dispatch` with an `epic` input targets a single epic (blank = sweep).
 - **Bounded.** `MAX_IN_FLIGHT` (default 2) caps how many sub-issues run at once — controlling parallel
   token cost and blast radius. Per-issue concurrency lanes in dev-lead keep concurrent items isolated.
 
@@ -91,12 +99,14 @@ bootstrap**, not just a technical dependency:
 
 - **Dry-run / preview** what would be released:
   `gh workflow run initiative-driver.yml -f dry_run=true` (or run the script with `DRY_RUN=true`).
-- **Arm Phase 2:** `gh issue edit 495 --add-label initiative:auto`.
+- **Arm an initiative:** `gh issue edit <epic> --add-label initiative:auto` — this fires the driver
+  immediately (labeled event) and the epic is picked up by every later sweep.
 - **Pause one issue:** add `initiative:hold`; **hand back to a human:** add `dev-lead:hands-off`.
 - **Throttle:** `gh workflow run initiative-driver.yml -f max_in_flight=1`.
 - **Disarm:** remove `initiative:auto` from the epic — in-flight items finish; nothing new is released.
 
 ## Follow-ups (not in this scaffold)
 
-- A bats test that mocks `gh` to assert the gate / blocker / cap logic.
-- Generalize `EPIC` beyond the hard-coded `495` default if a second initiative adopts the driver.
+- ~~A bats test that mocks `gh` to assert the gate / blocker / cap logic.~~ Done — `tests/test_initiative_driver.bats`.
+- ~~Generalize `EPIC` beyond the hard-coded `495` default if a second initiative adopts the driver.~~
+  Done — automatic triggers now sweep every `initiative:auto` epic; `workflow_dispatch` can still target one.

--- a/scripts/initiative-driver.sh
+++ b/scripts/initiative-driver.sh
@@ -93,7 +93,7 @@ labels_of() {
 # Returns 0 on success (including no-ops); never aborts the caller's sweep.
 drive_epic() {
   local epic="$1"
-  local epic_labels all_children_raw open_children_raw n_labels labels open_blockers
+  local epic_labels all_children_raw open_children_raw n n_labels labels open_blockers
   local -a all_children open_children
   local -A released
   local in_flight slots released_now in_epic
@@ -130,7 +130,6 @@ drive_epic() {
   fi
 
   # ── count in-flight (released but not yet closed) ───────────────────────────
-  released=()
   in_flight=0
   open_children_raw="$(gh api --paginate "repos/$REPO/issues/$epic/sub_issues" \
       --jq '.[] | select(.state=="open") | .number')"
@@ -209,6 +208,18 @@ log "Found ${#epics[@]} gated epic(s): ${epics[*]}"
 rc=0
 for e in "${epics[@]}"; do
   log "──────── Driving epic #$e ────────"
-  drive_epic "$e" || { rc=1; echo "::error::driver failed for epic #$e"; }
+  # Run each epic in a standalone subshell with errexit ON so a gh failure
+  # aborts that epic instead of being silently masked, while the parent (errexit
+  # OFF for the call) keeps sweeping the rest. NOTE: `drive_epic "$e" || …` would
+  # NOT work — Bash disables `set -e` inside a function invoked in an OR/if/&&
+  # context, letting an API failure fall through as a false "no sub-issues".
+  set +e
+  ( set -e; drive_epic "$e" )
+  ec=$?
+  set -e
+  if [[ "$ec" -ne 0 ]]; then
+    rc=1
+    echo "::error::driver failed for epic #$e"
+  fi
 done
 exit "$rc"

--- a/scripts/initiative-driver.sh
+++ b/scripts/initiative-driver.sh
@@ -63,7 +63,7 @@ DRY_RUN="${DRY_RUN:-false}"
 
 # Validate and normalize inputs before they reach arithmetic or API paths.
 # EPIC may be empty (sweep mode) or a positive integer (single-epic mode).
-if [[ -n "$EPIC" ]] && ! [[ "$EPIC" =~ ^[0-9]+$ ]]; then
+if [[ -n "$EPIC" ]] && ! [[ "$EPIC" =~ ^[1-9][0-9]*$ ]]; then
   echo "::error::EPIC must be a positive integer or empty, got: '$EPIC'"; exit 1
 fi
 [[ "$MAX_IN_FLIGHT" =~ ^[0-9]+$ ]] || { echo "::error::MAX_IN_FLIGHT must be a non-negative integer, got: '$MAX_IN_FLIGHT'"; exit 1; }

--- a/scripts/initiative-driver.sh
+++ b/scripts/initiative-driver.sh
@@ -12,6 +12,16 @@
 # this driver (on issues:[closed]) re-evaluates the DAG -> labels the now-ready
 # successors. The schedule cron is only a safety net for missed close events.
 #
+# EPIC selection — single epic or sweep:
+#   - EPIC set (a number)  -> drive just that epic (targeted/dry-run/dispatch).
+#   - EPIC empty/unset     -> SWEEP: discover every OPEN issue carrying
+#                             GATE_LABEL and drive each. This is what the
+#                             automatic triggers (schedule / issues:closed /
+#                             issues:labeled) use, so the driver is no longer
+#                             pinned to a single hard-coded epic — any epic a
+#                             maintainer arms with `initiative:auto` is picked
+#                             up automatically.
+#
 # IMPORTANT — the trigger requires a PAT, not GITHUB_TOKEN:
 #   GitHub does not start new workflow runs from events created by the default
 #   GITHUB_TOKEN (loop prevention). The `dev-lead` label MUST be applied with a
@@ -20,16 +30,18 @@
 #
 # Safety gates:
 #   - The epic must carry GATE_LABEL (default: initiative:auto). Without it the
-#     driver no-ops, so Phase 1 stays human-driven until you opt in.
+#     driver no-ops, so Phase 1 stays human-driven until you opt in. In sweep
+#     mode this is the discovery filter; in single-epic mode it is re-checked.
 #   - Issues carrying HANDS_OFF_LABEL (dev-lead:hands-off) or HOLD_LABEL
 #     (initiative:hold) are never released — they need a human.
-#   - MAX_IN_FLIGHT bounds how many sub-issues run at once (cost / blast radius).
+#   - MAX_IN_FLIGHT bounds how many sub-issues run at once, per epic
+#     (cost / blast radius).
 #
 # Env:
 #   REPO            owner/repo (default: petry-projects/.github-private)
-#   EPIC            epic issue number (required)
-#   CLOSED_ISSUE    issue number from an issues:closed event (optional; the run
-#                   exits early if it is not one of the epic's sub-issues)
+#   EPIC            epic issue number, or empty to sweep all gated epics
+#   CLOSED_ISSUE    issue number from an issues:closed event (optional; each
+#                   epic is skipped early if it is not one of its sub-issues)
 #   DEV_LEAD_LABEL  label that triggers dev-lead (default: dev-lead)
 #   GATE_LABEL      opt-in label on the epic (default: initiative:auto)
 #   HANDS_OFF_LABEL never-release label (default: dev-lead:hands-off)
@@ -40,7 +52,7 @@
 set -euo pipefail
 
 REPO="${REPO:-petry-projects/.github-private}"
-EPIC="${EPIC:?EPIC issue number required}"
+EPIC="${EPIC:-}"
 CLOSED_ISSUE="${CLOSED_ISSUE:-}"
 DEV_LEAD_LABEL="${DEV_LEAD_LABEL:-dev-lead}"
 GATE_LABEL="${GATE_LABEL:-initiative:auto}"
@@ -50,7 +62,10 @@ MAX_IN_FLIGHT="${MAX_IN_FLIGHT:-2}"
 DRY_RUN="${DRY_RUN:-false}"
 
 # Validate and normalize inputs before they reach arithmetic or API paths.
-[[ "$EPIC" =~ ^[0-9]+$ ]] || { echo "::error::EPIC must be a positive integer, got: '$EPIC'"; exit 1; }
+# EPIC may be empty (sweep mode) or a positive integer (single-epic mode).
+if [[ -n "$EPIC" ]] && ! [[ "$EPIC" =~ ^[0-9]+$ ]]; then
+  echo "::error::EPIC must be a positive integer or empty, got: '$EPIC'"; exit 1
+fi
 [[ "$MAX_IN_FLIGHT" =~ ^[0-9]+$ ]] || { echo "::error::MAX_IN_FLIGHT must be a non-negative integer, got: '$MAX_IN_FLIGHT'"; exit 1; }
 if [[ -n "$CLOSED_ISSUE" ]] && ! [[ "$CLOSED_ISSUE" =~ ^[0-9]+$ ]]; then
   echo "::warning::CLOSED_ISSUE is not a valid issue number ('$CLOSED_ISSUE') — treating as unset."
@@ -74,92 +89,126 @@ labels_of() {
   gh api "repos/$REPO/issues/$1" --jq '.labels[].name'
 }
 
-# ── gate: the epic must opt in ────────────────────────────────────────────────
-epic_labels="$(labels_of "$EPIC")"
-if ! has_label "$epic_labels" "$GATE_LABEL"; then
-  log "Gate '$GATE_LABEL' not on epic #$EPIC — no-op (Phase-1 human-driven). Add the label to activate."
-  exit 0
-fi
+# drive_epic <epic-number> — release the ready sub-issues of one epic.
+# Returns 0 on success (including no-ops); never aborts the caller's sweep.
+drive_epic() {
+  local epic="$1"
+  local epic_labels all_children_raw open_children_raw n_labels labels open_blockers
+  local -a all_children open_children
+  local -A released
+  local in_flight slots released_now in_epic
 
-# ── enumerate sub-issues (all states) ─────────────────────────────────────────
-all_children_raw="$(gh api --paginate "repos/$REPO/issues/$EPIC/sub_issues" --jq '.[].number')"
-if [[ -z "$all_children_raw" ]]; then
-  all_children=()
-else
-  mapfile -t all_children <<< "$all_children_raw"
-fi
-if [[ "${#all_children[@]}" -eq 0 ]]; then
-  log "Epic #$EPIC has no sub-issues — nothing to drive."
-  exit 0
-fi
-
-# ── on a close event, only act if the closed issue belongs to this epic ───────
-if [[ -n "$CLOSED_ISSUE" ]]; then
-  in_epic=false
-  for n in "${all_children[@]}"; do
-    [[ "$n" = "$CLOSED_ISSUE" ]] && in_epic=true && break
-  done
-  if [[ "$in_epic" != true ]]; then
-    log "Closed issue #$CLOSED_ISSUE is not a sub-issue of epic #$EPIC — no-op."
-    exit 0
-  fi
-fi
-
-# ── count in-flight (released but not yet closed) ─────────────────────────────
-declare -A released
-in_flight=0
-open_children_raw="$(gh api --paginate "repos/$REPO/issues/$EPIC/sub_issues" \
-    --jq '.[] | select(.state=="open") | .number')"
-if [[ -z "$open_children_raw" ]]; then
-  open_children=()
-else
-  mapfile -t open_children <<< "$open_children_raw"
-fi
-for n in "${open_children[@]}"; do
-  n_labels="$(labels_of "$n")"
-  if has_label "$n_labels" "$DEV_LEAD_LABEL"; then
-    released[$n]=1
-    in_flight=$((in_flight + 1))
-  fi
-done
-log "Epic #$EPIC: ${#open_children[@]} open sub-issue(s); in-flight=$in_flight; cap=$MAX_IN_FLIGHT."
-
-# ── release ready sub-issues up to the cap ────────────────────────────────────
-slots=$((MAX_IN_FLIGHT - in_flight))
-[[ "$slots" -lt 0 ]] && slots=0
-released_now=0
-
-for n in "${open_children[@]}"; do
-  [[ "$slots" -le 0 ]] && break
-  [[ -n "${released[$n]:-}" ]] && continue
-
-  labels="$(labels_of "$n")"
-  if has_label "$labels" "$HANDS_OFF_LABEL"; then
-    log "  #$n — skip: $HANDS_OFF_LABEL (needs a human)."
-    continue
-  fi
-  if has_label "$labels" "$HOLD_LABEL"; then
-    log "  #$n — skip: $HOLD_LABEL (held)."
-    continue
+  # ── gate: the epic must opt in ──────────────────────────────────────────────
+  epic_labels="$(labels_of "$epic")"
+  if ! has_label "$epic_labels" "$GATE_LABEL"; then
+    log "Gate '$GATE_LABEL' not on epic #$epic — no-op (Phase-1 human-driven). Add the label to activate."
+    return 0
   fi
 
-  open_blockers="$(
-    gh api "repos/$REPO/issues/$n/dependencies/blocked_by" \
-      --jq '[.[] | select(.state=="open") | .number] | join(",")'
-  )"
-  if [[ -n "$open_blockers" ]]; then
-    log "  #$n — blocked by open: [$open_blockers]."
-    continue
-  fi
-
-  if [[ "$DRY_RUN" = "true" ]]; then
-    log "  #$n — READY (dry-run, not labeling)."
+  # ── enumerate sub-issues (all states) ───────────────────────────────────────
+  all_children_raw="$(gh api --paginate "repos/$REPO/issues/$epic/sub_issues" --jq '.[].number')"
+  if [[ -z "$all_children_raw" ]]; then
+    all_children=()
   else
-    gh issue edit "$n" --repo "$REPO" --add-label "$DEV_LEAD_LABEL" >/dev/null
-    log "  #$n — RELEASED: applied '$DEV_LEAD_LABEL'."
+    mapfile -t all_children <<< "$all_children_raw"
   fi
-  slots=$((slots - 1))
-  released_now=$((released_now + 1))
-done
+  if [[ "${#all_children[@]}" -eq 0 ]]; then
+    log "Epic #$epic has no sub-issues — nothing to drive."
+    return 0
+  fi
 
-log "Released this run: $released_now."
+  # ── on a close event, only act if the closed issue belongs to this epic ─────
+  if [[ -n "$CLOSED_ISSUE" ]]; then
+    in_epic=false
+    for n in "${all_children[@]}"; do
+      [[ "$n" = "$CLOSED_ISSUE" ]] && in_epic=true && break
+    done
+    if [[ "$in_epic" != true ]]; then
+      log "Closed issue #$CLOSED_ISSUE is not a sub-issue of epic #$epic — no-op."
+      return 0
+    fi
+  fi
+
+  # ── count in-flight (released but not yet closed) ───────────────────────────
+  released=()
+  in_flight=0
+  open_children_raw="$(gh api --paginate "repos/$REPO/issues/$epic/sub_issues" \
+      --jq '.[] | select(.state=="open") | .number')"
+  if [[ -z "$open_children_raw" ]]; then
+    open_children=()
+  else
+    mapfile -t open_children <<< "$open_children_raw"
+  fi
+  for n in "${open_children[@]}"; do
+    n_labels="$(labels_of "$n")"
+    if has_label "$n_labels" "$DEV_LEAD_LABEL"; then
+      released[$n]=1
+      in_flight=$((in_flight + 1))
+    fi
+  done
+  log "Epic #$epic: ${#open_children[@]} open sub-issue(s); in-flight=$in_flight; cap=$MAX_IN_FLIGHT."
+
+  # ── release ready sub-issues up to the cap ──────────────────────────────────
+  slots=$((MAX_IN_FLIGHT - in_flight))
+  [[ "$slots" -lt 0 ]] && slots=0
+  released_now=0
+
+  for n in "${open_children[@]}"; do
+    [[ "$slots" -le 0 ]] && break
+    [[ -n "${released[$n]:-}" ]] && continue
+
+    labels="$(labels_of "$n")"
+    if has_label "$labels" "$HANDS_OFF_LABEL"; then
+      log "  #$n — skip: $HANDS_OFF_LABEL (needs a human)."
+      continue
+    fi
+    if has_label "$labels" "$HOLD_LABEL"; then
+      log "  #$n — skip: $HOLD_LABEL (held)."
+      continue
+    fi
+
+    open_blockers="$(
+      gh api "repos/$REPO/issues/$n/dependencies/blocked_by" \
+        --jq '[.[] | select(.state=="open") | .number] | join(",")'
+    )"
+    if [[ -n "$open_blockers" ]]; then
+      log "  #$n — blocked by open: [$open_blockers]."
+      continue
+    fi
+
+    if [[ "$DRY_RUN" = "true" ]]; then
+      log "  #$n — READY (dry-run, not labeling)."
+    else
+      gh issue edit "$n" --repo "$REPO" --add-label "$DEV_LEAD_LABEL" >/dev/null
+      log "  #$n — RELEASED: applied '$DEV_LEAD_LABEL'."
+    fi
+    slots=$((slots - 1))
+    released_now=$((released_now + 1))
+  done
+
+  log "Released this run for epic #$epic: $released_now."
+}
+
+# ── entrypoint: single epic, or sweep all gated epics ─────────────────────────
+if [[ -n "$EPIC" ]]; then
+  drive_epic "$EPIC"
+  exit 0
+fi
+
+log "No EPIC given — sweeping all open epics carrying '$GATE_LABEL'."
+epics_raw="$(gh api --paginate -X GET "repos/$REPO/issues" \
+    -f state=open -f labels="$GATE_LABEL" \
+    --jq '.[] | select(.pull_request|not) | .number')"
+if [[ -z "$epics_raw" ]]; then
+  log "No open epics carry '$GATE_LABEL' — nothing to drive."
+  exit 0
+fi
+mapfile -t epics <<< "$epics_raw"
+log "Found ${#epics[@]} gated epic(s): ${epics[*]}"
+
+rc=0
+for e in "${epics[@]}"; do
+  log "──────── Driving epic #$e ────────"
+  drive_epic "$e" || { rc=1; echo "::error::driver failed for epic #$e"; }
+done
+exit "$rc"

--- a/tests/test_initiative_driver.bats
+++ b/tests/test_initiative_driver.bats
@@ -165,3 +165,47 @@ EOF
   [[ "$output" == *"RELEASED"* ]]
   grep -qF "issue edit" "$GH_LOG"
 }
+
+# ── sweep mode: EPIC empty discovers all gated epics ─────────────────────────
+
+@test "sweep: drives every open epic carrying initiative:auto when EPIC is empty" {
+  export EPIC=""
+  cat > "$MOCK_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_LOG"
+args="$*"
+# Discovery query (state=open & labels=initiative:auto): two gated epics 10, 11
+if [[ "$args" == *"-f state=open"* ]]; then printf '10\n11'; exit 0; fi
+# Each epic carries the gate label
+if [[ "$args" == *"issues/10 --jq"* ]] || [[ "$args" == *"issues/11 --jq"* ]]; then
+  printf 'initiative:auto'; exit 0
+fi
+# Neither epic has sub-issues — both no-op cleanly
+if [[ "$args" == *"sub_issues"* ]]; then printf ''; exit 0; fi
+printf '[]'
+EOF
+  chmod +x "$MOCK_BIN/gh"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Found 2 gated epic(s): 10 11"* ]]
+  [[ "$output" == *"Driving epic #10"* ]]
+  [[ "$output" == *"Driving epic #11"* ]]
+}
+
+@test "sweep: no-op when no open epic carries initiative:auto" {
+  export EPIC=""
+  cat > "$MOCK_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_LOG"
+args="$*"
+if [[ "$args" == *"-f state=open"* ]]; then printf ''; exit 0; fi
+printf '[]'
+EOF
+  chmod +x "$MOCK_BIN/gh"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No open epics carry"* ]]
+  ! grep -qF "issue edit" "$GH_LOG"
+}

--- a/tests/test_initiative_driver.bats
+++ b/tests/test_initiative_driver.bats
@@ -193,6 +193,32 @@ EOF
   [[ "$output" == *"Driving epic #11"* ]]
 }
 
+@test "sweep: a gh failure on one epic surfaces as an error (not masked) and the sweep continues" {
+  export EPIC=""
+  cat > "$MOCK_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_LOG"
+args="$*"
+# Discovery: two gated epics 10, 11
+if [[ "$args" == *"-f state=open"* ]]; then printf '10\n11'; exit 0; fi
+# Epic 10: the labels lookup fails (simulated API/network error)
+if [[ "$args" == *"issues/10 --jq"* ]]; then exit 1; fi
+# Epic 11: healthy, gated, no sub-issues
+if [[ "$args" == *"issues/11 --jq"* ]]; then printf 'initiative:auto'; exit 0; fi
+if [[ "$args" == *"sub_issues"* ]]; then printf ''; exit 0; fi
+printf '[]'
+EOF
+  chmod +x "$MOCK_BIN/gh"
+
+  run bash "$SCRIPT"
+  # Non-zero overall (the failure is no longer swallowed as a false no-op)…
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"driver failed for epic #10"* ]]
+  # …but epic #11 was still driven.
+  [[ "$output" == *"Driving epic #11"* ]]
+  [[ "$output" == *"no sub-issues"* ]]
+}
+
 @test "sweep: no-op when no open epic carries initiative:auto" {
   export EPIC=""
   cat > "$MOCK_BIN/gh" <<'EOF'

--- a/tests/test_initiative_driver.bats
+++ b/tests/test_initiative_driver.bats
@@ -191,6 +191,8 @@ EOF
   [[ "$output" == *"Found 2 gated epic(s): 10 11"* ]]
   [[ "$output" == *"Driving epic #10"* ]]
   [[ "$output" == *"Driving epic #11"* ]]
+  # Neither epic has sub-issues, so nothing should be labeled.
+  ! grep -qF "issue edit" "$GH_LOG"
 }
 
 @test "sweep: a gh failure on one epic surfaces as an error (not masked) and the sweep continues" {


### PR DESCRIPTION
## Why

While monitoring the auto-implementation of epic **#676**, I found it had silently stalled. Adding `initiative:auto` to #676 flipped the safety gate but **started nothing**, and on its own it never would, because of two gaps in the driver:

1. **Nothing triggered the driver from arming an epic.** `initiative-driver.yml` only ran on `issues:closed`, a 6-hourly `schedule`, and `workflow_dispatch`. No trigger fired when `initiative:auto` was added — so the documented hand-off (`★ human adds initiative:auto → initiative-driver → dev-lead`) had no edge.
2. **The automatic paths were pinned to epic #495.** `EPIC: ${{ github.event.inputs.epic || '495' }}` — on `schedule`/`issues:closed` there are no inputs, so `EPIC` always resolved to `495`. The cron and every issue-close drove **only** #495; #676 (and any future epic) could never be picked up automatically.

This is the exact follow-up the design doc already flagged: *"Generalize `EPIC` beyond the hard-coded `495` default if a second initiative adopts the driver."*

(Adding the label did fire `dev-lead.yml` via `issues:[labeled]`, but dev-lead acts only on the `dev-lead` label, so that run was a harmless no-op.)

## What changed

- **`scripts/initiative-driver.sh`** — add **sweep mode**: when `EPIC` is empty, discover every open issue carrying `initiative:auto` and drive each. Per-epic logic is extracted into `drive_epic()`; single-epic mode (explicit dispatch) is byte-for-byte unchanged.
- **`.github/workflows/initiative-driver.yml`** —
  - trigger on `issues:[labeled]` so arming an epic starts it immediately (job `if` filters to the `initiative:auto` label so unrelated label changes don't sweep);
  - stop defaulting `EPIC` to `495` — automatic triggers run blank ⇒ sweep all armed epics; `workflow_dispatch` still accepts an optional `epic` to target one;
  - only pass `CLOSED_ISSUE` on actual close events (avoids mistaking a labeled epic's own number for a closed sub-issue);
  - single global concurrency lane so sweeps/close events serialize on label application.
- **`tests/test_initiative_driver.bats`** — add sweep-mode coverage (multi-epic discovery + empty no-op). All 10 tests pass.
- **docs** — document the labeled trigger + sweep behavior; resolve both listed follow-ups.

## Verification

- `shellcheck --severity=warning -x scripts/initiative-driver.sh` — clean
- `bats tests/test_initiative_driver.bats` — 10/10 pass (8 existing + 2 new)

## Note on #676

This PR fixes the mechanism but does **not** itself kick off #676 (that spends agent budget and opens PRs). Once merged, arming any epic — or re-arming #676 — will start it automatically. If you'd rather start #676 now without waiting for the merge, I can dispatch `initiative-driver.yml` with `epic=676`.

https://claude.ai/code/session_01RfwDpKTkNEBHjEMDcGkTY3

---
_Generated by [Claude Code](https://claude.ai/code/session_01RfwDpKTkNEBHjEMDcGkTY3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Initiative-driver workflow now supports sweep mode to process multiple epics automatically, in addition to targeting specific epics via manual dispatch.

* **Documentation**
  * Updated operational runbook with explicit commands for arming and managing the initiative automation process.
  * Clarified workflow trigger behavior and epic selection modes.

* **Tests**
  * Added comprehensive test coverage for multi-epic sweep functionality and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->