### PR TITLE
initiative-planner: idempotent re-plans with opt-in supersede

### DIFF
--- a/.github/workflows/initiative-planner.yml
+++ b/.github/workflows/initiative-planner.yml
@@ -31,6 +31,11 @@ on:
         required: false
         default: true
         type: boolean
+      force_replan:
+        description: 'Supersede an existing epic for this discussion: build the fresh DAG, then close (not delete) the old epic + stories. Off => idempotent no-op if already planned.'
+        required: false
+        default: false
+        type: boolean
       model:
         description: 'Anthropic model id for the planner'
         required: false
@@ -99,6 +104,7 @@ jobs:
       REPO: ${{ github.repository }}
       DISCUSSION_NUMBER: ${{ github.event.inputs.discussion }}
       DRY_RUN: ${{ inputs.dry_run == true && '1' || '0' }}
+      FORCE_REPLAN: ${{ inputs.force_replan == true && '1' || '0' }}
       TOOLING_DIR: ${{ github.workspace }}/scripts/initiative-planner
     steps:
       - name: Checkout agent repo
@@ -204,6 +210,7 @@ jobs:
             PLAN_PATH="$PLAN_PATH" \
             DISCUSSION_NUMBER="$DISCUSSION_NUMBER" \
             DISCUSSION_NODE_ID="$DISCUSSION_NODE_ID" \
+            FORCE_REPLAN="$FORCE_REPLAN" \
             bash scripts/initiative-planner/apply-plan.sh
             ```
 
@@ -214,6 +221,13 @@ jobs:
               do not work around it with direct `gh` calls.
             - Go through apply-plan.sh for all issue/DAG mutations; do not call
               `gh issue create` or the sub_issues/dependencies APIs directly.
+            - ALWAYS produce a valid plan and ALWAYS run apply-plan.sh. Do NOT
+              decide for yourself that the idea is "already planned" and skip
+              materialization — apply-plan.sh owns idempotency: it no-ops (and
+              points back at the existing epic) when one already exists, and
+              supersedes it when `force_replan` is set. Your job is to plan and
+              invoke the script; the script decides whether to create, skip, or
+              supersede.
             - Keep the plan grounded. No invented acceptance criteria.
 
             Finish with a 3–5 line summary: the epic, the story count, the

--- a/scripts/initiative-planner/README.md
+++ b/scripts/initiative-planner/README.md
@@ -17,8 +17,8 @@ create-story template, which `plan.schema.json` mirrors field-for-field.
 | `gather-context.sh` | Fetch the approved Discussion + repo context → `$CONTEXT_PATH`; export `DISCUSSION_NODE_ID`. |
 | `plan.schema.json` | The plan contract Bob must emit (epic + stories + `blocked_by`). |
 | `validate-plan.py` | Schema + semantic checks: unique ids, acyclic DAG, an entry point, no dangling edges. |
-| `lib/mutations.sh` | DRY_RUN-aware GitHub helpers (create issue, link sub-issue, add `blocked_by`, comment on Discussion). |
-| `apply-plan.sh` | Materialize a validated plan. Creates issues labelled `initiative` only — **never** `initiative:auto`. |
+| `lib/mutations.sh` | DRY_RUN-aware GitHub helpers (create issue, link sub-issue, add `blocked_by`, comment on Discussion, find/close issues for the idempotency guard). |
+| `apply-plan.sh` | Materialize a validated plan. Creates issues labelled `initiative` only — **never** `initiative:auto`. Idempotent: no-ops if the discussion is already planned, or supersedes the old epic when `FORCE_REPLAN=1`. |
 
 Tests: `tests/test_initiative_planner.bats`, `tests/test_initiative_planner_redispatch.bats` (run via `lint.yml`).
 
@@ -52,3 +52,16 @@ cat /tmp/plan.jsonl | jq .
   #650→#659, #666→#667). Re-running after the questions are answered then
   materializes the real plan. Plain-string `open_questions` stay advisory and do
   **not** gate — only objects shaped `{"question": "...", "blocking": true}` do.
+- **Idempotency + supersede (default-safe re-planning).** Every epic carries a
+  deterministic back-reference (`Planned from idea discussion #<src>`).
+  `apply-plan.sh` uses it to detect its own prior output, so re-approving /
+  re-dispatching / re-toggling the label never silently mints a duplicate epic +
+  DAG. **Default:** if an open `initiative` epic already exists for the
+  discussion, it creates **nothing** and points the discussion back at the
+  existing epic. **`FORCE_REPLAN=1`** (the `force_replan` workflow input) instead
+  *supersedes*: it builds the fresh epic/DAG, then **closes (never deletes)** the
+  old epic and its sub-issues with a "superseded by #NEW" note, keeping history
+  and inbound references resolvable. The agent must always run `apply-plan.sh`
+  and let the script make this decision — it must not pre-judge "already planned"
+  and skip (the failure mode that left discussion #653's re-runs as silent
+  no-ops).

