### PR TITLE
fix(gitleaks): allowlist example JWT fixture in test_gitleaks_config.bats

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -121,3 +121,14 @@ regexes = [
   '''api-request''',
   '''[0-9a-f]{64}''',
 ]
+
+# Issue #697 / PR #705 added a regression-guard test that embeds the example expired
+# JWT (the same dummy token used in .claude/skills/**/api-testing-patterns.md) directly
+# in this self-test as `EXPIRED_JWT='eyJ...'`. The full-history secret scan flags that
+# literal like any other occurrence. condition="AND" binds the dummy value to this one
+# path, so a real secret committed here in future would still be reported.
+[[allowlists]]
+description = "Suppress the example expired-JWT fixture in the gitleaks-config self-test (issue #697 / PR #705)"
+condition = "AND"
+paths = ['''^tests/test_gitleaks_config\.bats$''']
+regexes = ['''eyJhbGciOiJIUzI1NiIs''']


### PR DESCRIPTION
Closes #709.

## What
Adds a path-scoped `[[allowlists]]` entry to `.gitleaks.toml` for the example expired-JWT fixture embedded in `tests/test_gitleaks_config.bats`.

## Why
PR #705 (issue #697, commit `58934f64`) added a regression-guard test that embeds the example expired JWT **literally** in the committed file as `EXPIRED_JWT='eyJ…'`. The secret scan runs `gitleaks detect --source .` (full history), and `.gitleaks.toml` only allowlisted that token under `.claude/skills/**/api-testing-patterns.md` — not in the test file. So the unallowlisted occurrence fails **`Secret scan (gitleaks)`** on affected PRs (notably **#707**, which never touches that file). `main` is clean; this surfaces on PRs in that lineage.

## The fix
```toml
[[allowlists]]
description = "Suppress the example expired-JWT fixture in the gitleaks-config self-test (issue #697 / PR #705)"
condition = "AND"
paths = ['''^tests/test_gitleaks_config\.bats$''']
regexes = ['''eyJhbGciOiJIUzI1NiIs''']
```
`condition = "AND"` binds the dummy value to that one path — consistent with every other entry in the file — so a **real** secret committed there in future is still reported (not a blanket file suppression).

## Unblocks
- #705 (the source PR — it needs this to pass its own secret scan)
- #707 (initiative-planner open-questions gate)

Once merged, affected PRs clear the check by updating their branch with `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015VRMMWmqW9nW81jygmea3e)_