### PR TITLE
pilot(mcp): scan PR diffs for secrets via run_secret_scanning

### DIFF
--- a/.github/review-mcp.json
+++ b/.github/review-mcp.json
@@ -2,9 +2,11 @@
   "mcpServers": {
     "github": {
       "type": "http",
-      "url": "https://api.githubcopilot.com/mcp/x/secret_protection/readonly",
+      "url": "https://api.githubcopilot.com/mcp/",
       "headers": {
-        "Authorization": "Bearer ${GH_TOKEN}"
+        "Authorization": "Bearer ${GH_TOKEN}",
+        "X-MCP-Toolsets": "secret_protection",
+        "X-MCP-Tools": "run_secret_scanning"
       }
     }
   }

--- a/prompts/deep-review.md
+++ b/prompts/deep-review.md
@@ -37,14 +37,27 @@ enumeration. No actions on other PRs.
    these are the advisory bot findings the gate waited for. Weigh them in your review.
 3. `gh pr view "$PR_URL" --json number,title,body,author,isDraft,baseRefName,headRefName,headRefOid,url,headRepository,headRepositoryOwner,labels,reviewDecision,mergeable,mergeStateStatus,statusCheckRollup,reviewRequests,reviews,comments,commits,closingIssuesReferences,additions,deletions,changedFiles,files`
 4. `gh pr diff "$PR_URL"` — read the diff.
-5. Fetch linked issues if any.
-6. Check `statusCheckRollup` for CI status.
+5. **Secret scan (MCP, when available).** If the `run_secret_scanning` MCP tool
+   is available (it is exposed only when GitHub Secret Protection is enabled for
+   this repo), call `mcp__github__run_secret_scanning` with this PR's `owner` and
+   `repo` and `files` set to the **added/modified content** from the diff — one
+   array entry per changed file. This runs GitHub's validated secret detectors
+   (500+ providers, with on/off-by validity signals) and complements — does not
+   replace — the gitleaks CI check.
+   - Treat any returned finding as **HIGH / `critical`** and **blocking**: record
+     the secret type, file, and line in `findings`, set `risk: HIGH`, and escalate.
+   - If the tool is not available, or it errors (e.g. auth/entitlement), state
+     that in one line and continue the normal review. **Never** fail or block a
+     review because MCP was unavailable, and never fabricate a scan result.
+6. Fetch linked issues if any.
+7. Check `statusCheckRollup` for CI status.
 
 ## Risk classification
 
 Same taxonomy as shared.md:
 
 ### HIGH → escalate to security audit (Tier 3)
+- A verified secret reported by `run_secret_scanning` (MCP) — always blocking
 - Auth/secrets/credentials/crypto/tokens/`.env*`
 - DB migrations/schema changes
 - Security anti-patterns (injection, eval, shell=True, hardcoded secrets, etc.)

--- a/prompts/deep-review.md
+++ b/prompts/deep-review.md
@@ -40,12 +40,15 @@ enumeration. No actions on other PRs.
 5. **Secret scan (MCP, when available).** If the `run_secret_scanning` MCP tool
    is available (it is exposed only when GitHub Secret Protection is enabled for
    this repo), call `mcp__github__run_secret_scanning` with this PR's `owner` and
-   `repo` and `files` set to the **added/modified content** from the diff — one
-   array entry per changed file. This runs GitHub's validated secret detectors
-   (500+ providers, with on/off-by validity signals) and complements — does not
-   replace — the gitleaks CI check.
-   - Treat any returned finding as **HIGH / `critical`** and **blocking**: record
-     the secret type, file, and line in `findings`, set `risk: HIGH`, and escalate.
+   `repo` and `files` set to the **raw added/modified content** from the diff.
+   Per the tool's schema, `files` is a single string or an **array of strings**
+   (raw file contents or diff hunks — *not* file paths, and *not* objects); pass
+   one array entry per changed file. This runs GitHub's validated secret
+   detectors (500+ providers, with on/off validity signals) and complements —
+   does not replace — the gitleaks CI check.
+   - Treat any returned finding as **HIGH** and **blocking**: append it to
+     `findings` with `severity: "critical"` and `category: "secret"` (note the
+     secret type, file, and line in `message`), set `risk: HIGH`, and escalate.
    - If the tool is not available, or it errors (e.g. auth/entitlement), state
      that in one line and continue the normal review. **Never** fail or block a
      review because MCP was unavailable, and never fabricate a scan result.


### PR DESCRIPTION
## What

Now that **GitHub Secret Protection (GHAS) is enabled** on this repo, this PR lets the PR-review agent actually scan PR diffs for exposed secrets through the GitHub remote MCP server.

### Changes

1. **`.github/review-mcp.json`** — switched from the `secret_protection/readonly` path (which only exposes the *historical-alert* readers `list_secret_scanning_alerts` / `get_secret_scanning_alert`) to the base remote-server URL plus the documented headers that additionally expose the **diff scanner**:
   ```
   X-MCP-Toolsets: secret_protection
   X-MCP-Tools:    run_secret_scanning
   ```
   `run_secret_scanning` is attached to the `copilot` toolset upstream, so per GitHub's docs it must be added explicitly via `X-MCP-Tools` alongside the `secret_protection` toolset. The exposed surface stays read-only — list/get alerts + an ephemeral diff scan; **no write tools** are enabled.

2. **`prompts/deep-review.md`** — the tier-2 reviewer now calls `mcp__github__run_secret_scanning` on the PR's changed content (GitHub's validated detectors, 500+ providers), **complementing** — not replacing — the gitleaks CI check. Any finding is treated as a blocking **HIGH/`critical`** that escalates to the security auditor. Degradation is explicit: if the tool is absent or errors, the reviewer notes it in one line and continues — it never fails the review or fabricates a result.

## Why here

`run_secret_scanning` is only available via the **remote** MCP server, and only when Secret Protection is enabled. Wiring it into deep-review (tier 2) means it runs on every escalated PR — the workhorse path — and is observable in the run logs.

## Activation

Effective once merged **and** `pr-review/stable` is re-cut to include this commit.

Pilot for epic #676 (#681).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015VRMMWmqW9nW81jygmea3e)_