### PR TITLE
feat: implement issue #614 — [Phase 2] Register plan_json artifact type (plan rubric + structured-findings channel)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -63,6 +63,7 @@ jobs:
             tests/test_validate_cases.bats \
             tests/test_review_registry.bats \
             tests/test_pr_diff_dispatch.bats \
+            tests/test_plan_review.bats \
             tests/test_skill_evals.bats \
             tests/test_holdout_guard.bats \
             tests/test_skill_eval_report.bats \

--- a/prompts/plan-review.md
+++ b/prompts/plan-review.md
@@ -1,0 +1,91 @@
+# Plan rubric: adversarial critique of an initiative plan
+
+You are Epic #597's **fixed plan critic**. You review one `plan.json` produced by
+the BMAD Scrum Master (Bob) **before** `apply-plan.sh` materializes it into a
+GitHub epic + sub-issue DAG. Your verdict is consumed by the planner as
+machine-readable findings — you do **not** post a GitHub review.
+
+## Inputs (environment variables)
+
+- `$PLAN_PATH` — path to the `plan.json` under review (the content_ref).
+- `$OUTPUT_FILE` — path where you MUST write your findings JSON.
+
+You have `Bash`, `Read`, `Grep`, and `Glob`. Read `$PLAN_PATH`, and read any
+repo files it cites so you can verify grounding.
+
+## What you do NOT check (already enforced — do not duplicate)
+
+`scripts/initiative-planner/validate-plan.py` and `plan.schema.json` already
+enforce the **structural** invariants. Do NOT re-report any of these — they are
+checked before you run and a structural failure means you are never invoked:
+
+- JSON-schema shape, required fields, field length minimums.
+- Unique story ids; `blocked_by` referencing only real ids.
+- No story blocking itself; the `blocked_by` graph being acyclic.
+- At least one entry-point story (a story with no blockers).
+- That a path-like `references` / `target_surface` entry resolves on disk.
+
+If your only complaint about an item is one of the above, drop it.
+
+## What you DO critique (adversarial + semantic, layered on top)
+
+Score the plan against this fixed checklist. For each problem, emit one finding.
+
+1. **Grounding.** Do the `dev_notes` actually ground the implementer? The
+   implementer (dev-lead) sees ONLY the story body. Flag stories whose dev_notes
+   are vague, hand-wave the approach, or omit the architecture/constraints/testing
+   guidance needed to start. Spot-check cited files (`references`,
+   `target_surface`) and flag a citation that resolves but does **not** support
+   the claim it is attached to (wrong file, unrelated section).
+2. **Reference resolution.** Beyond "the path exists" (already validated): is the
+   cited path the *right* one? Flag references that point at the wrong layer
+   (e.g. a test when the change is in the script), or stories that touch a
+   surface they never cite.
+3. **AC testability.** Is each acceptance criterion a concrete, verifiable
+   outcome a reviewer could check? Flag ACs that are aspirational ("works well",
+   "is robust"), unmeasurable, or that restate the title instead of defining
+   done. Flag tasks whose `ac_refs` do not actually satisfy the AC they cite.
+4. **Scope & sequencing.** Flag stories that are too large to be one unit of work
+   (should be split), `blocked_by` edges that are missing (a story that clearly
+   depends on another but is not ordered after it), or `hands_off` mismatches (an
+   automatable story marked hands_off, or a human-judgement story not marked).
+5. **Open questions.** Flag a plan that proceeds past a question that should have
+   been `blocking:true` — i.e. an unresolved decision that changes the shape of
+   the DAG but was left advisory.
+
+Be adversarial but precise: every finding must name the offending story and a
+concrete reason. Do not invent problems to pad the list — an excellent plan may
+yield zero findings.
+
+## Verdict
+
+- `pass` — no blocking concerns; the plan can be materialized as-is (minor/info
+  findings may still accompany a pass).
+- `revise` — at least one `major` or `critical` finding the planner should
+  resolve before `apply-plan.sh` runs.
+
+## Output
+
+Write a single JSON object to `$OUTPUT_FILE` with `cat > "$OUTPUT_FILE" <<'JSON'
+... JSON`. It MUST parse with `jq`:
+
+```json
+{
+  "artifact_type": "plan_json",
+  "verdict": "pass|revise",
+  "summary": "2-3 sentences on the plan's overall quality and the headline concerns.",
+  "findings": [
+    {
+      "severity": "info|minor|major|critical",
+      "category": "grounding|reference|ac_quality|scope|sequencing|open_questions",
+      "message": "Concrete, actionable critique.",
+      "story_id": 1,
+      "location": "stories[0].acceptance_criteria[0] or null"
+    }
+  ]
+}
+```
+
+`story_id` is the plan-local story id the finding is about (or `null` for an
+epic- or plan-level finding). Set `verdict` to `revise` if and only if at least
+one finding is `major` or `critical`.

