### PR TITLE
pilot(mcp): scan for secrets on the triage-approved path too

### DIFF
--- a/prompts/single-review.md
+++ b/prompts/single-review.md
@@ -47,8 +47,9 @@ You review **exactly one pull request**: `$PR_URL`. Nothing else.
      what's new.
 3. **Secret scan (MCP, when available).** If the `run_secret_scanning` MCP tool
    is available (exposed only when GitHub Secret Protection is enabled for this
-   repo), call `mcp__github__run_secret_scanning` with this PR's `owner` and
-   `repo` and `files` set to the **raw added/modified content** from the diff.
+   repo), call `mcp__github__run_secret_scanning` with this PR's `owner`
+   (`headRepository.owner.login`) and `repo` (`headRepository.name`) from the
+   step-1 PR metadata, and `files` set to the **raw added/modified content** from the diff.
    Per the tool's schema, `files` is a single string or an **array of strings**
    (raw file contents or diff hunks — *not* file paths, and *not* objects); pass
    one entry per changed file. This runs GitHub's validated detectors (500+

--- a/prompts/single-review.md
+++ b/prompts/single-review.md
@@ -45,8 +45,21 @@ You review **exactly one pull request**: `$PR_URL`. Nothing else.
      `gh api "repos/{owner}/{repo}/compare/$PRIOR_REVIEW_SHA...$PR_HEAD_SHA" --jq '.commits[].commit.message, .files[].filename'`
      to understand what changed since last review. Focus your analysis on
      what's new.
-3. Fetch linked issues (same as shared.md).
-4. Inspect `statusCheckRollup`.
+3. **Secret scan (MCP, when available).** If the `run_secret_scanning` MCP tool
+   is available (exposed only when GitHub Secret Protection is enabled for this
+   repo), call `mcp__github__run_secret_scanning` with this PR's `owner` and
+   `repo` and `files` set to the **raw added/modified content** from the diff.
+   Per the tool's schema, `files` is a single string or an **array of strings**
+   (raw file contents or diff hunks — *not* file paths, and *not* objects); pass
+   one entry per changed file. This runs GitHub's validated detectors (500+
+   providers) and complements — does not replace — the gitleaks CI check.
+   - Any returned finding is **HIGH** and **blocking**: record it in `FINDINGS`
+     (note the secret type, file, and line), set `RISK="HIGH"` and
+     `DECISION="escalate"` (HIGH can never auto-approve).
+   - If the tool is unavailable or errors, note it in one line and continue.
+     **Never** fail the review over MCP availability, and never fabricate a result.
+4. Fetch linked issues (same as shared.md).
+5. Inspect `statusCheckRollup`.
 
 ## Risk classification
 


### PR DESCRIPTION
## What

Extends the secret-scanning pilot (#681) to the **triage-approved path** so every agent-reviewed PR is scanned — not just escalated ones.

### Why

The tier-2 deep-review secret scan (merged in #783) only runs on PRs that triage **escalates**. Clean PRs are triage-approved and handled by `single-review.md`, which never scanned them. A secret in an otherwise-trivial PR could therefore be approved by the agent without an MCP scan. (gitleaks CI still scans every PR, but the *agent* didn't — this closes that gap.)

### Change

`prompts/single-review.md` — add a `run_secret_scanning` step mirroring `deep-review.md`:
- Scans the diff's **raw added/modified content** (`files` = string or array of strings, not paths/objects — per the tool schema).
- Any finding is **HIGH** and **blocking** → `RISK=HIGH`, `DECISION=escalate` (HIGH can never auto-approve).
- Same graceful degradation: if the tool is unavailable or errors, note it in one line and continue — never fail the review or fabricate a result.

### Activation

Effective once merged **and** `pr-review/stable` is re-cut to include the commit.

Pilot for epic #676 (#681).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015VRMMWmqW9nW81jygmea3e)_