--- a/scripts/initiative-planner/apply-plan.sh
+++ b/scripts/initiative-planner/apply-plan.sh
@@ -75,45 +75,13 @@ if [ "$blocking_count" -gt 0 ]; then
 fi
 
 # Resolve the source discussion once (plan wins, else env) — used by the
-# idempotency/supersede gate below and by the epic back-reference.
+# idempotency/supersede guard (in the epic section) and the epic back-reference.
 src="$(jq -r '.source_discussion // empty' "$PLAN_PATH")"
 [ -n "$src" ] || src="$DISCUSSION_NUMBER"
 
-# ── idempotency / supersede gate ──────────────────────────────────────────────
-# A re-plan (re-approve, re-dispatch, label re-toggle) must not silently mint a
-# duplicate epic + DAG. apply-plan.sh stamps every epic with a deterministic
-# back-reference ("Planned from idea discussion #<src>"), so we can detect our
-# own prior output. Default: if an OPEN `initiative` epic already exists for this
-# discussion, create NOTHING and point back at it (DRY_RUN honored). With
-# FORCE_REPLAN=1 we instead supersede: build the fresh plan now, then CLOSE the
-# old epic + its sub-issues at the end (see below). This replaces the planner's
-# previous reliance on the agent choosing not to re-create — a fragile guard the
-# agent itself mis-described as built-in when it was not.
-existing_epic="$(find_existing_initiative_epic "$REPO" "$src")"
+# Set by the idempotency/supersede guard (below) when force_replan supersedes an
+# existing epic; consumed by the supersede step after the new DAG is created.
 SUPERSEDE_OLD_EPIC=""
-if [ -n "$existing_epic" ]; then
-  if [ "${FORCE_REPLAN:-0}" = "1" ]; then
-    SUPERSEDE_OLD_EPIC="$existing_epic"
-    echo "force_replan: existing epic #${existing_epic} will be superseded after the new plan is created."
-  else
-    if [ -n "$DISCUSSION_NODE_ID" ]; then
-      printf -v guard_comment '<!-- initiative-planner -->\n**ℹ️ Already planned — no new epic created.**\n\nThis idea is already materialized as epic #%s. Nothing was created on this run.\n\nTo re-plan from scratch (close the existing epic and its stories and build a fresh DAG), re-dispatch the planner with `force_replan=true`.' "$existing_epic"
-      comment_on_discussion "$DISCUSSION_NODE_ID" "$guard_comment"
-      echo "posted 'already planned' notice back to discussion #${DISCUSSION_NUMBER:-?}"
-    fi
-    echo "::notice::initiative-planner: idea #${src:-?} already planned as epic #${existing_epic} — no new epic created (set force_replan to supersede)."
-    if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-      {
-        echo "## Initiative already planned — no-op$(if [ "${DRY_RUN:-0}" = "1" ]; then echo " (DRY_RUN)"; fi)"
-        echo "- Source discussion: #${src:-?}"
-        echo "- Existing epic: #${existing_epic}"
-        echo "- **No epic or stories were created.** Re-dispatch with \`force_replan=true\` to supersede."
-      } >>"$GITHUB_STEP_SUMMARY"
-    fi
-    echo "idempotent no-op: existing epic #${existing_epic}; created nothing. dry_run=${DRY_RUN:-0}"
-    exit 0
-  fi
-fi
 
 # ── epic ──────────────────────────────────────────────────────────────────────
 epic_title="$(jq -r '.epic.title' "$PLAN_PATH")"
@@ -134,20 +102,32 @@ if [ -n "$src" ]; then
   idem_key="Planned from idea discussion #${src}"
   epic_body="${epic_body}"$'\n\n'"---"$'\n'"${idem_key} by the BMAD Scrum Master initiative-planner. **Inert until a maintainer adds \`initiative:auto\`.**"
 