--- a/scripts/initiative-planner/review-plan.sh
+++ b/scripts/initiative-planner/review-plan.sh
@@ -97,7 +97,11 @@ if ! jq empty "$OUTPUT_FILE" 2>/dev/null; then
 fi
 
 # ── deliver via the resolved structured-findings channel ──────────────────────
-# Default the planner-consumption path to a stable temp file when the caller
-# didn't pin one, so the findings always land somewhere readable.
-export PLAN_FINDINGS_OUTPUT="${PLAN_FINDINGS_OUTPUT:-$WORK_DIR/plan-findings.json}"
+# Default the planner-consumption path to a stable temp file OUTSIDE WORK_DIR
+# when the caller didn't pin one — WORK_DIR is removed by the EXIT trap, so any
+# path within it would be deleted before the caller can consume the findings.
+if [ -z "${PLAN_FINDINGS_OUTPUT:-}" ]; then
+  PLAN_FINDINGS_OUTPUT="$(mktemp "${TMPDIR:-/tmp}/plan-findings.XXXXXX.json")"
+fi
+export PLAN_FINDINGS_OUTPUT
 bash "$REPO_ROOT/$REVIEW_OUTPUT_CHANNEL" "$CONTENT_REF" "$OUTPUT_FILE" "$DRY_RUN"

--- a/scripts/initiative-planner/review-plan.sh
+++ b/scripts/initiative-planner/review-plan.sh
@@ -77,7 +77,9 @@ export OUTPUT_FILE
 : > "$OUTPUT_FILE"
 
 run_agentic "$REPO_ROOT/$RUBRIC_PROMPT" "$ENGINE_DEEP_MODEL" "deep" > "$WORK_DIR/raw.out" 2>"$WORK_DIR/raw.err" || {
-  echo "::warning::plan rubric run exited non-zero; see logs" >&2
+  echo "::error::plan rubric run exited non-zero. Error log:" >&2
+  cat "$WORK_DIR/raw.err" >&2
+  exit 1
 }
 
 # Resolve the findings JSON: prefer the file the prompt wrote; fall back to
@@ -86,7 +88,10 @@ if ! jq empty "$OUTPUT_FILE" 2>/dev/null; then
   if jq empty "$WORK_DIR/raw.out" 2>/dev/null; then
     cp "$WORK_DIR/raw.out" "$OUTPUT_FILE"
   else
-    echo "::error::plan rubric did not produce valid findings JSON" >&2
+    echo "::error::plan rubric did not produce valid findings JSON. Output log:" >&2
+    cat "$WORK_DIR/raw.out" >&2
+    echo "Error log:" >&2
+    cat "$WORK_DIR/raw.err" >&2
     exit 1
   fi
 fi

