### PR TITLE
feat: implement issue #691 — [Guardrail] Held-out hygiene: dev/test split so the proposer never scores against cases it can see

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Default owner for all files
 * @petry-projects/org-leads
 
-# Held-out eval cases are the trust anchor for skill-quality measurement.
-# They MUST stay separately owned: a future automated skill proposer may only
-# edit the skill markdown, never this held-out set (reward-hacking guard, #582).
-/evals/ @petry-projects/org-leads
+# Held-out eval cases (#691, epic #581) — the proposer must never edit these.
+# Explicit rule so the holdout stays owner-locked even if broader rules loosen;
+# the dev/ split may remain proposer-visible.
+/evals/**/holdout/ @petry-projects/org-leads

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,7 +59,7 @@ jobs:
             tests/test_dependabot.bats \
             tests/test_apply_repo_settings.bats \
             tests/test_sweep_stuck_reviews.bats \
-            tests/test_evals_cases.bats
+            tests/test_validate_cases.bats
 
   validate-agent-profiles:
     runs-on: ubuntu-latest

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,64 +1,91 @@
-# Held-out eval cases
+# `evals/` — held-out eval sets for self-improving skills
 
-This directory holds the **held-out eval-case sets** used to measure prompt-skill
-quality against fixed, reward-hack-resistant expected outputs. It is the trust
-anchor of the skill-quality initiative (Discussion #572): cases live here, on
-their own, and are validated structurally — there is **no scorer and no model
-invocation** in this directory.
+This directory holds the evaluation cases that the self-improving-skills pipeline
+(epic #581, Discussion #572) uses to decide whether a proposed change to a skill
+is a real improvement. Its single job is **held-out hygiene**: keeping the cases
+the gate scores against out of sight of the proposer that is trying to pass them.
 
-## Layout
+This directory is **data, structure, and validation only**. No scorer, model
+invocation, or proposer logic lives here (consistent with #582).
+
+## The dev/holdout split
+
+Every skill's cases are partitioned into two splits:
 
 ```
 evals/
-├── case.schema.json        # JSON-Schema (draft 2020-12) for one eval case
-├── validate-cases.py       # validate a .jsonl set against the schema
-└── <skill>/cases.jsonl     # one case per line for that skill (e.g. triage/)
+  <skill>/
+    dev/cases.jsonl       # proposer-visible
+    holdout/cases.jsonl   # CODEOWNER-gated; the gate scores against this
 ```
 
-Each `<skill>/cases.jsonl` is [JSON Lines](https://jsonlines.org/): one JSON
-object per line, each conforming to `case.schema.json`.
+- **`dev/`** — the **proposer-visible** split. Any proposer prompt or context
+  (Phase 3 proposer, #587) is constructed from the **dev split only**.
+- **`holdout/`** — the **held-out** split. The scorer (#583) and the
+  strict-improvement gate (#586) score against the **holdout split only**. The
+  proposer must never tune a skill to these specific cases.
 
-## Case format
+`cases.jsonl` is [JSON Lines](https://jsonlines.org/): one JSON object per line.
+Blank lines are ignored. Every case **must** carry a non-empty string `id`. The
+rest of the case payload (e.g. `prompt`, `expected`, rubric fields) is owned by
+the scorer story (#583); this directory's validator is deliberately agnostic to
+it and only governs the split structure and `id` discipline.
 
-A case pairs a single triage **input** with the **expected** decision the skill
-must emit. Required fields (see `case.schema.json` for the authoritative
-contract — it is `additionalProperties: false`, so unknown keys are rejected):
+`example-skill/` is a template: copy its `dev/` and `holdout/` layout when adding
+a new skill's eval set.
 
-| Field               | Type                      | Notes                                                                                  |
-| ------------------- | ------------------------- | -------------------------------------------------------------------------------------- |
-| `id`                | string (kebab-case)       | Stable, unique identifier for the case.                                                 |
-| `input`             | string                    | The pre-fetched PR context exactly as `prompts/triage.md` consumes under `## Pre-fetched PR context`. Self-contained; triage has no tools. |
-| `expected.escalate` | boolean                   | Whether triage must escalate (`true`) or may approve (`false`).                          |
-| `expected.risk`     | `LOW` \| `MEDIUM` \| `HIGH` | Expected risk classification. Any `HIGH` signal must pair with `escalate: true`.        |
-| `description`        | string (optional)        | What the case exercises and which `triage.md` criterion grounds the expected decision.  |
-| `tags`               | string[] (optional)      | Coverage labels, e.g. the high-risk trigger a case exercises (`auth-secrets`, `db-migration`, `security-anti-pattern`). |
+## The no-overlap rule
 
-Expected decisions are **grounded strictly in the numbered decision criteria of
-`prompts/triage.md`** — not invented behavior. `triage.md` emits a deterministic
-JSON object with no tools, so the expected `escalate`/`risk` can be fixed values.
+**A case must never appear in both splits.** `id`s are unique within each split
+*and* disjoint across the two splits (checked over their union). If the same case
+lived in both, the proposer could see — and overfit to — a case the gate later
+scores against, which defeats the entire held-out guarantee ("teaching to the
+test").
 
-## Validation
+`validate-cases.py` enforces this. Run it over the whole tree:
 
-Validation uses the same `python jsonschema` pattern that
-`scripts/initiative-planner/plan.schema.json` uses:
-
-```sh
-pip install 'jsonschema>=4'
-python3 evals/validate-cases.py evals/triage/cases.jsonl
+```bash
+python3 evals/validate-cases.py            # validates evals/ (this dir)
+python3 evals/validate-cases.py <root>     # validates an alternate root
 ```
 
-The validator checks every line against `case.schema.json` and enforces the one
-cross-line invariant the set depends on: **case ids must be unique**. It runs in
-CI via `tests/test_evals_cases.bats`.
+It fails (non-zero) on malformed JSONL, a missing/empty `id`, a duplicate `id`
+within a split, an `id` shared across splits, or a skill missing either split.
+The validator is exercised by `tests/test_validate_cases.bats` in CI.
 
-## Separately owned — reward-hacking guard
+## De-identification requirement (decision A3)
 
-This directory is **separately owned** via `.github/CODEOWNERS`. That is a
-deliberate guard: a future automated skill *proposer* may only ever edit the
-skill markdown (e.g. `prompts/triage.md`), **never** this held-out set. If the
-proposer could edit the cases, it could optimize the skill against a moving
-target — reward hacking. Keeping the cases CODEOWNER-gated, apart from any
-scorer or proposer, is what makes a measurement against them trustworthy.
+All cases — in **both** splits — must be **de-identified** before they are
+committed. Do not paste real customer data, secrets, tokens, internal hostnames,
+personal names, or any other PII into a case. Cases are synthetic or redacted
+reconstructions of a behavior, not raw captured transcripts. Because the `dev/`
+split is proposer-visible (and the whole repo is readable by other automation),
+treat every committed case as world-readable within the org.
 
-Any change to `evals/**` therefore requires review from the designated
-code owners.
+## Why CODEOWNER-gating the holdout is sufficient (AC1/AC4)
+
+The held-out guarantee rests on two independent controls:
+
+1. **Tamper protection (enforced here).** `holdout/` is CODEOWNER-gated in
+   [`.github/CODEOWNERS`](../.github/CODEOWNERS) with an explicit rule, on top of
+   the repo-wide default. The proposer runs as `GITHUB_TOKEN` and therefore
+   **cannot merge** any edit to a holdout file — it can neither rewrite the
+   holdout to match a weak skill nor move cases between splits. The reward-hacking
+   guard from #582 (CODEOWNERS over `evals/`) is what this rule specialises.
+
+2. **Context isolation (enforced by the consumer).** The proposer prompt is built
+   from `dev/` only; the gate reads `holdout/` only. This is a contract the
+   Phase 3 proposer (#587) and the scorer/gate (#583/#586) implement at
+   prompt-/context-assembly time — the directory split is the structural boundary
+   they key off.
+
+**Residual risk and future hardening.** Because this repo is a single git tree,
+control (2) is a *contract*, not a hard wall: a proposer that read raw files under
+`holdout/` instead of using the sanctioned dev-only context builder could still
+see them. Directory split + CODEOWNERS removes the *tampering* and *accidental
+inclusion* vectors and is sufficient for the current single-repo pipeline. Making
+the holdout truly **unreadable** by the proposer's checkout (a separate
+access-controlled store, an encrypted/rotating holdout, or fetching the holdout
+only inside the gate's isolated job) is the stronger mechanism and is left as
+follow-up hardening — tracked against the proposer/gate stories rather than this
+structural deliverable.

--- a/evals/example-skill/dev/cases.jsonl
+++ b/evals/example-skill/dev/cases.jsonl
@@ -1,0 +1,3 @@
+{"id": "dev-0001", "prompt": "Summarize a CI failure log where a shellcheck warning (SC2086) blocks the build.", "expected": "Identifies the unquoted variable, names SC2086, and proposes quoting the expansion."}
+{"id": "dev-0002", "prompt": "A workflow uses a mutable action ref (uses: actions/checkout@v4). What should change?", "expected": "Recommends SHA-pinning the third-party action and notes the first-party channel-tag exception."}
+{"id": "dev-0003", "prompt": "An agent profile markdown file is missing its tools frontmatter field. Describe the fix.", "expected": "Notes the required name/description/tools frontmatter and adds a tools field."}

--- a/evals/example-skill/holdout/cases.jsonl
+++ b/evals/example-skill/holdout/cases.jsonl
@@ -1,0 +1,3 @@
+{"id": "ho-0001", "prompt": "A scheduled workflow has no timeout-minutes set. What is the risk and the fix?", "expected": "Flags the missing timeout (runaway-job/cost risk) and adds a timeout-minutes bound."}
+{"id": "ho-0002", "prompt": "A script hardcodes a token literal instead of reading from the environment. Describe the fix.", "expected": "Replaces the literal with $GITHUB_TOKEN from the environment and warns about secret leakage."}
+{"id": "ho-0003", "prompt": "A bash script omits 'set -euo pipefail'. Why does that matter here?", "expected": "Explains silent failures from unset vars/pipes and adds the strict-mode preamble."}

--- a/evals/validate-cases.py
+++ b/evals/validate-cases.py
@@ -1,18 +1,25 @@
 #!/usr/bin/env python3
-"""Validate a held-out eval-case set (JSONL) against case.schema.json.
+"""Validate held-out eval cases under evals/<skill>/{dev,holdout}/cases.jsonl.
 
-Each line of the .jsonl file is one case object. Beyond per-line JSON-Schema
-structural checks this enforces the one cross-line invariant the held-out set
-depends on:
+This enforces the held-out-hygiene contract (#691, epic #581): the proposer only
+ever sees the *dev* split, and the gate scores against the *holdout* split. For
+that to mean anything, a case must never live in both splits — otherwise the
+proposer could see (and overfit to) a case the gate later scores against.
 
-  - case ids are unique (a duplicate id silently shadows a case)
+Per skill directory under the eval root, this checks:
 
-This is intentionally a *validator only* — no scorer, no model invocation. The
-held-out cases are the trust anchor of skill-quality measurement; this tool
-exists so the set can be checked in CI the same way scripts/initiative-planner
-checks plan.schema.json (python jsonschema, draft 2020-12).
+  - both a dev/ and a holdout/ split exist (each with a cases.jsonl)
+  - every non-blank line is a JSON object
+  - every case has a non-empty string `id`
+  - ids are unique within each split
+  - ids are disjoint across the two splits (no case appears in both)
 
-Usage: validate-cases.py <cases.jsonl> [schema.json]
+This is data/structure/validation only — it never invokes a scorer or a model
+(consistent with #582). The case payload schema beyond `id` is owned by the
+scorer story (#583); this validator is deliberately agnostic to it.
+
+Usage: validate-cases.py [eval_root]
+  eval_root defaults to the directory containing this script (the evals/ tree).
 Exit 0 on success; non-zero with a message on failure.
 """
 import json
@@ -20,59 +27,97 @@ import sys
 from pathlib import Path
 from typing import NoReturn
 
+SPLITS = ("dev", "holdout")
+CASES_FILENAME = "cases.jsonl"
+
 
 def fail(msg: str) -> NoReturn:
-    # stdout (not stderr) so the reason is visible in workflow logs and capturable
+    # Write to stderr so the reason is visible in workflow logs and capturable
     # by tests; the ::error:: prefix still renders as a GitHub annotation.
-    print(f"::error::eval cases invalid: {msg}")
+    print(f"::error::eval cases invalid: {msg}", file=sys.stderr)
     sys.exit(1)
 
 
-def main() -> None:
-    if len(sys.argv) < 2:
-        fail("usage: validate-cases.py <cases.jsonl> [schema.json]")
-    cases_path = Path(sys.argv[1])
-    schema_path = Path(sys.argv[2]) if len(sys.argv) > 2 else Path(__file__).with_name("case.schema.json")
+def load_split_ids(cases_path: Path) -> list[str]:
+    """Parse a cases.jsonl file and return its ordered list of case ids.
 
+    Fails (exits non-zero) on malformed JSON, non-object lines, missing/empty
+    ids, or duplicate ids within this single file.
+    """
     try:
-        import jsonschema
-    except ImportError:
-        fail("jsonschema not installed (pip install 'jsonschema>=4')")
-
-    try:
-        schema = json.loads(schema_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        fail(f"could not read/parse schema {schema_path}: {exc}")
-
-    try:
-        raw = cases_path.read_text(encoding="utf-8")
+        raw = cases_path.read_text()
     except OSError as exc:
         fail(f"could not read {cases_path}: {exc}")
 
-    validator = jsonschema.Draft202012Validator(schema)
-    ids: dict[str, int] = {}
-    count = 0
+    ids: list[str] = []
+    seen: set[str] = set()
     for lineno, line in enumerate(raw.splitlines(), start=1):
         if not line.strip():
-            continue  # tolerate blank separator lines
+            continue  # blank lines are allowed as separators
         try:
             case = json.loads(line)
         except json.JSONDecodeError as exc:
-            fail(f"line {lineno}: not valid JSON: {exc}")
-        error = next(validator.iter_errors(case), None)
-        if error is not None:
-            loc = "/".join(str(p) for p in error.absolute_path) or "<root>"
-            fail(f"line {lineno}: schema violation at {loc}: {error.message}")
-        case_id = case["id"]
-        if case_id in ids:
-            fail(f"line {lineno}: duplicate case id '{case_id}' (first seen on line {ids[case_id]})")
-        ids[case_id] = lineno
-        count += 1
+            fail(f"{cases_path}:{lineno}: invalid JSON: {exc}")
+        if not isinstance(case, dict):
+            fail(f"{cases_path}:{lineno}: each case line must be a JSON object")
+        if "id" not in case:
+            fail(f"{cases_path}:{lineno}: case is missing required field 'id'")
+        cid = case["id"]
+        if not isinstance(cid, str) or not cid.strip():
+            fail(f"{cases_path}:{lineno}: case 'id' must be a non-empty string")
+        if cid in seen:
+            fail(f"{cases_path}:{lineno}: duplicate id '{cid}' within this split")
+        seen.add(cid)
+        ids.append(cid)
+    return ids
 
-    if count == 0:
-        fail(f"{cases_path} contains no cases")
 
-    print(f"cases OK: {count} case(s), unique ids, schema-valid.")
+def validate_skill(skill_dir: Path) -> int:
+    """Validate one skill's dev/holdout split. Returns the total case count."""
+    split_ids: dict[str, list[str]] = {}
+    for split in SPLITS:
+        cases_path = skill_dir / split / CASES_FILENAME
+        if not cases_path.is_file():
+            fail(f"skill '{skill_dir.name}' is missing its {split} split "
+                 f"(expected {cases_path})")
+        split_ids[split] = load_split_ids(cases_path)
+
+    overlap = set(split_ids["dev"]) & set(split_ids["holdout"])
+    if overlap:
+        joined = ", ".join(sorted(overlap))
+        fail(f"skill '{skill_dir.name}': id(s) appear in both dev and holdout "
+             f"splits (a case must not be in both): {joined}")
+
+    return sum(len(ids) for ids in split_ids.values())
+
+
+def discover_skills(eval_root: Path) -> list[Path]:
+    """A skill is any direct subdirectory that has a dev/ or holdout/ split."""
+    skills = []
+    for child in sorted(eval_root.iterdir()):
+        if not child.is_dir():
+            continue
+        if any((child / split).is_dir() for split in SPLITS):
+            skills.append(child)
+    return skills
+
+
+def main() -> None:
+    eval_root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(__file__).parent
+    if not eval_root.is_dir():
+        fail(f"eval root is not a directory: {eval_root}")
+
+    skills = discover_skills(eval_root)
+    if not skills:
+        fail(f"no skills found under {eval_root} "
+             f"(expected <skill>/dev/ and <skill>/holdout/ subdirectories)")
+
+    total = 0
+    for skill_dir in skills:
+        total += validate_skill(skill_dir)
+
+    print(f"OK: {len(skills)} skill(s), {total} case(s) across dev+holdout, "
+          f"no cross-split id overlap.")
 
 
 if __name__ == "__main__":

--- a/evals/validate-cases.py
+++ b/evals/validate-cases.py
@@ -45,7 +45,7 @@ def load_split_ids(cases_path: Path) -> list[str]:
     ids, or duplicate ids within this single file.
     """
     try:
-        raw = cases_path.read_text()
+        raw = cases_path.read_text(encoding="utf-8")
     except OSError as exc:
         fail(f"could not read {cases_path}: {exc}")
 

--- a/tests/test_validate_cases.bats
+++ b/tests/test_validate_cases.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+# Tests for evals/validate-cases.py — the held-out hygiene validator (#691, epic #581).
+# Validates the dev/holdout split: well-formed JSONL, unique non-empty `id` per
+# split, and no `id` shared across splits (a case must never appear in both).
+
+setup() {
+  ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  VALIDATOR="$ROOT/evals/validate-cases.py"
+  TMP="$(mktemp -d)"
+  # A well-formed skill: disjoint dev/holdout ids.
+  mkdir -p "$TMP/example-skill/dev" "$TMP/example-skill/holdout"
+  cat >"$TMP/example-skill/dev/cases.jsonl" <<'JSONL'
+{"id": "dev-001", "prompt": "redacted input A", "expected": "redacted output A"}
+{"id": "dev-002", "prompt": "redacted input B", "expected": "redacted output B"}
+JSONL
+  cat >"$TMP/example-skill/holdout/cases.jsonl" <<'JSONL'
+{"id": "ho-001", "prompt": "redacted input C", "expected": "redacted output C"}
+{"id": "ho-002", "prompt": "redacted input D", "expected": "redacted output D"}
+JSONL
+}
+
+teardown() { rm -rf "$TMP"; }
+
+@test "validate-cases accepts a well-formed dev/holdout split" {
+  run python3 "$VALIDATOR" "$TMP"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK"* ]]
+}
+
+@test "validate-cases rejects an id appearing in both dev and holdout" {
+  # Make ho-001 collide with a dev id.
+  cat >"$TMP/example-skill/holdout/cases.jsonl" <<'JSONL'
+{"id": "dev-001", "prompt": "leaked into holdout", "expected": "x"}
+{"id": "ho-002", "prompt": "redacted input D", "expected": "redacted output D"}
+JSONL
+  run python3 "$VALIDATOR" "$TMP"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"dev-001"* ]]
+  [[ "$output" == *"both"* ]]
+}
+
+@test "validate-cases rejects a duplicate id within a split" {
+  cat >"$TMP/example-skill/dev/cases.jsonl" <<'JSONL'
+{"id": "dev-001", "prompt": "a", "expected": "a"}
+{"id": "dev-001", "prompt": "dup", "expected": "dup"}
+JSONL
+  run python3 "$VALIDATOR" "$TMP"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"duplicate"* ]]
+}
+
+@test "validate-cases rejects malformed JSON in a case line" {
+  printf '%s\n' '{"id": "dev-003", "prompt": "broken"' >>"$TMP/example-skill/dev/cases.jsonl"
+  run python3 "$VALIDATOR" "$TMP"
+  [ "$status" -ne 0 ]
+}
+
+@test "validate-cases rejects a case missing an id" {
+  printf '%s\n' '{"prompt": "no id here", "expected": "x"}' >>"$TMP/example-skill/dev/cases.jsonl"
+  run python3 "$VALIDATOR" "$TMP"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"id"* ]]
+}
+
+@test "validate-cases rejects a case with an empty id" {
+  printf '%s\n' '{"id": "   ", "prompt": "blank id", "expected": "x"}' >>"$TMP/example-skill/dev/cases.jsonl"
+  run python3 "$VALIDATOR" "$TMP"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"id"* ]]
+}
+
+@test "validate-cases rejects a non-object case line" {
+  printf '%s\n' '["not", "an", "object"]' >>"$TMP/example-skill/dev/cases.jsonl"
+  run python3 "$VALIDATOR" "$TMP"
+  [ "$status" -ne 0 ]
+}
+
+@test "validate-cases skips blank lines in a cases file" {
+  printf '\n\n' >>"$TMP/example-skill/dev/cases.jsonl"
+  run python3 "$VALIDATOR" "$TMP"
+  [ "$status" -eq 0 ]
+}
+
+@test "validate-cases fails when a skill has a dev split but no holdout" {
+  rm -rf "$TMP/example-skill/holdout"
+  run python3 "$VALIDATOR" "$TMP"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"holdout"* ]]
+}
+
+@test "validate-cases validates the committed evals tree" {
+  # The real example skill checked into the repo must always validate.
+  run python3 "$VALIDATOR" "$ROOT/evals"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK"* ]]
+}


### PR DESCRIPTION
Closes #691

Implemented by dev-lead agent. Please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated validator for evaluation case JSONL files to enforce required `id`s, uniqueness, and disjoint `dev`/`holdout` splits.
* **Tests**
  * Extended CI Bats coverage to run the new evaluation-case validation checks.
* **Documentation**
  * Documented the `evals/` directory structure, required case format, `dev` vs `holdout` split rules, de-identification expectations, and held-out integrity protections.
* **Chores**
  * Updated CODEOWNERS to lock ownership for `/evals/**/holdout/` paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->