### PR TITLE
pilot(mcp): thread REVIEW_MCP_ALLOWED_TOOLS into the review job env

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -171,6 +171,13 @@ jobs:
       MAX_REVIEW_CYCLES: ${{ vars.MAX_REVIEW_CYCLES || '3' }}
       MAX_PRS: ${{ vars.MAX_PRS || '10' }}
       CANDIDATE_LIMIT: ${{ vars.CANDIDATE_LIMIT || '250' }}
+      # Opt-in GitHub MCP review (issue #679 / pilot #681). REVIEW_MCP_CONFIG
+      # auto-defaults in engine.sh to the committed .github/review-mcp.json when
+      # present (do NOT set it here — an empty value would disable that default).
+      # The configured MCP tools must be allow-listed or the CLI connects the
+      # server yet blocks the tool calls ("not permitted"); set the repo variable
+      # REVIEW_MCP_ALLOWED_TOOLS (e.g. `mcp__github__*`) to permit them.
+      REVIEW_MCP_ALLOWED_TOOLS: ${{ vars.REVIEW_MCP_ALLOWED_TOOLS || '' }}
       # Pin via vars.CLAUDE_CODE_VERSION for fully reproducible caching; default
       # 'latest' caches an install indefinitely under that key — flush via the
       # Actions cache UI or bump the variable to pick up new releases.


### PR DESCRIPTION
## What

Closes the gap that prevented the secret-scanning pilot (#681) from actually executing `run_secret_scanning` in the workflow.

## Root cause

`run_agentic` already threads `--mcp-config` for every claude tier (`REVIEW_MCP_CONFIG` auto-defaults in `engine.sh` to the committed `.github/review-mcp.json`). But `engine.sh` only merges the configured MCP tools into `--allowed-tools` when `REVIEW_MCP_ALLOWED_TOOLS` is set — and the reusable `pr-review.yml` **never mapped that variable into the job env**. Result: the CLI connected the GitHub MCP server but blocked `run_secret_scanning` as *"not permitted"* on every tier. The scan has never actually run — confirmed via a dry-run of #774 on stable v1.6.4, whose single-review verdict said *"MCP secret-scan tool was not permitted in this run."*

## Change

`pr-review.yml` — add `REVIEW_MCP_ALLOWED_TOOLS: ${{ vars.REVIEW_MCP_ALLOWED_TOOLS || '' }}` to the job env, using the same `vars.X || default` pattern as the rest of the block.

`REVIEW_MCP_CONFIG` is intentionally **not** set here — it auto-defaults in `engine.sh` to the committed config, and an empty env value would *disable* that default.

## Activation

1. Merge.
2. Ensure repo variable **`REVIEW_MCP_ALLOWED_TOOLS = mcp__github__*`** is set.
3. Re-cut `pr-review/stable` (v1.6.5) to include this commit.

Then `run_secret_scanning` will actually execute on the deep (#783) and approve (#786) paths.

Pilot for epic #676 (#681).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015VRMMWmqW9nW81jygmea3e)_