--- a/scripts/initiative-planner/review-plan.sh
+++ b/scripts/initiative-planner/review-plan.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# review-plan.sh — adversarially review one initiative plan.json against the
+# fixed plan rubric, emitting machine-readable findings (issue #614, epic #610
+# Phase 2).
+#
+# This is the content_ref adapter for artifact_type=plan_json. Like
+# review-one-pr.sh is the pr_diff handler, this is the plan_json handler of the
+# rubric registry: it resolves {rubric, output_channel} for plan_json from the
+# versioned manifest, presents the plan.json (the content_ref) to the rubric,
+# and reuses engine.sh's existing deep-tier model routing (run_agentic) — it
+# introduces NO separate model selector. The verdict is delivered as structured
+# findings by the resolved output channel (scripts/post-plan-findings.sh), which
+# is NOT a GitHub PR review and never calls post-pr-review.sh.
+#
+# Usage: review-plan.sh <plan.json>
+#
+# Env:
+#   REVIEW_ENGINE   — "claude" | "gemini" | "copilot" (default: claude), via engine.sh
+#   DRY_RUN         — "true"/"false", forwarded to the output channel (default: false)
+#   PLAN_FINDINGS_OUTPUT — optional destination path for the findings JSON
+#                          (consumed by the output channel; defaults to a temp file)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Engine abstraction: ENGINE_* model vars + run_agentic (deep tier). Reused as-is
+# — the registry is an input-adapter layer ABOVE engine.sh and must not change
+# model routing.
+# shellcheck source=../engine.sh
+source "$REPO_ROOT/scripts/engine.sh"
+# Rubric registry: review_registry_lookup resolves {rubric, output_channel}.
+# shellcheck source=../lib/review-registry.sh
+source "$REPO_ROOT/scripts/lib/review-registry.sh"
+
+PLAN_PATH="${1:?usage: review-plan.sh <plan.json>}"
+[ -s "$PLAN_PATH" ] || { echo "::error::plan file '$PLAN_PATH' missing or empty" >&2; exit 1; }
+# Resolve to an absolute path so the rubric prompt can read it regardless of the
+# engine's working directory.
+PLAN_PATH="$(cd "$(dirname "$PLAN_PATH")" && pwd)/$(basename "$PLAN_PATH")"
+export PLAN_PATH
+DRY_RUN="${DRY_RUN:-false}"
+
+# ── artifact-contract dispatch ────────────────────────────────────────────────
+ARTIFACT_TYPE="plan_json"
+CONTENT_REF="$PLAN_PATH"
+
+REVIEW_RUBRIC=$(review_registry_lookup "$ARTIFACT_TYPE" rubric | tr -d '\r') || {
+  echo "::error::no rubric registered for artifact_type=$ARTIFACT_TYPE"
+  exit 1
+}
+REVIEW_OUTPUT_CHANNEL=$(review_registry_lookup "$ARTIFACT_TYPE" output_channel | tr -d '\r') || {
+  echo "::error::no output_channel registered for artifact_type=$ARTIFACT_TYPE"
+  exit 1
+}
+
+# The plan rubric is a single prompt file (the fixed critic checklist). Take the
+# first cascade entry; the registry stores it as a one-element comma list so the
+# field is uniform with pr_diff's multi-tier cascade.
+IFS=',' read -ra REVIEW_RUBRIC_CASCADE <<< "$REVIEW_RUBRIC"
+RUBRIC_PROMPT="${REVIEW_RUBRIC_CASCADE[0]}"
+
+echo "==> reviewing plan: $PLAN_PATH"
+echo "    artifact_type=$ARTIFACT_TYPE content_ref=$CONTENT_REF"
+echo "    rubric=$REVIEW_RUBRIC"
+echo "    output_channel=$REVIEW_OUTPUT_CHANNEL"
+
+# ── run the rubric via engine.sh deep tier ────────────────────────────────────
+# The prompt writes its findings JSON to $OUTPUT_FILE. run_agentic also tees the
+# agent's stdout; capture it as a fallback in case the model printed the JSON to
+# stdout instead of writing the file.
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+OUTPUT_FILE="$WORK_DIR/findings.json"
+export OUTPUT_FILE
+: > "$OUTPUT_FILE"
+
+run_agentic "$REPO_ROOT/$RUBRIC_PROMPT" "$ENGINE_DEEP_MODEL" "deep" > "$WORK_DIR/raw.out" 2>"$WORK_DIR/raw.err" || {
+  echo "::warning::plan rubric run exited non-zero; see logs" >&2
+}
+
+# Resolve the findings JSON: prefer the file the prompt wrote; fall back to
+# stdout if the model printed the JSON there instead.
+if ! jq empty "$OUTPUT_FILE" 2>/dev/null; then
+  if jq empty "$WORK_DIR/raw.out" 2>/dev/null; then
+    cp "$WORK_DIR/raw.out" "$OUTPUT_FILE"
+  else
+    echo "::error::plan rubric did not produce valid findings JSON" >&2
+    exit 1
+  fi
+fi
+
+# ── deliver via the resolved structured-findings channel ──────────────────────
+# Default the planner-consumption path to a stable temp file when the caller
+# didn't pin one, so the findings always land somewhere readable.
+export PLAN_FINDINGS_OUTPUT="${PLAN_FINDINGS_OUTPUT:-$WORK_DIR/plan-findings.json}"
+bash "$REPO_ROOT/$REVIEW_OUTPUT_CHANNEL" "$CONTENT_REF" "$OUTPUT_FILE" "$DRY_RUN"

--- a/scripts/lib/README.md
+++ b/scripts/lib/README.md
@@ -11,8 +11,11 @@ contract names the small, stable interface between "what is being reviewed" and
 
 The registry is an input-adapter layer **above** `engine.sh`. It does **not**
 change engine/model routing — it only decides which rubric and output channel