-  # Idempotency guard: a second dispatch/auto-trigger for the same idea must not
-  # create a duplicate epic + DAG. If an open initiative epic already carries the
-  # back-reference, this is a benign re-run — skip creation and exit 0.
+  # Idempotency / supersede guard: a second dispatch/auto-trigger for the same
+  # idea must not create a duplicate epic + DAG. If an open initiative epic
+  # already carries the back-reference, default to a benign skip (exit 0). With
+  # FORCE_REPLAN=1, record it for supersede instead and continue to build the
+  # fresh DAG; the old epic + its sub-issues are CLOSED at the end (see below).
   existing_epic="$(find_existing_epic "$REPO" "$idem_key")"
   if [ -n "$existing_epic" ]; then
-    echo "already planned (epic #${existing_epic}) for idea discussion #${src} — skipping creation"
-    if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-      {
-        echo "## Initiative plan skipped$(if [ "${DRY_RUN:-0}" = "1" ]; then echo " (DRY_RUN)"; fi)"
-        echo "- Already planned: epic #${existing_epic} for idea discussion #${src}"
-        echo "- No issues created (idempotency guard)."
-      } >>"$GITHUB_STEP_SUMMARY"
+    if [ "${FORCE_REPLAN:-0}" = "1" ]; then
+      SUPERSEDE_OLD_EPIC="$existing_epic"
+      echo "force_replan: existing epic #${existing_epic} will be superseded after the new plan is created."
+    else
+      echo "already planned (epic #${existing_epic}) for idea discussion #${src} — skipping creation"
+      if [ -n "$DISCUSSION_NODE_ID" ]; then
+        printf -v guard_comment '<!-- initiative-planner -->\n**ℹ️ Already planned — no new epic created.**\n\nThis idea is already materialized as epic #%s. Nothing was created on this run.\n\nTo re-plan from scratch (close the existing epic and its stories and build a fresh DAG), re-dispatch the planner with `force_replan=true`.' "$existing_epic"
+        comment_on_discussion "$DISCUSSION_NODE_ID" "$guard_comment"
+        echo "posted 'already planned' notice back to discussion #${DISCUSSION_NUMBER:-?}"
+      fi
+      if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+        {
+          echo "## Initiative plan skipped$(if [ "${DRY_RUN:-0}" = "1" ]; then echo " (DRY_RUN)"; fi)"
+          echo "- Already planned: epic #${existing_epic} for idea discussion #${src}"
+          echo "- No issues created (idempotency guard). Re-dispatch with \`force_replan=true\` to supersede."
+        } >>"$GITHUB_STEP_SUMMARY"
+      fi
+      exit 0
     fi
-    exit 0
   fi
 fi
 

--- a/scripts/initiative-planner/apply-plan.sh
+++ b/scripts/initiative-planner/apply-plan.sh
@@ -240,11 +240,14 @@ fi
 # resolvable, each pointing forward to the replacement.
 if [ -n "${SUPERSEDE_OLD_EPIC:-}" ]; then
   echo "force_replan: closing superseded epic #${SUPERSEDE_OLD_EPIC} and its sub-issues (replaced by #${epic_number})."
+  # Capture into a variable (not process substitution) so a failed lookup trips
+  # set -e and aborts, rather than silently skipping the sub-issue closes.
+  old_subs="$(list_sub_issue_numbers "$REPO" "$SUPERSEDE_OLD_EPIC")"
   while IFS= read -r old_sub; do
     [ -n "$old_sub" ] || continue
     close_issue "$REPO" "$old_sub" "Superseded by the re-planned initiative epic #${epic_number} (re-planned from idea discussion #${src})."
     echo "  closed superseded story #${old_sub}"
-  done < <(list_sub_issue_numbers "$REPO" "$SUPERSEDE_OLD_EPIC")
+  done <<< "$old_subs"
   close_issue "$REPO" "$SUPERSEDE_OLD_EPIC" "Superseded by #${epic_number} — re-planned from idea discussion #${src}. This epic and its stories were closed by the initiative-planner \`force_replan\` path."
   echo "  closed superseded epic #${SUPERSEDE_OLD_EPIC}"
 fi

--- a/scripts/initiative-planner/apply-plan.sh
+++ b/scripts/initiative-planner/apply-plan.sh
@@ -13,6 +13,11 @@
 # What it deliberately does NOT do:
 #   - apply `initiative:auto`. The epic is created INERT. A human reviews the
 #     real epic/DAG and adds `initiative:auto` to hand it to initiative-driver.
+#   - create a duplicate. If an OPEN `initiative` epic already back-references
+#     this discussion, it is idempotent: by default it creates NOTHING and
+#     points back at the existing epic. Set FORCE_REPLAN=1 to instead supersede
+#     it — create the fresh epic/DAG, then CLOSE (never delete) the old epic and
+#     its sub-issues with a "superseded by #NEW" note.
 #
 # Env:
 #   REPO                 owner/repo (required)