-apply to a given artifact. Phase 1 registers a single type, `pr_diff`, which
-resolves to today's PR-review behavior with no change.
+apply to a given artifact. Phase 1 registers `pr_diff`, which resolves to today's
+PR-review behavior with no change. Phase 2 (#614) adds `plan_json` additively: an
+initiative `plan.json` scored against a fixed adversarial/semantic plan rubric,
+with the verdict delivered as **machine-readable findings** the planner consumes
+before `apply-plan.sh` materializes the epic/DAG — not a GitHub PR review.
 
 ## The artifact contract
 
@@ -20,10 +23,10 @@ Every reviewable thing is described by four fields:
 
 | Field | Meaning | Allowed values |
 | --- | --- | --- |
-| `artifact_type` | What kind of thing is being reviewed. The registry key. | A type registered in the manifest. Phase 1: `pr_diff` only. |
-| `content_ref` | A pointer to the concrete content to review (not the content itself). | Opaque to the registry; interpreted by the output channel / caller. For `pr_diff` it is a PR URL (as passed to `review-one-pr.sh`). |
-| `rubric` | The standard the content is scored against — an ordered cascade of prompt files, applied in sequence. | Resolved from the manifest. For `pr_diff`: `prompts/triage.md` → `prompts/deep-review.md` → `prompts/synthesize.md`. |
-| `output_channel` | How the verdict is delivered. | Resolved from the manifest. For `pr_diff`: `scripts/post-pr-review.sh` (GitHub inline review comments + an approve/escalate review). |
+| `artifact_type` | What kind of thing is being reviewed. The registry key. | A type registered in the manifest: `pr_diff`, `plan_json`. |
+| `content_ref` | A pointer to the concrete content to review (not the content itself). | Opaque to the registry; interpreted by the output channel / caller. For `pr_diff` it is a PR URL (as passed to `review-one-pr.sh`); for `plan_json` it is a `plan.json` path (as passed to `initiative-planner/review-plan.sh`). |
+| `rubric` | The standard the content is scored against — an ordered cascade of prompt files, applied in sequence. | Resolved from the manifest. For `pr_diff`: `prompts/triage.md` → `prompts/deep-review.md` → `prompts/synthesize.md`. For `plan_json`: `prompts/plan-review.md` (the fixed plan critic). |
+| `output_channel` | How the verdict is delivered. | Resolved from the manifest. For `pr_diff`: `scripts/post-pr-review.sh` (GitHub inline review comments + an approve/escalate review). For `plan_json`: `scripts/post-plan-findings.sh` (machine-readable findings JSON for the planner — never a GitHub review). |
 
 `artifact_type` and `content_ref` are supplied by the caller (the input). The
 registry resolves `rubric` and `output_channel` from the `artifact_type`.
@@ -48,10 +51,12 @@ reviewer.
 ```bash
 source scripts/lib/review-registry.sh
 
-review_registry_version                         # -> 1
-review_registry_types                           # -> pr_diff
-review_registry_lookup pr_diff rubric           # -> prompts/triage.md,prompts/deep-review.md,prompts/synthesize.md
-review_registry_lookup pr_diff output_channel   # -> scripts/post-pr-review.sh
+review_registry_version                          # -> 2
+review_registry_types                            # -> pr_diff\nplan_json
+review_registry_lookup pr_diff rubric            # -> prompts/triage.md,prompts/deep-review.md,prompts/synthesize.md
+review_registry_lookup pr_diff output_channel    # -> scripts/post-pr-review.sh
+review_registry_lookup plan_json rubric          # -> prompts/plan-review.md
+review_registry_lookup plan_json output_channel  # -> scripts/post-plan-findings.sh
 ```
 
 `review_registry_lookup` returns `1` for an unknown `artifact_type` and `2` for

--- a/scripts/lib/review-registry.tsv
+++ b/scripts/lib/review-registry.tsv
@@ -6,14 +6,20 @@
 # artifact contract and field meanings. Data, not code — add a row to register
 # a new artifact_type; do not fork the reviewer (issue #611).
 #
-# schema_version: 1
+# schema_version: 2
 #
 # Columns (tab-separated): artifact_type	rubric	output_channel
 #   rubric         — ordered, comma-separated cascade of prompt files
 #                    (repo-root-relative), applied in sequence.
-#   output_channel — repo-root-relative script that posts the verdict.
+#   output_channel — repo-root-relative script that delivers the verdict.
 #
-# Phase 1 registers only pr_diff, resolving to today's PR-review behavior with
-# no change: the triage -> deep-review -> synthesize cascade, delivered as
-# GitHub inline review comments by post-pr-review.sh.
+# Phase 1 registers pr_diff, resolving to today's PR-review behavior with no
+# change: the triage -> deep-review -> synthesize cascade, delivered as GitHub
+# inline review comments by post-pr-review.sh.
 pr_diff	prompts/triage.md,prompts/deep-review.md,prompts/synthesize.md	scripts/post-pr-review.sh
+# Phase 2 (#614) registers plan_json additively: an initiative plan.json is
+# scored against the fixed adversarial/semantic plan rubric, and the verdict is
+# delivered as machine-readable findings the planner consumes before apply-plan.sh
+# materializes the epic/DAG — NOT a GitHub review (post-plan-findings.sh never
+# calls post-pr-review.sh).
+plan_json	prompts/plan-review.md	scripts/post-plan-findings.sh

--- a/scripts/post-plan-findings.sh
+++ b/scripts/post-plan-findings.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# post-plan-findings.sh — structured-findings output channel for the plan_json
+# artifact type (issue #614, epic #610 Phase 2).
+#
+# This is the plan_json half of the review artifact contract's output_channel:
+# the rubric registry (scripts/lib/review-registry.tsv) maps artifact_type
+# plan_json -> {rubric: prompts/plan-review.md, output_channel: THIS script}.
+#
+# Unlike the pr_diff channel (scripts/post-pr-review.sh, which posts a GitHub PR
+# review), a plan is consumed by the *planner*, not a human on a PR. So this
+# channel delivers the critic's verdict as MACHINE-READABLE findings JSON the
+# planner can read before apply-plan.sh materializes the epic/DAG. It NEVER
+# posts a GitHub review and NEVER calls post-pr-review.sh.
+#
+# Inputs:
+#   $1 — content_ref: the plan.json path that was reviewed (for the log line).
+#   $2 — findings JSON path: the rubric's output (see prompts/plan-review.md).
+#   $3 — DRY_RUN (true/false). Findings are local artifacts, so delivery is the
+#        same either way; the flag is accepted for output-channel contract
+#        symmetry with post-pr-review.sh and surfaced in the log.
+#
+# Env:
+#   PLAN_FINDINGS_OUTPUT — optional destination path. When set, the validated
+#        findings JSON is written there for the planner to consume. When unset,
+#        the findings are summarized to stdout only.
+#
+# Findings JSON shape (emitted by prompts/plan-review.md):
+#   {
+#     "artifact_type": "plan_json",
+#     "verdict": "pass|revise",
+#     "summary": "...",
+#     "findings": [ { "severity","category","message","story_id","location" } ]
+#   }
+#
+# Exit codes: 0 on a well-formed verdict (pass or revise); non-zero when the
+# findings file is missing, unparseable, or carries an unknown verdict.
+
+set -euo pipefail
+
+CONTENT_REF="${1:?usage: post-plan-findings.sh <plan-path> <findings-json> <dry-run>}"
+FINDINGS_JSON="${2:?usage: post-plan-findings.sh <plan-path> <findings-json> <dry-run>}"
+DRY_RUN="${3:-false}"
+
+if [ ! -s "$FINDINGS_JSON" ]; then
+  echo "ERROR: plan findings JSON not found or empty at $FINDINGS_JSON" >&2
+  exit 1
+fi
+
+if ! jq empty "$FINDINGS_JSON" 2>/dev/null; then
+  echo "ERROR: plan findings JSON at $FINDINGS_JSON is not valid JSON" >&2
+  exit 1
+fi
+
+VERDICT="$(jq -r '.verdict // ""' "$FINDINGS_JSON")"
+case "$VERDICT" in
+  pass|revise) ;;
+  *)
+    echo "ERROR: invalid plan verdict '$VERDICT' (expected: pass|revise)" >&2
+    exit 1
+    ;;
+esac
+
+FINDING_COUNT="$(jq '(.findings // []) | length' "$FINDINGS_JSON")"
+SUMMARY="$(jq -r '.summary // ""' "$FINDINGS_JSON")"
+
+# Deliver the machine-readable findings to the planner's consumption path. This
+# is a local artifact write (never an external mutation), so DRY_RUN does not
+# gate it — a planner reviewing in dry-run still needs the findings to decide.
+if [ -n "${PLAN_FINDINGS_OUTPUT:-}" ]; then
+  jq '.' "$FINDINGS_JSON" > "$PLAN_FINDINGS_OUTPUT"
+  echo "plan findings written to $PLAN_FINDINGS_OUTPUT"
+fi
+
+echo "=== plan review findings${DRY_RUN:+ (dry_run=$DRY_RUN)} ==="
+echo "content_ref: $CONTENT_REF"
+echo "verdict: $VERDICT"
+echo "findings: $FINDING_COUNT"
+[ -n "$SUMMARY" ] && echo "summary: $SUMMARY"
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "## Plan review — verdict: ${VERDICT}"
+    echo "- Reviewed: \`${CONTENT_REF}\`"
+    echo "- Findings: ${FINDING_COUNT}"
+    [ -n "$SUMMARY" ] && echo "- ${SUMMARY}"
+  } >>"$GITHUB_STEP_SUMMARY"
+fi
+
+exit 0

--- a/scripts/post-plan-findings.sh
+++ b/scripts/post-plan-findings.sh
@@ -67,8 +67,13 @@ SUMMARY="$(jq -r '.summary // ""' "$FINDINGS_JSON")"
 # is a local artifact write (never an external mutation), so DRY_RUN does not
 # gate it — a planner reviewing in dry-run still needs the findings to decide.
 if [ -n "${PLAN_FINDINGS_OUTPUT:-}" ]; then
-  jq '.' "$FINDINGS_JSON" > "$PLAN_FINDINGS_OUTPUT"
-  echo "plan findings written to $PLAN_FINDINGS_OUTPUT"
+  mkdir -p "$(dirname "$PLAN_FINDINGS_OUTPUT")"
+  if [ "$FINDINGS_JSON" -ef "$PLAN_FINDINGS_OUTPUT" ]; then
+    echo "plan findings already at $PLAN_FINDINGS_OUTPUT"
+  else
+    jq '.' "$FINDINGS_JSON" > "$PLAN_FINDINGS_OUTPUT"
+    echo "plan findings written to $PLAN_FINDINGS_OUTPUT"
+  fi
 fi
 
 echo "=== plan review findings${DRY_RUN:+ (dry_run=$DRY_RUN)} ==="

--- a/tests/test_plan_review.bats
+++ b/tests/test_plan_review.bats
@@ -152,6 +152,15 @@ write_findings() {
   [ "$status" -ne 0 ]
 }
 