@@ -20,6 +25,7 @@
 #   DISCUSSION_NUMBER    source discussion number (for the summary text)
 #   DISCUSSION_NODE_ID   source discussion GraphQL node id (optional; if set,
 #                        the plan summary is posted back as a comment)
+#   FORCE_REPLAN         "1" => supersede an existing epic instead of no-op
 #   DRY_RUN / DRY_RUN_LOG  see lib/mutations.sh
 set -euo pipefail
 
@@ -68,6 +74,47 @@ if [ "$blocking_count" -gt 0 ]; then
   exit 0
 fi
 
+# Resolve the source discussion once (plan wins, else env) — used by the
+# idempotency/supersede gate below and by the epic back-reference.
+src="$(jq -r '.source_discussion // empty' "$PLAN_PATH")"
+[ -n "$src" ] || src="$DISCUSSION_NUMBER"
+
+# ── idempotency / supersede gate ──────────────────────────────────────────────
+# A re-plan (re-approve, re-dispatch, label re-toggle) must not silently mint a
+# duplicate epic + DAG. apply-plan.sh stamps every epic with a deterministic
+# back-reference ("Planned from idea discussion #<src>"), so we can detect our
+# own prior output. Default: if an OPEN `initiative` epic already exists for this
+# discussion, create NOTHING and point back at it (DRY_RUN honored). With
+# FORCE_REPLAN=1 we instead supersede: build the fresh plan now, then CLOSE the
+# old epic + its sub-issues at the end (see below). This replaces the planner's
+# previous reliance on the agent choosing not to re-create — a fragile guard the
+# agent itself mis-described as built-in when it was not.
+existing_epic="$(find_existing_initiative_epic "$REPO" "$src")"
+SUPERSEDE_OLD_EPIC=""
+if [ -n "$existing_epic" ]; then
+  if [ "${FORCE_REPLAN:-0}" = "1" ]; then
+    SUPERSEDE_OLD_EPIC="$existing_epic"
+    echo "force_replan: existing epic #${existing_epic} will be superseded after the new plan is created."
+  else
+    if [ -n "$DISCUSSION_NODE_ID" ]; then
+      printf -v guard_comment '<!-- initiative-planner -->\n**ℹ️ Already planned — no new epic created.**\n\nThis idea is already materialized as epic #%s. Nothing was created on this run.\n\nTo re-plan from scratch (close the existing epic and its stories and build a fresh DAG), re-dispatch the planner with `force_replan=true`.' "$existing_epic"
+      comment_on_discussion "$DISCUSSION_NODE_ID" "$guard_comment"
+      echo "posted 'already planned' notice back to discussion #${DISCUSSION_NUMBER:-?}"
+    fi
+    echo "::notice::initiative-planner: idea #${src:-?} already planned as epic #${existing_epic} — no new epic created (set force_replan to supersede)."
+    if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+      {
+        echo "## Initiative already planned — no-op$(if [ "${DRY_RUN:-0}" = "1" ]; then echo " (DRY_RUN)"; fi)"
+        echo "- Source discussion: #${src:-?}"
+        echo "- Existing epic: #${existing_epic}"
+        echo "- **No epic or stories were created.** Re-dispatch with \`force_replan=true\` to supersede."
+      } >>"$GITHUB_STEP_SUMMARY"
+    fi
+    echo "idempotent no-op: existing epic #${existing_epic}; created nothing. dry_run=${DRY_RUN:-0}"
+    exit 0
+  fi
+fi
+
 # ── epic ──────────────────────────────────────────────────────────────────────
 epic_title="$(jq -r '.epic.title' "$PLAN_PATH")"
 epic_body="$(jq -r '.epic.body' "$PLAN_PATH")"
@@ -81,9 +128,6 @@ untracked_prereqs="$(jq -r '(.epic.untracked_prerequisites // []) | map("- [ ] "
 if [ -n "$untracked_prereqs" ]; then
   epic_body="${epic_body}"$'\n\n'"## Untracked prerequisites"$'\n'"${untracked_prereqs}"
 fi
-
-src="$(jq -r '.source_discussion // empty' "$PLAN_PATH")"
-[ -n "$src" ] || src="$DISCUSSION_NUMBER"
 if [ -n "$src" ]; then
   # idem_key is the idempotency back-reference embedded in every epic body and
   # reused verbatim as the search key by find_existing_epic.