+@test "driver PLAN_FINDINGS_OUTPUT default does not point inside WORK_DIR (survives EXIT trap)" {
+  # The EXIT trap removes WORK_DIR on script exit. If the default path for
+  # PLAN_FINDINGS_OUTPUT were inside WORK_DIR, the findings file would be deleted
+  # before callers can consume it. The driver must use mktemp (outside WORK_DIR)
+  # as the default, not a path like $WORK_DIR/plan-findings.json.
+  run bash -c "grep -qE 'PLAN_FINDINGS_OUTPUT[^#]*:?=.*WORK_DIR' '$DRIVER'"
+  [ "$status" -ne 0 ]
+}
+
 # ---------------------------------------------------------------------------
 # Structured-findings output channel — a sample plan produces findings (AC #3, #5)
 # ---------------------------------------------------------------------------

--- a/tests/test_plan_review.bats
+++ b/tests/test_plan_review.bats
@@ -207,3 +207,20 @@ write_findings() {
   run bash -c "grep -vE '^[[:space:]]*#' '$OUTPUT_CHANNEL' | grep -qE 'post-pr-review\\.sh|gh pr review|/pulls/.*/reviews'"
   [ "$status" -ne 0 ]
 }
+
+@test "output channel creates parent directories when PLAN_FINDINGS_OUTPUT has a missing parent" {
+  write_findings pass
+  DEST="$BATS_TEST_TMPDIR/nested/deep/out.json"
+  run env PLAN_FINDINGS_OUTPUT="$DEST" bash "$OUTPUT_CHANNEL" "/tmp/plan.json" "$FINDINGS_FILE" false
+  [ "$status" -eq 0 ]
+  [ -s "$DEST" ]
+}
+
+@test "output channel does not truncate when PLAN_FINDINGS_OUTPUT is the same file as FINDINGS_JSON" {
+  write_findings revise
+  run env PLAN_FINDINGS_OUTPUT="$FINDINGS_FILE" bash "$OUTPUT_CHANNEL" "/tmp/plan.json" "$FINDINGS_FILE" false
+  [ "$status" -eq 0 ]
+  # The file must still be valid JSON with the expected verdict
+  run jq -r '.verdict' "$FINDINGS_FILE"
+  [ "$output" = "revise" ]
+}