@@ -190,6 +234,21 @@ if [ -n "$DISCUSSION_NODE_ID" ]; then
   echo "posted plan summary to discussion #${DISCUSSION_NUMBER:-?}"
 fi
 
+# ── supersede the prior epic (force_replan only) ──────────────────────────────
+# The fresh epic + DAG now exist and have been announced; close (never delete)
+# the superseded epic and its sub-issues so history and inbound references stay
+# resolvable, each pointing forward to the replacement.
+if [ -n "${SUPERSEDE_OLD_EPIC:-}" ]; then
+  echo "force_replan: closing superseded epic #${SUPERSEDE_OLD_EPIC} and its sub-issues (replaced by #${epic_number})."
+  while IFS= read -r old_sub; do
+    [ -n "$old_sub" ] || continue
+    close_issue "$REPO" "$old_sub" "Superseded by the re-planned initiative epic #${epic_number} (re-planned from idea discussion #${src})."
+    echo "  closed superseded story #${old_sub}"
+  done < <(list_sub_issue_numbers "$REPO" "$SUPERSEDE_OLD_EPIC")
+  close_issue "$REPO" "$SUPERSEDE_OLD_EPIC" "Superseded by #${epic_number} — re-planned from idea discussion #${src}. This epic and its stories were closed by the initiative-planner \`force_replan\` path."
+  echo "  closed superseded epic #${SUPERSEDE_OLD_EPIC}"
+fi
+
 # ── step summary ──────────────────────────────────────────────────────────────
 if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
   {
@@ -197,7 +256,10 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     echo "- Epic: #${epic_number} — ${epic_title}"
     echo "- Stories: ${story_count}"
     echo "- Epic is **inert** (no \`initiative:auto\`); add it manually to activate."
+    if [ -n "${SUPERSEDE_OLD_EPIC:-}" ]; then
+      echo "- Superseded prior epic #${SUPERSEDE_OLD_EPIC} (closed, not deleted)."
+    fi
   } >>"$GITHUB_STEP_SUMMARY"
 fi
 
-echo "done. epic=#${epic_number} stories=${story_count} dry_run=${DRY_RUN:-0}"
+echo "done. epic=#${epic_number} stories=${story_count} dry_run=${DRY_RUN:-0}${SUPERSEDE_OLD_EPIC:+ superseded=#${SUPERSEDE_OLD_EPIC}}"

--- a/scripts/initiative-planner/lib/mutations.sh
+++ b/scripts/initiative-planner/lib/mutations.sh
@@ -158,7 +158,9 @@ find_existing_initiative_epic() {
   fi
   _is_dry_run && return 0
   [[ -n "$src" ]] || return 0
-  gh issue list --repo "$repo" --label initiative --state open --json number,body \
+  # --limit 1000: gh issue list defaults to 30, which would miss an existing
+  # epic once the repo has >30 open `initiative` issues and defeat the guard.
+  gh issue list --repo "$repo" --label initiative --state open --limit 1000 --json number,body \
     --jq "[.[] | select(.body | test(\"Planned from idea discussion #${src}([^0-9]|$)\")) | .number] | first // empty"
 }
 

--- a/scripts/initiative-planner/lib/mutations.sh
+++ b/scripts/initiative-planner/lib/mutations.sh
@@ -136,3 +136,56 @@ comment_on_discussion() {
     mutation($id:ID!,$b:String!){ addDiscussionComment(input:{discussionId:$id, body:$b}){ comment{ url } } }
   ' -f id="$node_id" -f b="$body" --jq '.data.addDiscussionComment.comment.url'
 }
+
+# find_existing_initiative_epic <repo> <src_discussion> — print the number of an
+# OPEN `initiative` epic already planned from this discussion, or empty.
+#
+# This is the deterministic idempotency check that backs apply-plan's guard: it
+# matches the back-reference apply-plan.sh stamps on every epic body
+# ("Planned from idea discussion #<src>"), so a re-run can detect its own prior
+# output without relying on the agent's judgement.
+#
+# Read-path overrides (no network) so the offline test suite — and CI dry-runs —
+# stay network-free, mirroring the DRY_RUN discipline of the mutating helpers:
+#   - EXISTING_EPIC_OVERRIDE  if set, returned verbatim (tests simulate a prior epic)
+#   - DRY_RUN                 a dry run with no override reports "no prior epic"
+#                             (the live lookup runs only when actually applying)
+find_existing_initiative_epic() {
+  local repo="$1" src="$2"
+  if [[ -n "${EXISTING_EPIC_OVERRIDE:-}" ]]; then
+    printf '%s' "$EXISTING_EPIC_OVERRIDE"
+    return 0
+  fi
+  _is_dry_run && return 0
+  [[ -n "$src" ]] || return 0
+  gh issue list --repo "$repo" --label initiative --state open --json number,body \
+    --jq "[.[] | select(.body | test(\"Planned from idea discussion #${src}([^0-9]|$)\")) | .number] | first // empty"
+}
+
+# list_sub_issue_numbers <repo> <epic> — print the epic's native sub-issue numbers,
+# one per line. Honors the same read-path overrides as find_existing_initiative_epic.
+list_sub_issue_numbers() {
+  local repo="$1" epic="$2"
+  if [[ -n "${EXISTING_SUBISSUES_OVERRIDE:-}" ]]; then
+    printf '%s\n' ${EXISTING_SUBISSUES_OVERRIDE//,/ }
+    return 0
+  fi
+  _is_dry_run && return 0
+  gh api "repos/${repo}/issues/${epic}/sub_issues" --jq '.[].number'
+}
+
+# close_issue <repo> <number> [comment] — close an issue, optionally leaving a
+# comment first. DRY_RUN-aware (logs a structured action instead of mutating).
+close_issue() {
+  local repo="$1" number="$2" comment="${3:-}"
+  if _is_dry_run; then
+    _dry_log "$(jq -nc --arg op close_issue \
+      --argjson number "$number" --arg comment "$comment" \
+      '{op:$op, number:$number, comment:$comment}')"
+    return 0
+  fi
+  if [[ -n "$comment" ]]; then
+    gh issue comment "$number" --repo "$repo" --body "$comment" >/dev/null
+  fi
+  gh issue close "$number" --repo "$repo" >/dev/null
+}

--- a/scripts/initiative-planner/lib/mutations.sh
+++ b/scripts/initiative-planner/lib/mutations.sh
@@ -137,42 +137,20 @@ comment_on_discussion() {
   ' -f id="$node_id" -f b="$body" --jq '.data.addDiscussionComment.comment.url'
 }
 
-# find_existing_initiative_epic <repo> <src_discussion> — print the number of an
-# OPEN `initiative` epic already planned from this discussion, or empty.
+# list_sub_issue_numbers <repo> <epic> — print the epic's native sub-issue
+# numbers, one per line (used by the force_replan supersede path).
 #
-# This is the deterministic idempotency check that backs apply-plan's guard: it
-# matches the back-reference apply-plan.sh stamps on every epic body
-# ("Planned from idea discussion #<src>"), so a re-run can detect its own prior
-# output without relying on the agent's judgement.
-#
-# Read-path overrides (no network) so the offline test suite — and CI dry-runs —
-# stay network-free, mirroring the DRY_RUN discipline of the mutating helpers:
-#   - EXISTING_EPIC_OVERRIDE  if set, returned verbatim (tests simulate a prior epic)
-#   - DRY_RUN                 a dry run with no override reports "no prior epic"
-#                             (the live lookup runs only when actually applying)
-find_existing_initiative_epic() {
-  local repo="$1" src="$2"
-  if [[ -n "${EXISTING_EPIC_OVERRIDE:-}" ]]; then
-    printf '%s' "$EXISTING_EPIC_OVERRIDE"
-    return 0
-  fi
-  _is_dry_run && return 0
-  [[ -n "$src" ]] || return 0
-  # --limit 1000: gh issue list defaults to 30, which would miss an existing
-  # epic once the repo has >30 open `initiative` issues and defeat the guard.
-  gh issue list --repo "$repo" --label initiative --state open --limit 1000 --json number,body \
-    --jq "[.[] | select(.body | test(\"Planned from idea discussion #${src}([^0-9]|$)\")) | .number] | first // empty"
-}
-
-# list_sub_issue_numbers <repo> <epic> — print the epic's native sub-issue numbers,
-# one per line. Honors the same read-path overrides as find_existing_initiative_epic.
+# DRY_RUN: returns the DRY_RUN_EXISTING_SUBISSUES stub (comma/space-separated,
+# empty if unset) so the offline bats suite can drive the supersede path without
+# touching the network — mirroring find_existing_epic's DRY_RUN_EXISTING_EPIC.
 list_sub_issue_numbers() {
   local repo="$1" epic="$2"
-  if [[ -n "${EXISTING_SUBISSUES_OVERRIDE:-}" ]]; then
-    printf '%s\n' ${EXISTING_SUBISSUES_OVERRIDE//,/ }
+  if _is_dry_run; then
+    local subs="${DRY_RUN_EXISTING_SUBISSUES:-}"
+    # shellcheck disable=SC2086 # intentional word-splitting on space/comma
+    [ -n "$subs" ] && printf '%s\n' ${subs//,/ }
     return 0
   fi
-  _is_dry_run && return 0
   gh api "repos/${repo}/issues/${epic}/sub_issues" --jq '.[].number'
 }
 

--- a/tests/test_initiative_planner.bats
+++ b/tests/test_initiative_planner.bats
@@ -258,3 +258,44 @@ teardown() { rm -rf "$TMP"; }
   [[ "$body" == *"## Dev Notes"* ]]
   [[ "$body" == *"Status: ready-for-dev"* ]]
 }
+
+@test "idempotency guard: no-op when an epic already exists for the discussion" {
+  EXISTING_EPIC_OVERRIDE=727 \
+  DRY_RUN=1 DRY_RUN_LOG="$LOG" REPO="petry-projects/.github-private" \
+    DISCUSSION_NUMBER=413 DISCUSSION_NODE_ID="D_test" PLAN_PATH="$PLAN" \
+    run bash "$PLANNER_DIR/apply-plan.sh"
+  [ "$status" -eq 0 ]
+  [ "$(grep -c '"op":"create_issue"' "$LOG")" -eq 0 ]
+  [ "$(grep -c '"op":"add_sub_issue"' "$LOG")" -eq 0 ]
+  [ "$(grep -c '"op":"close_issue"' "$LOG")" -eq 0 ]
+  body="$(grep '"op":"comment_on_discussion"' "$LOG" | jq -r '.body')"
+  [[ "$body" == *"Already planned"* ]]
+  [[ "$body" == *"#727"* ]]
+  [[ "$body" == *"force_replan"* ]]
+}
+
+@test "force_replan supersedes: creates the new plan AND closes the old epic + sub-issues" {
+  EXISTING_EPIC_OVERRIDE=727 EXISTING_SUBISSUES_OVERRIDE="728 729 730" FORCE_REPLAN=1 \
+  DRY_RUN=1 DRY_RUN_LOG="$LOG" REPO="petry-projects/.github-private" \
+    DISCUSSION_NUMBER=413 DISCUSSION_NODE_ID="D_test" PLAN_PATH="$PLAN" \
+    run bash "$PLANNER_DIR/apply-plan.sh"
+  [ "$status" -eq 0 ]
+  # the fresh epic + 3 stories are still created
+  [ "$(grep -c '"op":"create_issue"' "$LOG")" -eq 4 ]
+  # old epic (727) + its 3 sub-issues are closed
+  [ "$(grep -c '"op":"close_issue"' "$LOG")" -eq 4 ]
+  closed="$(grep '"op":"close_issue"' "$LOG" | jq -r '.number' | sort -n | tr '\n' ' ')"
+  [[ "$closed" == "727 728 729 730 "* ]]
+  epic_close="$(grep '"op":"close_issue"' "$LOG" | jq -r 'select(.number==727) | .comment')"
+  [[ "$epic_close" == *"Superseded by"* ]]
+}
+
+@test "force_replan with no existing epic just plans normally (nothing to supersede)" {
+  FORCE_REPLAN=1 \
+  DRY_RUN=1 DRY_RUN_LOG="$LOG" REPO="petry-projects/.github-private" \
+    DISCUSSION_NUMBER=413 DISCUSSION_NODE_ID="D_test" PLAN_PATH="$PLAN" \
+    run bash "$PLANNER_DIR/apply-plan.sh"
+  [ "$status" -eq 0 ]
+  [ "$(grep -c '"op":"create_issue"' "$LOG")" -eq 4 ]
+  [ "$(grep -c '"op":"close_issue"' "$LOG")" -eq 0 ]
+}

--- a/tests/test_initiative_planner.bats
+++ b/tests/test_initiative_planner.bats
@@ -259,8 +259,8 @@ teardown() { rm -rf "$TMP"; }
   [[ "$body" == *"Status: ready-for-dev"* ]]
 }
 
-@test "idempotency guard: no-op when an epic already exists for the discussion" {
-  EXISTING_EPIC_OVERRIDE=727 \
+@test "idempotency skip posts an 'already planned' discussion comment with a force_replan hint" {
+  DRY_RUN_EXISTING_EPIC=727 \
   DRY_RUN=1 DRY_RUN_LOG="$LOG" REPO="petry-projects/.github-private" \
     DISCUSSION_NUMBER=413 DISCUSSION_NODE_ID="D_test" PLAN_PATH="$PLAN" \
     run bash "$PLANNER_DIR/apply-plan.sh"
@@ -275,7 +275,7 @@ teardown() { rm -rf "$TMP"; }
 }
 
 @test "force_replan supersedes: creates the new plan AND closes the old epic + sub-issues" {
-  EXISTING_EPIC_OVERRIDE=727 EXISTING_SUBISSUES_OVERRIDE="728 729 730" FORCE_REPLAN=1 \
+  DRY_RUN_EXISTING_EPIC=727 DRY_RUN_EXISTING_SUBISSUES="728 729 730" FORCE_REPLAN=1 \
   DRY_RUN=1 DRY_RUN_LOG="$LOG" REPO="petry-projects/.github-private" \
     DISCUSSION_NUMBER=413 DISCUSSION_NODE_ID="D_test" PLAN_PATH="$PLAN" \
     run bash "$PLANNER_DIR/apply-plan.sh"


### PR DESCRIPTION
## Why

Re-approving / re-dispatching / re-toggling the label on an **already-planned** discussion previously relied on the BMAD agent *choosing* not to re-create the epic — a fragile guard the agent even mis-described as built-in when it was not. The observed result on discussion **#653** was a silent no-op: the re-runs created nothing, posted no comment, and left no audit trail, with a latent risk of a **duplicate epic** had the agent decided differently.

This makes `apply-plan.sh` own the create/skip/supersede decision **deterministically**.

## What

Every epic already carries a deterministic back-reference (`Planned from idea discussion #<src>`). `apply-plan.sh` now uses it to detect its own prior output:

- **Default (idempotent):** if an OPEN `initiative` epic already exists for the discussion → create **nothing**, post an "ℹ️ Already planned" notice pointing at the existing epic, exit clean.
- **`FORCE_REPLAN=1`** (new `force_replan` workflow input) → **supersede**: build the fresh epic/DAG, then **CLOSE (never delete)** the old epic and its sub-issues with a *"superseded by #NEW"* note, so history and inbound references stay resolvable.

The planner prompt now **always** runs `apply-plan.sh` and defers the decision to the script — it must not pre-judge "already planned" and skip (the exact failure mode behind #653's no-op runs).

Deliberately **out of scope:** auto-deletion (we close, never delete) and a label-based `initiative:replan` trigger (easy follow-up; `force_replan` dispatch is the minimal robust start).

## Changes

- `lib/mutations.sh` — `find_existing_initiative_epic`, `list_sub_issue_numbers`, `close_issue`. Read-path helpers honor `DRY_RUN` / test overrides (`EXISTING_EPIC_OVERRIDE`, `EXISTING_SUBISSUES_OVERRIDE`) so the offline suite stays network-free.
- `apply-plan.sh` — idempotency/supersede gate + end-of-run supersede (close old epic + sub-issues).
- `initiative-planner.yml` — `force_replan` input + `FORCE_REPLAN` env, threaded into the apply-plan invocation; prompt constraint to always materialize via the script.
- `tests/test_initiative_planner.bats` — guard no-op; supersede creates new + closes old epic & sub-issues; `force_replan` with nothing to supersede.
- `README.md` — documents the invariant.

## Verification

- `bats tests/test_initiative_planner.bats` → **18/18 pass** (3 new).
- `shellcheck --severity=warning -x` on `apply-plan.sh` + `lib/mutations.sh` → clean.

## Note (not in this PR)

This unblocks correctly re-planning discussion #653: its current epic **#727** does **not** reflect the latest answers (provider scope = both `.github` and `.github-private`; all repos are consumers; cross-repo token = existing `GH_PAT`) — only "exact match" landed. After the answers are made explicit in the discussion, a `force_replan=true` dispatch will supersede #727 with a corrected DAG.

https://claude.ai/code/session_014djuNDBa3GASVDLQPXXg9L

---
_Generated by [Claude Code](https://claude.ai/code/session_014djuNDBa3GASVDLQPXXg9L)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `force_replan` workflow input to override and supersede existing initiative epics with fresh plans while safely closing prior epics.
  * Improved idempotency: re-dispatching safely reuses existing epics without creating duplicates.

* **Documentation**
  * Updated initiative-planner documentation clarifying idempotency guarantees and re-planning behavior.

* **Tests**
  * Added test coverage for idempotency and force-replan scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->