--- a/tests/test_plan_review.bats
+++ b/tests/test_plan_review.bats
@@ -1,0 +1,209 @@
+#!/usr/bin/env bats
+# Tests for the plan_json artifact type (issue #614, epic #610 Phase 2).
+#
+# Phase 2 registers a SECOND review artifact_type, plan_json, additively beside
+# pr_diff. It binds a fixed adversarial/semantic plan rubric (prompts/plan-review.md)
+# to a structured-findings output channel (scripts/post-plan-findings.sh) that
+# emits machine-readable findings for the initiative planner — NOT a GitHub PR
+# review. A content_ref adapter (scripts/initiative-planner/review-plan.sh) feeds
+# a plan.json into the rubric via engine.sh's existing model routing.
+#
+# These tests lock the wiring without running the LLM cascade (which needs a live
+# engine): registry resolution, driver dispatch wiring, and the deterministic
+# output-channel behavior over a sample plan's findings JSON.
+#
+# Run with: bats tests/test_plan_review.bats
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  source "$REPO_ROOT/scripts/lib/review-registry.sh"
+  RUBRIC_PROMPT="$REPO_ROOT/prompts/plan-review.md"
+  OUTPUT_CHANNEL="$REPO_ROOT/scripts/post-plan-findings.sh"
+  DRIVER="$REPO_ROOT/scripts/initiative-planner/review-plan.sh"
+  FINDINGS_FILE="$BATS_TEST_TMPDIR/findings.json"
+}
+
+# write_findings — materialize a structured-findings JSON in the documented
+# plan_json output shape (see scripts/post-plan-findings.sh header).
+write_findings() {
+  local verdict="${1:-revise}"
+  jq -n --arg v "$verdict" '{
+    artifact_type: "plan_json",
+    verdict: $v,
+    summary: "Sample critique of the plan.",
+    findings: [
+      { severity: "major", category: "ac_quality", message: "AC 1 is not testable.", story_id: 1, location: "stories[0].acceptance_criteria[0]" },
+      { severity: "minor", category: "grounding", message: "Dev note lacks a source citation.", story_id: 2, location: "stories[1].dev_notes" }
+    ]
+  }' > "$FINDINGS_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# Registry — plan_json is registered (AC #1)
+# ---------------------------------------------------------------------------
+
+@test "plan_json is registered" {
+  run review_registry_types
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qx "plan_json"
+}
+
+@test "plan_json rubric resolves to the plan-review rubric" {
+  run review_registry_lookup plan_json rubric
+  [ "$status" -eq 0 ]
+  [ "$output" = "prompts/plan-review.md" ]
+}
+
+@test "plan_json output_channel resolves to the structured-findings channel" {
+  run review_registry_lookup plan_json output_channel
+  [ "$status" -eq 0 ]
+  [ "$output" = "scripts/post-plan-findings.sh" ]
+}
+
+@test "plan_json output_channel is NOT post-pr-review.sh (structured findings, not a PR review)" {
+  run review_registry_lookup plan_json output_channel
+  [ "$status" -eq 0 ]
+  [ "$output" != "scripts/post-pr-review.sh" ]
+}
+
+@test "every plan_json referenced rubric/channel file exists on disk" {
+  run review_registry_lookup plan_json rubric
+  [ "$status" -eq 0 ]
+  IFS=',' read -ra rubric_files <<< "$output"
+  for f in "${rubric_files[@]}"; do
+    [ -f "$REPO_ROOT/$f" ] || { echo "missing rubric file: $f"; false; }
+  done
+  run review_registry_lookup plan_json output_channel
+  [ "$status" -eq 0 ]
+  [ -f "$REPO_ROOT/$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# Additive guard — pr_diff is untouched (AC #4)
+# ---------------------------------------------------------------------------
+
+@test "pr_diff is still registered alongside plan_json" {
+  run review_registry_types
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qx "pr_diff"
+}
+
+@test "pr_diff still resolves to its existing cascade and channel" {
+  run review_registry_lookup pr_diff rubric
+  [ "$status" -eq 0 ]
+  [ "$output" = "prompts/triage.md,prompts/deep-review.md,prompts/synthesize.md" ]
+  run review_registry_lookup pr_diff output_channel
+  [ "$status" -eq 0 ]
+  [ "$output" = "scripts/post-pr-review.sh" ]
+}
+
+# ---------------------------------------------------------------------------
+# Content_ref adapter / driver wiring (AC #2)
+# ---------------------------------------------------------------------------
+
+@test "driver dispatches on artifact_type=plan_json" {
+  run grep -qE 'plan_json' "$DRIVER"
+  [ "$status" -eq 0 ]
+}
+
+@test "driver sources the rubric registry helper" {
+  run grep -qE 'lib/review-registry\.sh' "$DRIVER"
+  [ "$status" -eq 0 ]
+}
+
+@test "driver reuses engine.sh model routing (sources engine.sh, calls run_agentic)" {
+  run grep -qE 'engine\.sh' "$DRIVER"
+  [ "$status" -eq 0 ]
+  run grep -qE 'run_agentic' "$DRIVER"
+  [ "$status" -eq 0 ]
+}
+
+@test "driver runs the rubric at the deep tier (no separate model selector)" {
+  run grep -qE 'run_agentic[^#]*(ENGINE_DEEP_MODEL|"deep")' "$DRIVER"
+  [ "$status" -eq 0 ]
+}
+
+@test "driver resolves rubric and output_channel via the registry helper" {
+  run grep -qE 'review_registry_lookup[^|]*rubric' "$DRIVER"
+  [ "$status" -eq 0 ]
+  run grep -qE 'review_registry_lookup[^|]*output_channel' "$DRIVER"
+  [ "$status" -eq 0 ]
+}
+
+@test "driver presents the plan.json path to the rubric as content_ref" {
+  # The adapter exports the plan path so the rubric prompt can read it.
+  run grep -qE 'PLAN_PATH' "$DRIVER"
+  [ "$status" -eq 0 ]
+}
+
+@test "driver delivers via the resolved output channel variable, not a hard-coded path" {
+  # The verdict is delivered through the registry-resolved channel variable, so
+  # no literal output-channel script path is invoked at the bash call site.
+  run grep -qE 'bash[[:space:]].*REVIEW_OUTPUT_CHANNEL' "$DRIVER"
+  [ "$status" -eq 0 ]
+  run grep -nE 'bash[[:space:]]+scripts/post-plan-findings\.sh' "$DRIVER"
+  [ "$status" -ne 0 ]
+}
+
+@test "driver never calls post-pr-review.sh (plan_json is not a PR review)" {
+  # Ignore comment lines (the header documents the prohibition); a real
+  # invocation would be on a non-comment line.
+  run bash -c "grep -vE '^[[:space:]]*#' '$DRIVER' | grep -qE 'post-pr-review\\.sh'"
+  [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Structured-findings output channel — a sample plan produces findings (AC #3, #5)
+# ---------------------------------------------------------------------------
+
+@test "output channel emits machine-readable findings to the destination path" {
+  write_findings revise
+  DEST="$BATS_TEST_TMPDIR/out.json"
+  run env PLAN_FINDINGS_OUTPUT="$DEST" bash "$OUTPUT_CHANNEL" "/tmp/plan.json" "$FINDINGS_FILE" true
+  [ "$status" -eq 0 ]
+  [ -s "$DEST" ]
+  run jq -e '.findings | length == 2' "$DEST"
+  [ "$status" -eq 0 ]
+  run jq -r '.verdict' "$DEST"
+  [ "$output" = "revise" ]
+}
+
+@test "output channel surfaces the verdict and finding count for the planner" {
+  write_findings revise
+  run bash "$OUTPUT_CHANNEL" "/tmp/plan.json" "$FINDINGS_FILE" true
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qE 'verdict: revise'
+  echo "$output" | grep -qE 'findings: 2'
+}
+
+@test "output channel accepts a clean pass verdict (zero findings)" {
+  jq -n '{artifact_type:"plan_json", verdict:"pass", summary:"No blocking issues.", findings:[]}' > "$FINDINGS_FILE"
+  run bash "$OUTPUT_CHANNEL" "/tmp/plan.json" "$FINDINGS_FILE" true
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qE 'verdict: pass'
+}
+
+@test "output channel rejects a missing findings file" {
+  run bash "$OUTPUT_CHANNEL" "/tmp/plan.json" "$BATS_TEST_TMPDIR/nope.json" true
+  [ "$status" -ne 0 ]
+}
+
+@test "output channel rejects malformed (non-JSON) findings" {
+  echo "not json {" > "$FINDINGS_FILE"
+  run bash "$OUTPUT_CHANNEL" "/tmp/plan.json" "$FINDINGS_FILE" true
+  [ "$status" -ne 0 ]
+}
+
+@test "output channel rejects an unknown verdict value" {
+  write_findings frobnicate
+  run bash "$OUTPUT_CHANNEL" "/tmp/plan.json" "$FINDINGS_FILE" true
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -qiE 'verdict'
+}
+
+@test "output channel does NOT call the GitHub PR review API or post-pr-review.sh" {
+  # Static guard: the structured-findings channel must never deliver a PR review.
+  # Ignore comment lines (the header documents the prohibition).
+  run bash -c "grep -vE '^[[:space:]]*#' '$OUTPUT_CHANNEL' | grep -qE 'post-pr-review\\.sh|gh pr review|/pulls/.*/reviews'"
+  [ "$status" -ne 0 ]
+}

--- a/tests/test_review_registry.bats
+++ b/tests/test_review_registry.bats
@@ -37,19 +37,15 @@ write_verdict() {
 }
 
 # ---------------------------------------------------------------------------
-# Registered types — pr_diff is the SOLE type (AC #2)
+# Registered types — pr_diff stays registered (AC #2). Phase 2 (#614) added
+# plan_json additively; this guard pins that pr_diff is never removed or
+# renamed, not that it is the sole type.
 # ---------------------------------------------------------------------------
 
 @test "pr_diff is registered" {
   run review_registry_types
   [ "$status" -eq 0 ]
   echo "$output" | grep -qx "pr_diff"
-}
-
-@test "pr_diff is the only registered type" {
-  run review_registry_types
-  [ "$status" -eq 0 ]
-  [ "$(echo "$output" | grep -c .)" -eq 1 ]
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #614

Implemented by dev-lead agent. Please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plan review capability to validate and analyze initiative plans using structured critique rules.
  * Plan findings are now output as machine-readable JSON and integrated with GitHub Actions summaries.

* **Tests**
  * Added comprehensive test suite for plan review workflow verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->