### PR TITLE
feat(dev-lead): retry failed initial issue implementations, never silent (#781)

### DIFF
--- a/.github/workflows/dev-lead-reusable.yml
+++ b/.github/workflows/dev-lead-reusable.yml
@@ -46,6 +46,7 @@ permissions: {}
 #                                                                 avoids issue#/PR# collision)
 #   issues / issue_comment on issue  -> dev-lead-issue-<n>       (issue lane)
 #   repository_dispatch (ci-failure) -> dev-lead-pr-<n>          (client_payload.pr_number)
+#   repository_dispatch (issue-retry)-> dev-lead-issue-<n>       (client_payload.issue_number)
 #   anything else                    -> dev-lead-run-<run_id>    (unique; never cancelled)
 #
 # cancel-in-progress is false: a newer same-lane event queues behind the active
@@ -58,6 +59,7 @@ concurrency:
       || (github.event.issue.pull_request && format('dev-lead-pr-{0}', github.event.issue.number))
       || (github.event.issue.number && format('dev-lead-issue-{0}', github.event.issue.number))
       || (github.event.client_payload.pr_number && format('dev-lead-pr-{0}', github.event.client_payload.pr_number))
+      || (github.event.client_payload.issue_number && format('dev-lead-issue-{0}', github.event.client_payload.issue_number))
       || format('dev-lead-run-{0}', github.run_id)
     }}
   cancel-in-progress: false

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -32,7 +32,7 @@ on:
   check_run:
     types: [completed]
   repository_dispatch:
-    types: [dev-lead-ci-failure, dev-lead-reviews-retry]
+    types: [dev-lead-ci-failure, dev-lead-reviews-retry, dev-lead-issue-retry]
 
 permissions: {}
 

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -145,18 +145,26 @@ condition = "AND"
 commits = ["eb7fd4c955378d274794e38ee9b942912ce79c6f"]
 regexes = ['''ghp_classicPATplaceholder0000000000000000''']
 
-# The path-based entries below guard against future re-introduction of a ghp_*
-# stub that crosses the entropy threshold; ghp_stub itself is too short to fire.
+# The path-based entries below suppress both the historical 40-char placeholder
+# from commit eb7fd4c and the current shorter stub (ghp_stub, below entropy
+# threshold), guarding against future re-introduction of any ghp_* stub that
+# crosses the entropy threshold.
 [[allowlists]]
-description = "Suppress classic-PAT stub (ghp_stub) in test_engine_fallback.bats"
+description = "Suppress PAT stubs in test_engine_fallback.bats (historical + current)"
 targetRules = ["github-pat"]
 condition = "AND"
 paths = ['''^tests/dev-lead/unit/test_engine_fallback\.bats$''']
-regexes = ['''ghp_stub''']
+regexes = [
+  '''ghp_stub''',
+  '''ghp_classicPATplaceholder0000000000000000''',
+]
 
 [[allowlists]]
-description = "Suppress classic-PAT stub (ghp_stub) in test_fix_issue.bats"
+description = "Suppress PAT stubs in test_fix_issue.bats (historical + current)"
 targetRules = ["github-pat"]
 condition = "AND"
 paths = ['''^tests/dev-lead/unit/test_fix_issue\.bats$''']
-regexes = ['''ghp_stub''']
+regexes = [
+  '''ghp_stub''',
+  '''ghp_classicPATplaceholder0000000000000000''',
+]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -145,26 +145,23 @@ condition = "AND"
 commits = ["eb7fd4c955378d274794e38ee9b942912ce79c6f"]
 regexes = ['''ghp_classicPATplaceholder0000000000000000''']
 
-# The path-based entries below suppress both the historical 40-char placeholder
-# from commit eb7fd4c and the current shorter stub (ghp_stub, below entropy
-# threshold), guarding against future re-introduction of any ghp_* stub that
-# crosses the entropy threshold.
+# The path-based entries below suppress the ghp_stub placeholder used in current
+# and future commits of these test files.  Each allowlist uses a single regex so
+# that gitleaks' condition="AND" logic (which ANDs across condition types AND
+# within the regexes array) can satisfy the regex condition with one match.
+# The historical 40-char placeholder (ghp_classicPATplaceholder0000000000000000)
+# in commit eb7fd4c is covered by the commit-scoped allowlist above and does not
+# need to be repeated here.
 [[allowlists]]
-description = "Suppress PAT stubs in test_engine_fallback.bats (historical + current)"
+description = "Suppress ghp_stub placeholder in test_engine_fallback.bats"
 targetRules = ["github-pat"]
 condition = "AND"
 paths = ['''^tests/dev-lead/unit/test_engine_fallback\.bats$''']
-regexes = [
-  '''ghp_stub''',
-  '''ghp_classicPATplaceholder0000000000000000''',
-]
+regexes = ['''ghp_stub''']
 
 [[allowlists]]
-description = "Suppress PAT stubs in test_fix_issue.bats (historical + current)"
+description = "Suppress ghp_stub placeholder in test_fix_issue.bats"
 targetRules = ["github-pat"]
 condition = "AND"
 paths = ['''^tests/dev-lead/unit/test_fix_issue\.bats$''']
-regexes = [
-  '''ghp_stub''',
-  '''ghp_classicPATplaceholder0000000000000000''',
-]
+regexes = ['''ghp_stub''']

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -133,14 +133,13 @@ condition = "AND"
 paths = ['''^tests/test_gitleaks_config\.bats$''']
 regexes = ['''eyJhbGciOiJIUzI1NiIs''']
 
-# Engine fallback and fix-issue unit tests originally used a stub classic-PAT
-# token (ghp_classicPATplaceholder…) introduced in commit eb7fd4c to trigger
-# the engine.sh copilot-skip path. The token was later shortened to ghp_stub
-# in subsequent commits; this allowlist suppresses the historical diff in eb7fd4c.
-# condition="AND" binds the pattern to the exact commit so any real ghp_ token
-# committed elsewhere would still be reported.
+# Engine fallback and fix-issue unit tests use a stub classic-PAT token
+# (ghp_stub) introduced in commit eb7fd4c to trigger the engine.sh copilot-skip
+# path (ghp_* prefix → copilot fallback skipped). condition="AND" binds the
+# dummy value to the exact commit so any real ghp_ token committed elsewhere
+# would still be reported.
 [[allowlists]]
 description = "Suppress classic-PAT stub committed in Phase 1 test fixtures (eb7fd4c)"
 condition = "AND"
 commits = ["eb7fd4c955378d274794e38ee9b942912ce79c6f"]
-regexes = ['''ghp_classicPATplaceholder''']
+regexes = ['''ghp_stub''']

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -133,11 +133,20 @@ condition = "AND"
 paths = ['''^tests/test_gitleaks_config\.bats$''']
 regexes = ['''eyJhbGciOiJIUzI1NiIs''']
 
-# Engine fallback and fix-issue unit tests use a stub classic-PAT token
-# (ghp_stub) to trigger the engine.sh copilot-skip path (ghp_* prefix →
-# copilot fallback skipped). Each file gets its own allowlist entry (single
-# path per entry) to avoid gitleaks v8 condition="AND" multi-path ambiguity.
-# targetRules pins each entry to the github-pat rule that fires on ghp_* values.
+# Engine fallback and fix-issue unit tests originally used a 40-char classic-PAT-length
+# placeholder "ghp_classicPATplaceholder0000000000000000" in commit eb7fd4c to trigger
+# the copilot-skip path in engine.sh (ghp_* prefix → copilot fallback skipped). Commit
+# 7cbe053 replaced it with the shorter "ghp_stub" (below entropy threshold). This entry
+# suppresses the three historical github-pat findings in eb7fd4c.
+[[allowlists]]
+description = "Suppress classic-PAT-length placeholder in Phase 1 engine-failure tests (commit eb7fd4c)"
+targetRules = ["github-pat"]
+condition = "AND"
+commits = ["eb7fd4c955378d274794e38ee9b942912ce79c6f"]
+regexes = ['''ghp_classicPATplaceholder0000000000000000''']
+
+# The path-based entries below guard against future re-introduction of a ghp_*
+# stub that crosses the entropy threshold; ghp_stub itself is too short to fire.
 [[allowlists]]
 description = "Suppress classic-PAT stub (ghp_stub) in test_engine_fallback.bats"
 targetRules = ["github-pat"]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -134,12 +134,14 @@ paths = ['''^tests/test_gitleaks_config\.bats$''']
 regexes = ['''eyJhbGciOiJIUzI1NiIs''']
 
 # Engine fallback and fix-issue unit tests use a stub classic-PAT token
-# (ghp_stub) introduced in commit eb7fd4c to trigger the engine.sh copilot-skip
-# path (ghp_* prefix → copilot fallback skipped). condition="AND" binds the
-# dummy value to the exact commit so any real ghp_ token committed elsewhere
-# would still be reported.
+# (ghp_stub) to trigger the engine.sh copilot-skip path (ghp_* prefix →
+# copilot fallback skipped). condition="AND" binds the dummy value to those
+# specific test file paths so a real ghp_ token elsewhere would still be caught.
 [[allowlists]]
-description = "Suppress classic-PAT stub committed in Phase 1 test fixtures (eb7fd4c)"
+description = "Suppress classic-PAT stub (ghp_stub) in Phase 1/2 test fixtures"
 condition = "AND"
-commits = ["eb7fd4c955378d274794e38ee9b942912ce79c6f"]
+paths = [
+  '''^tests/dev-lead/unit/test_engine_fallback\.bats$''',
+  '''^tests/dev-lead/unit/test_fix_issue\.bats$''',
+]
 regexes = ['''ghp_stub''']

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -136,10 +136,11 @@ regexes = ['''eyJhbGciOiJIUzI1NiIs''']
 # Engine fallback and fix-issue unit tests originally used a 40-char classic-PAT-length
 # placeholder "ghp_classicPATplaceholder0000000000000000" in commit eb7fd4c to trigger
 # the copilot-skip path in engine.sh (ghp_* prefix → copilot fallback skipped). Commit
-# 7cbe053 replaced it with the shorter "ghp_stub" (below entropy threshold). This entry
-# is kept for documentation but the three historical github-pat findings in eb7fd4c are
-# suppressed via .gitleaksignore fingerprints because gitleaks v8.24.3 does not honour
-# condition="AND" when both commits and regexes are specified together.
+# 7cbe053 replaced it with the shorter "ghp_stub" (below entropy threshold).
+# gitleaks v8.24.3 does not honour condition="AND" when both `commits` and `regexes`
+# are specified together, so the commit-scoped entry below is inert. The path-based
+# entries that follow cover both the historical placeholder (eb7fd4c) and the current
+# stub; .gitleaksignore fingerprints are retained as a belt-and-suspenders fallback.
 [[allowlists]]
 description = "Suppress classic-PAT-length placeholder in Phase 1 engine-failure tests (commit eb7fd4c)"
 targetRules = ["github-pat"]
@@ -147,23 +148,35 @@ condition = "AND"
 commits = ["eb7fd4c955378d274794e38ee9b942912ce79c6f"]
 regexes = ['''ghp_classicPATplaceholder0000000000000000''']
 
-# The path-based entries below suppress the ghp_stub placeholder used in current
-# and future commits of these test files.  Each allowlist uses a single regex so
-# that gitleaks' condition="AND" logic (which ANDs across condition types AND
-# within the regexes array) can satisfy the regex condition with one match.
-# The historical 40-char placeholder (ghp_classicPATplaceholder0000000000000000)
-# in commit eb7fd4c is covered by .gitleaksignore fingerprints (see above comment)
-# and does not need to be repeated here.
+# Path-based entries suppress both the historical 40-char placeholder (commit eb7fd4c)
+# and the current shorter stub (ghp_stub, below entropy threshold) in these test files.
+# Each allowlist uses a single regex so that gitleaks' condition="AND" logic (which ANDs
+# across condition types AND within the regexes array) can satisfy the regex condition
+# with one match.
 [[allowlists]]
-description = "Suppress ghp_stub placeholder in test_engine_fallback.bats"
+description = "Suppress ghp_stub placeholder in test_engine_fallback.bats (current commits)"
 targetRules = ["github-pat"]
 condition = "AND"
 paths = ['''^tests/dev-lead/unit/test_engine_fallback\.bats$''']
 regexes = ['''ghp_stub''']
 
 [[allowlists]]
-description = "Suppress ghp_stub placeholder in test_fix_issue.bats"
+description = "Suppress historical classic-PAT placeholder in test_engine_fallback.bats (commit eb7fd4c)"
+targetRules = ["github-pat"]
+condition = "AND"
+paths = ['''^tests/dev-lead/unit/test_engine_fallback\.bats$''']
+regexes = ['''ghp_classicPATplaceholder0000000000000000''']
+
+[[allowlists]]
+description = "Suppress ghp_stub placeholder in test_fix_issue.bats (current commits)"
 targetRules = ["github-pat"]
 condition = "AND"
 paths = ['''^tests/dev-lead/unit/test_fix_issue\.bats$''']
 regexes = ['''ghp_stub''']
+
+[[allowlists]]
+description = "Suppress historical classic-PAT placeholder in test_fix_issue.bats (commit eb7fd4c)"
+targetRules = ["github-pat"]
+condition = "AND"
+paths = ['''^tests/dev-lead/unit/test_fix_issue\.bats$''']
+regexes = ['''ghp_classicPATplaceholder0000000000000000''']

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -132,3 +132,16 @@ description = "Suppress the example expired-JWT fixture in the gitleaks-config s
 condition = "AND"
 paths = ['''^tests/test_gitleaks_config\.bats$''']
 regexes = ['''eyJhbGciOiJIUzI1NiIs''']
+
+# Engine fallback and fix-issue unit tests use a stub classic-PAT token
+# (ghp_ prefix) to trigger the engine.sh copilot-skip path without a real
+# credential. condition="AND" binds the dummy value to these two files so
+# a real ghp_ token committed anywhere else would still be reported.
+[[allowlists]]
+description = "Suppress classic-PAT stub in engine-fallback and fix-issue unit tests"
+condition = "AND"
+paths = [
+  '''^tests/dev-lead/unit/test_engine_fallback\.bats$''',
+  '''^tests/dev-lead/unit/test_fix_issue\.bats$''',
+]
+regexes = ['''ghp_classicPATplaceholder''']

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -137,7 +137,9 @@ regexes = ['''eyJhbGciOiJIUzI1NiIs''']
 # placeholder "ghp_classicPATplaceholder0000000000000000" in commit eb7fd4c to trigger
 # the copilot-skip path in engine.sh (ghp_* prefix → copilot fallback skipped). Commit
 # 7cbe053 replaced it with the shorter "ghp_stub" (below entropy threshold). This entry
-# suppresses the three historical github-pat findings in eb7fd4c.
+# is kept for documentation but the three historical github-pat findings in eb7fd4c are
+# suppressed via .gitleaksignore fingerprints because gitleaks v8.24.3 does not honour
+# condition="AND" when both commits and regexes are specified together.
 [[allowlists]]
 description = "Suppress classic-PAT-length placeholder in Phase 1 engine-failure tests (commit eb7fd4c)"
 targetRules = ["github-pat"]
@@ -150,8 +152,8 @@ regexes = ['''ghp_classicPATplaceholder0000000000000000''']
 # that gitleaks' condition="AND" logic (which ANDs across condition types AND
 # within the regexes array) can satisfy the regex condition with one match.
 # The historical 40-char placeholder (ghp_classicPATplaceholder0000000000000000)
-# in commit eb7fd4c is covered by the commit-scoped allowlist above and does not
-# need to be repeated here.
+# in commit eb7fd4c is covered by .gitleaksignore fingerprints (see above comment)
+# and does not need to be repeated here.
 [[allowlists]]
 description = "Suppress ghp_stub placeholder in test_engine_fallback.bats"
 targetRules = ["github-pat"]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -133,15 +133,14 @@ condition = "AND"
 paths = ['''^tests/test_gitleaks_config\.bats$''']
 regexes = ['''eyJhbGciOiJIUzI1NiIs''']
 
-# Engine fallback and fix-issue unit tests use a stub classic-PAT token
-# (ghp_ prefix) to trigger the engine.sh copilot-skip path without a real
-# credential. condition="AND" binds the dummy value to these two files so
-# a real ghp_ token committed anywhere else would still be reported.
+# Engine fallback and fix-issue unit tests originally used a stub classic-PAT
+# token (ghp_classicPATplaceholder…) introduced in commit eb7fd4c to trigger
+# the engine.sh copilot-skip path. The token was later shortened to ghp_stub
+# in subsequent commits; this allowlist suppresses the historical diff in eb7fd4c.
+# condition="AND" binds the pattern to the exact commit so any real ghp_ token
+# committed elsewhere would still be reported.
 [[allowlists]]
-description = "Suppress classic-PAT stub in engine-fallback and fix-issue unit tests"
+description = "Suppress classic-PAT stub committed in Phase 1 test fixtures (eb7fd4c)"
 condition = "AND"
-paths = [
-  '''^tests/dev-lead/unit/test_engine_fallback\.bats$''',
-  '''^tests/dev-lead/unit/test_fix_issue\.bats$''',
-]
+commits = ["eb7fd4c955378d274794e38ee9b942912ce79c6f"]
 regexes = ['''ghp_classicPATplaceholder''']

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -135,13 +135,19 @@ regexes = ['''eyJhbGciOiJIUzI1NiIs''']
 
 # Engine fallback and fix-issue unit tests use a stub classic-PAT token
 # (ghp_stub) to trigger the engine.sh copilot-skip path (ghp_* prefix →
-# copilot fallback skipped). condition="AND" binds the dummy value to those
-# specific test file paths so a real ghp_ token elsewhere would still be caught.
+# copilot fallback skipped). Each file gets its own allowlist entry (single
+# path per entry) to avoid gitleaks v8 condition="AND" multi-path ambiguity.
+# targetRules pins each entry to the github-pat rule that fires on ghp_* values.
 [[allowlists]]
-description = "Suppress classic-PAT stub (ghp_stub) in Phase 1/2 test fixtures"
+description = "Suppress classic-PAT stub (ghp_stub) in test_engine_fallback.bats"
+targetRules = ["github-pat"]
 condition = "AND"
-paths = [
-  '''^tests/dev-lead/unit/test_engine_fallback\.bats$''',
-  '''^tests/dev-lead/unit/test_fix_issue\.bats$''',
-]
+paths = ['''^tests/dev-lead/unit/test_engine_fallback\.bats$''']
+regexes = ['''ghp_stub''']
+
+[[allowlists]]
+description = "Suppress classic-PAT stub (ghp_stub) in test_fix_issue.bats"
+targetRules = ["github-pat"]
+condition = "AND"
+paths = ['''^tests/dev-lead/unit/test_fix_issue\.bats$''']
 regexes = ['''ghp_stub''']

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -11,3 +11,7 @@
 eb7fd4c955378d274794e38ee9b942912ce79c6f:tests/dev-lead/unit/test_fix_issue.bats:github-pat:485
 eb7fd4c955378d274794e38ee9b942912ce79c6f:tests/dev-lead/unit/test_engine_fallback.bats:github-pat:276
 eb7fd4c955378d274794e38ee9b942912ce79c6f:tests/dev-lead/unit/test_engine_fallback.bats:github-pat:323
+# commit 334fac2 (initial .gitleaksignore): the comment at line 5 quoted the
+# 40-char classic-PAT-length test placeholder verbatim; commit a547c50 rewrote
+# it to avoid the literal. Fingerprint suppresses the historical commit's finding.
+334fac2ca4528d821b7511e1a0f8e5051a2aca65:.gitleaksignore:github-pat:5

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -2,7 +2,7 @@
 # Each line: {commit}:{file}:{rule}:{line}
 #
 # commit eb7fd4c (Phase 1 engine-failure): introduced COPILOT_GITHUB_TOKEN set to
-# "ghp_classicPATplaceholder0000000000000000" (a 40-char test placeholder used to
+# a 40-char test placeholder matching the ghp_* classic-PAT pattern (used to
 # trigger the copilot-skip path in engine.sh). These three findings are test fixtures,
 # not real credentials. The commit-scoped [[allowlists]] entry in .gitleaks.toml
 # targets the same commit+regex but is not suppressed by gitleaks v8.24.3 when

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,13 @@
+# Fingerprints of known false-positive gitleaks findings.
+# Each line: {commit}:{file}:{rule}:{line}
+#
+# commit eb7fd4c (Phase 1 engine-failure): introduced COPILOT_GITHUB_TOKEN set to
+# "ghp_classicPATplaceholder0000000000000000" (a 40-char test placeholder used to
+# trigger the copilot-skip path in engine.sh). These three findings are test fixtures,
+# not real credentials. The commit-scoped [[allowlists]] entry in .gitleaks.toml
+# targets the same commit+regex but is not suppressed by gitleaks v8.24.3 when
+# condition="AND" is combined with both commits and regexes; fingerprint ignores
+# are used here as the reliable fallback.
+eb7fd4c955378d274794e38ee9b942912ce79c6f:tests/dev-lead/unit/test_fix_issue.bats:github-pat:485
+eb7fd4c955378d274794e38ee9b942912ce79c6f:tests/dev-lead/unit/test_engine_fallback.bats:github-pat:276
+eb7fd4c955378d274794e38ee9b942912ce79c6f:tests/dev-lead/unit/test_engine_fallback.bats:github-pat:323

--- a/docs/dev-lead/spec.md
+++ b/docs/dev-lead/spec.md
@@ -109,6 +109,8 @@ Every GitHub webhook event that reaches `dev-lead.yml` is classified into exactl
 | `issues` labeled `dev-lead` | Any | `issue` | `dev-lead-fix-issue.sh` |
 | `check_run` completed, failure | Not a `dev-lead /` check | _relay only_ | `ci-relay` job |
 | `repository_dispatch` `dev-lead-ci-failure` | Dispatched by `ci-relay` | `fix-ci` | `dev-lead-fix-ci.sh` |
+| `repository_dispatch` `dev-lead-reviews-retry` | Dispatched by `dev-lead-retry` cron | _(payload `intent_type`)_ | `dev-lead-fix-reviews.sh` |
+| `repository_dispatch` `dev-lead-issue-retry` | Dispatched by `dev-lead-retry` cron (#781) | `issue` | `dev-lead-fix-issue.sh` |
 | All others | — | `skip` | (no-op) |
 
 ### 4.2 Intent definitions
@@ -436,6 +438,22 @@ Reads the specific comment body as the user's instruction. Executes it as an age
 6. **Wait for CI** — fix any failures (calls `dev-lead-fix-ci.sh` logic inline)
 7. **Tag CODEOWNERS** — post comment tagging relevant owners when CI is green
 
+**Engine-failure handling (`handle_engine_failure`, #781).** When `run_writer_with_fallback`
+fails (before a PR exists), the handler never exits silently. It classifies the cause from the
+`/tmp/dev-lead-failure-reason` sidecar written by `engine.sh` (`rate-limited` | `missing-binary`
+| `engine-error`), computes the attempt number from prior `<!-- dev-lead-issue <N> ... -->`
+markers, and posts a comment with the cause, a run deep-link, and a redacted ~40-line tail of the
+session output. Decision matrix (`MAX_ATTEMPTS=3`):
+
+| Cause | `attempt < MAX` | `attempt ≥ MAX` |
+|---|---|---|
+| `missing-binary` | `dev-lead:needs-human` label + comment (deterministic infra — no retry) | _(same)_ |
+| `rate-limited` / `engine-error` | retryable marker `<!-- dev-lead-issue <N> status=<failed\|rate-limited> attempt=<K> reason=<r> run=<id> [reset=ISO] -->` + comment | `dev-lead:needs-human` label + "retries exhausted" comment |
+
+Exit codes are unchanged (`2` rate-limit, `1` otherwise). The retryable marker is what the
+`dev-lead-retry` cron scans for to re-dispatch a `dev-lead-issue-retry`; an issue carrying the
+`dev-lead:needs-human` label is skipped by the cron.
+
 **Standards injection (always prepended to prompt):**
 
 The prompt includes instructions to:
@@ -599,6 +617,24 @@ claude → gemini → copilot → abort (post "rate limited" comment on PR)
 ```
 
 This mirrors the `review-batch.sh` `session_engine_fallback()` pattern.
+
+When **all** engines are exhausted, `run_writer_with_fallback` records the cause class to
+`/tmp/dev-lead-failure-reason` (`rate-limited` | `missing-binary` | `engine-error`), and
+`run_writer` persists the redacted session output to the run step summary on every exit path
+(including the rate-limit early return). Downstream handlers read the sidecar to classify the
+failure rather than collapsing everything into a generic exit code.
+
+### 10.1a Failed initial issue implementations (#781)
+
+A first issue implementation that fails at the engine step has no PR to attach a retry marker to,
+so before #781 it stalled silently. Now `dev-lead-fix-issue.sh` posts a cause-bearing
+`<!-- dev-lead-issue <N> status=<failed|rate-limited> attempt=<K> ... -->` marker (see §7.5), and
+the `dev-lead-retry` cron's `scan_repo_issues` enumerates open `dev-lead`-labelled issues, finds
+the newest such marker, and re-dispatches a `dev-lead-issue-retry` (honouring the rate-limit
+`reset=` window and the `attempt < MAX_ATTEMPTS` ceiling, skipping issues that already have an open
+PR or the `dev-lead:needs-human` label). After `MAX_ATTEMPTS` (3) the issue is labelled
+`dev-lead:needs-human` and left for a human — the same terminal escalation used for deterministic
+`missing-binary` infra failures.
 
 ### 10.2 CI still failing after MAX_CI_CYCLES
 

--- a/docs/dev-lead/spec.md
+++ b/docs/dev-lead/spec.md
@@ -629,10 +629,10 @@ failure rather than collapsing everything into a generic exit code.
 A first issue implementation that fails at the engine step has no PR to attach a retry marker to,
 so before #781 it stalled silently. Now `dev-lead-fix-issue.sh` posts a cause-bearing
 `<!-- dev-lead-issue <N> status=<failed|rate-limited> attempt=<K> ... -->` marker (see §7.5), and
-the `dev-lead-retry` cron's `scan_repo_issues` enumerates open `dev-lead`-labelled issues, finds
+the `dev-lead-retry` cron's `scan_repo_issues` enumerates open `dev-lead`-labeled issues, finds
 the newest such marker, and re-dispatches a `dev-lead-issue-retry` (honouring the rate-limit
 `reset=` window and the `attempt < MAX_ATTEMPTS` ceiling, skipping issues that already have an open
-PR or the `dev-lead:needs-human` label). After `MAX_ATTEMPTS` (3) the issue is labelled
+PR or the `dev-lead:needs-human` label). After `MAX_ATTEMPTS` (3) the issue is labeled
 `dev-lead:needs-human` and left for a human — the same terminal escalation used for deterministic
 `missing-binary` infra failures.
 

--- a/scripts/dev-lead-fix-issue.sh
+++ b/scripts/dev-lead-fix-issue.sh
@@ -11,11 +11,161 @@ REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
 DEV_LEAD_DRY_RUN="${DEV_LEAD_DRY_RUN:-false}"
 export PROMPTS_DIR="${PROMPTS_DIR:-prompts/dev-lead}"
 
+# Machine-readable marker the retry cron (dev-lead-retry.sh) scans for to requeue
+# a failed initial issue implementation. Mirrors the PR-side conventions in
+# dev-lead-fix-ci.sh / dev-lead-fix-reviews.sh:
+#   <!-- dev-lead-issue <N> status=<failed|rate-limited> attempt=<K> reason=<r> run=<id> [reset=ISO] -->
+ISSUE_MARKER_PREFIX="<!-- dev-lead-issue "
+# Total attempts (initial + retries) before escalating to a human. Matches the
+# MAX_ATTEMPTS=3 convention used by auto-rebase-retry.sh.
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-3}"
+# Label applied when an issue can no longer be auto-retried; the retry cron
+# skips issues carrying it.
+NEEDS_HUMAN_LABEL="${NEEDS_HUMAN_LABEL:-dev-lead:needs-human}"
+
 check_existing_pr() {
   local existing
   existing=$(gh api "repos/${REPO}/pulls?state=open" \
     --jq "[.[] | select(.head.ref | startswith(\"dev-lead/issue-${ISSUE_NUMBER}\"))] | length" 2>/dev/null || echo "0")
   [ "$existing" -gt 0 ]
+}
+
+# count_prior_attempts: highest attempt= recorded in any prior dev-lead-issue
+# marker on this issue (0 if none). The next attempt is this value + 1.
+# --paginate keeps the count accurate on issues with >30 comments.
+count_prior_attempts() {
+  local prefix="${ISSUE_MARKER_PREFIX}${ISSUE_NUMBER} "
+  gh api --paginate "repos/${REPO}/issues/${ISSUE_NUMBER}/comments?per_page=100" 2>/dev/null \
+    | jq -r --arg p "$prefix" '
+        [ .[] | .body // ""
+          | select(contains($p))
+          | capture("attempt=(?<a>[0-9]+)").a
+          | tonumber
+        ] | max // 0' 2>/dev/null \
+    || echo 0
+}
+
+# html_escape: escape &, <, > so a redacted snippet cannot break the wrapping
+# <pre>/<details> block in the issue comment (mirrors engine.sh:run_writer).
+html_escape() {
+  sed 's|&|\&amp;|g; s|<|\&lt;|g; s|>|\&gt;|g'
+}
+
+# session_snippet: redacted ~40-line tail of the engine session output, wrapped
+# in a collapsible <details> block. The source file is already secret-scrubbed
+# by engine.sh:run_writer, so no further redaction is needed here.
+session_snippet() {
+  [ -s /tmp/dev-lead-session-output.txt ] || return 0
+  printf '<details><summary>Last 40 lines of engine output (redacted)</summary>\n\n<pre>\n'
+  tail -n 40 /tmp/dev-lead-session-output.txt | html_escape
+  printf '\n</pre>\n</details>'
+}
+
+# ensure_needs_human_label: idempotently create then apply the escalation label.
+# gh issue edit --add-label fails if the label does not exist, so create first.
+ensure_needs_human_label() {
+  gh label create "$NEEDS_HUMAN_LABEL" --repo "$REPO" \
+    --color B60205 --description "dev-lead could not complete this issue; needs human attention" \
+    2>/dev/null || true
+  gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "$NEEDS_HUMAN_LABEL" 2>/dev/null || true
+}
+
+# handle_engine_failure <engine_rc>
+# Replaces the previous silent `exit 1` (and unifies the rate-limit branch).
+# Classifies the cause via the /tmp/dev-lead-failure-reason sidecar written by
+# engine.sh, surfaces it on the issue (marker + human-readable comment + run
+# link + redacted snippet), and decides retry vs. human escalation. Never
+# returns — exits 2 for rate-limit, 1 otherwise (exit semantics unchanged).
+handle_engine_failure() {
+  local engine_rc="$1"
+  rm -f "$prompt_file"
+
+  # Cause class from the engine layer; default to engine-error if the sidecar is
+  # absent (e.g. an older engine.sh). exit 2 always means rate-limited.
+  local reason="engine-error"
+  if [ -s /tmp/dev-lead-failure-reason ]; then
+    reason=$(tr -d '[:space:]' < /tmp/dev-lead-failure-reason)
+  fi
+  [ -n "$reason" ] || reason="engine-error"
+  [ "$engine_rc" -eq 2 ] && reason="rate-limited"
+
+  local reset=""
+  [ -f /tmp/dev-lead-rate-limit-reset ] && reset=$(cat /tmp/dev-lead-rate-limit-reset)
+
+  local attempt
+  attempt=$(( $(count_prior_attempts) + 1 ))
+  local run_url="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-$REPO}/actions/runs/${GITHUB_RUN_ID:-}"
+  local snippet
+  snippet=$(session_snippet)
+
+  # Deterministic infra failure (missing engine binary): retrying cannot help —
+  # escalate to a human immediately, no retry marker.
+  if [ "$reason" = "missing-binary" ]; then
+    echo "::error::Engine binary missing while implementing issue #${ISSUE_NUMBER} — escalating to human"
+    ensure_needs_human_label
+    gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "<!-- dev-lead-issue ${ISSUE_NUMBER} status=needs-human attempt=${attempt} reason=${reason} run=${GITHUB_RUN_ID:-} -->
+## Dev-Lead: cannot implement issue #${ISSUE_NUMBER} — needs human attention
+
+A required engine binary was missing in the runner environment while implementing this issue. This is an **infrastructure/configuration** problem, not a transient error, so automatic retry is disabled.
+
+- **Cause:** \`${reason}\`
+- **Run:** ${run_url}
+
+${snippet}
+
+Please check the runner/engine configuration, then re-apply the \`dev-lead\` label to retry." 2>/dev/null || true
+    exit 1
+  fi
+
+  # Retries exhausted: escalate to a human, no further retry marker.
+  if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+    echo "::error::Engine failed to implement issue #${ISSUE_NUMBER} (reason=${reason}); retries exhausted (attempt ${attempt}/${MAX_ATTEMPTS}) — escalating to human"
+    ensure_needs_human_label
+    gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "<!-- dev-lead-issue ${ISSUE_NUMBER} status=needs-human attempt=${attempt} reason=${reason} run=${GITHUB_RUN_ID:-} -->
+## Dev-Lead: cannot implement issue #${ISSUE_NUMBER} — needs human attention
+
+Automatic retries are exhausted (**attempt ${attempt} of ${MAX_ATTEMPTS}**). The most recent failure was \`${reason}\`.
+
+- **Run:** ${run_url}
+
+${snippet}
+
+Please review the failures above. To retry anyway, remove the \`${NEEDS_HUMAN_LABEL}\` label and re-apply the \`dev-lead\` label." 2>/dev/null || true
+    [ "$engine_rc" -eq 2 ] && exit 2
+    exit 1
+  fi
+
+  # Retryable (rate-limited or engine-error, attempt < MAX): post the marker the
+  # retry cron scans for, plus a human-readable comment with the cause.
+  local status="failed"
+  [ "$reason" = "rate-limited" ] && status="rate-limited"
+  local reset_attr=""
+  [ -n "$reset" ] && reset_attr=" reset=${reset}"
+  local marker="${ISSUE_MARKER_PREFIX}${ISSUE_NUMBER} status=${status} attempt=${attempt} reason=${reason} run=${GITHUB_RUN_ID:-}${reset_attr} -->"
+
+  local cause_line reset_line=""
+  if [ "$reason" = "rate-limited" ]; then
+    echo "::warning::All engines rate-limited while implementing issue #${ISSUE_NUMBER} (attempt ${attempt}/${MAX_ATTEMPTS}) — will retry automatically"
+    cause_line="All engines were **rate-limited**."
+    [ -n "$reset" ] && reset_line="
+- **Limit resets:** ${reset}"
+  else
+    echo "::error::Engine failed to implement issue #${ISSUE_NUMBER} (reason=${reason}, attempt ${attempt}/${MAX_ATTEMPTS}) — will retry automatically"
+    cause_line="The engine failed (\`${reason}\` — e.g. a timeout or transient engine error)."
+  fi
+
+  gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "${marker}
+## Dev-Lead: issue #${ISSUE_NUMBER} implementation failed — will retry
+
+${cause_line} This was **attempt ${attempt} of ${MAX_ATTEMPTS}**; dev-lead will retry automatically. You can also re-apply the \`dev-lead\` label to retry now.
+
+- **Cause:** \`${reason}\`
+- **Run:** ${run_url}${reset_line}
+
+${snippet}" 2>/dev/null || true
+
+  [ "$engine_rc" -eq 2 ] && exit 2
+  exit 1
 }
 
 main() {
@@ -74,21 +224,11 @@ main() {
 
   local engine_rc=0
   run_writer_with_fallback "$prompt_file" "fix-issue" || engine_rc=$?
-  if [ "$engine_rc" -eq 2 ]; then
-    echo "::warning::All engines rate-limited — cannot implement issue #${ISSUE_NUMBER}; re-apply the label to retry"
-    local reset_msg=""
-    if [ -f /tmp/dev-lead-rate-limit-reset ]; then
-      local reset_time
-      reset_time=$(cat /tmp/dev-lead-rate-limit-reset)
-      [ -n "$reset_time" ] && reset_msg=" The limit is expected to reset at ${reset_time}."
-    fi
-    gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "<!-- dev-lead-rate-limited -->All engines are currently rate-limited.${reset_msg} Please re-apply the \`dev-lead\` label when the rate limit clears to retry." 2>/dev/null || true
-    rm -f "$prompt_file"
-    exit 2
-  elif [ "$engine_rc" -ne 0 ]; then
-    echo "::error::Engine failed to implement issue #${ISSUE_NUMBER}"
-    rm -f "$prompt_file"
-    exit 1
+  if [ "$engine_rc" -ne 0 ]; then
+    # Unified failure handler: classifies the cause, surfaces it on the issue
+    # (marker + comment + run link + redacted snippet), and decides retry vs.
+    # human escalation. Never returns — exits 2 (rate-limit) or 1 (otherwise).
+    handle_engine_failure "$engine_rc"
   fi
 
   # git status --porcelain catches untracked files that git diff misses.

--- a/scripts/dev-lead-fix-issue.sh
+++ b/scripts/dev-lead-fix-issue.sh
@@ -36,8 +36,8 @@ check_existing_pr() {
 count_prior_attempts() {
   local prefix="${ISSUE_MARKER_PREFIX}${ISSUE_NUMBER} "
   gh api --paginate "repos/${REPO}/issues/${ISSUE_NUMBER}/comments?per_page=100" 2>/dev/null \
-    | jq -r --arg p "$prefix" '
-        [ .[] | .body // ""
+    | jq -s -r --arg p "$prefix" '
+        [ .[] | .[]? | .body // ""
           | select(contains($p))
           | capture("attempt=(?<a>[0-9]+)").a
           | tonumber

--- a/scripts/dev-lead-intent.sh
+++ b/scripts/dev-lead-intent.sh
@@ -377,9 +377,16 @@ case "$EVENT_NAME" in
     fi
     dispatch_type=$(jq -r '.action // empty' "$EVENT_PATH" 2>/dev/null || true)
     pr_number=$(jq -r '.client_payload.pr_number // empty' "$EVENT_PATH" 2>/dev/null || true)
+    issue_number=$(jq -r '.client_payload.issue_number // empty' "$EVENT_PATH" 2>/dev/null || true)
     head_sha=$(jq -r '.client_payload.head_sha // empty' "$EVENT_PATH" 2>/dev/null || true)
-    if [ -z "$pr_number" ]; then
-      emit_skip "no-pr-number-in-payload"
+
+    # The subject whose labels gate hands-off. PR-based dispatch types carry
+    # pr_number; the issue-retry type (#781) carries issue_number instead. Both
+    # resolve under repos/<repo>/issues/<n>/labels (PRs are issues for labels),
+    # so an issue-only payload is no longer dropped before routing.
+    subject_number="${pr_number:-$issue_number}"
+    if [ -z "$subject_number" ]; then
+      emit_skip "no-subject-number-in-payload"
       exit 0
     fi
 
@@ -388,7 +395,7 @@ case "$EVENT_NAME" in
     # fails (auth error, transient failure, token without label read access),
     # skip rather than route with unknown label state.
     _dispatch_labels=""
-    if ! _dispatch_labels=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${pr_number}/labels" \
+    if ! _dispatch_labels=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${subject_number}/labels" \
         --paginate --jq '.[].name' 2>/dev/null); then
       emit_skip "label-lookup-error"
       exit 0
@@ -401,6 +408,10 @@ case "$EVENT_NAME" in
 
     case "$dispatch_type" in
       dev-lead-ci-failure)
+        if [ -z "$pr_number" ]; then
+          emit_skip "no-pr-number-in-payload"
+          exit 0
+        fi
         checks=$(jq -c '.client_payload.checks // []' "$EVENT_PATH" 2>/dev/null || echo "[]")
         context=$(jq -nc \
           --argjson pr_number "$pr_number" \
@@ -410,6 +421,10 @@ case "$EVENT_NAME" in
         emit_intent "fix-ci" "ci-failure-dispatch" "$context"
         ;;
       dev-lead-reviews-retry)
+        if [ -z "$pr_number" ]; then
+          emit_skip "no-pr-number-in-payload"
+          exit 0
+        fi
         intent_type=$(jq -r '.client_payload.intent_type // empty' "$EVENT_PATH" 2>/dev/null || true)
         case "$intent_type" in
           fix-reviews|fix-bot-comment|on-mention|review-changes|rebase)
@@ -431,6 +446,19 @@ case "$EVENT_NAME" in
             emit_skip "unknown-reviews-retry-intent-type"
             ;;
         esac
+        ;;
+      dev-lead-issue-retry)
+        # Bounded auto-retry of a failed initial issue implementation (#781). The
+        # payload is issue-only (no PR exists yet); route to the existing `issue`
+        # intent so the same handler re-runs the implementation. The issue
+        # handler re-derives all context fresh from the issue, so a re-dispatch
+        # has full fidelity (like the PR-side retryable intents).
+        if [ -z "$issue_number" ]; then
+          emit_skip "no-issue-number-in-payload"
+          exit 0
+        fi
+        context=$(printf '{"issue_number":%s}' "$issue_number")
+        emit_intent "issue" "issue-retry-dispatch" "$context"
         ;;
       *)
         emit_skip "unknown-dispatch-type"

--- a/scripts/dev-lead-retry.sh
+++ b/scripts/dev-lead-retry.sh
@@ -207,7 +207,7 @@ scan_pr_for_rate_limits() {
   # Fetch all comment bodies, paginating to ensure we don't miss markers on busy PRs
   local comments_json
   comments_json=$(gh api --paginate "repos/${repo}/issues/${pr_number}/comments?per_page=100" \
-    --jq '[.[].body]' 2>/dev/null || echo "[]")
+    --jq '[.[].body]' 2>/dev/null | jq -s 'add // []' || echo "[]")
 
   local dispatched=0
 
@@ -292,7 +292,7 @@ scan_repo() {
     --jq '[.[] | {number: .number, head_sha: .head.sha}]' 2>/dev/null || echo "[]")
 
   local pr_count
-  pr_count=$(echo "$prs_json" | jq 'length')
+  pr_count=$(echo "$prs_json" | jq -s 'add // [] | length')
   if [ "$pr_count" -eq 0 ]; then
     echo "  no open PRs in ${repo}"
   else
@@ -304,7 +304,7 @@ scan_repo() {
       local dispatched
       dispatched=$(scan_pr_for_rate_limits "$repo" "$pr_number")
       total_dispatched=$(( total_dispatched + dispatched ))
-    done < <(echo "$prs_json" | jq -c '.[]')
+    done < <(echo "$prs_json" | jq -sc 'add // [] | .[]')
     echo "  dispatched ${total_dispatched} PR retries from ${repo}"
   fi
 
@@ -319,9 +319,9 @@ scan_repo() {
 # the issue must NOT be re-dispatched (the PR path takes over).
 open_issue_pr_exists() {
   local repo="$1" issue_number="$2" count
-  count=$(gh api "repos/${repo}/pulls?state=open&per_page=100" \
-    --jq "[.[] | select(.head.ref | startswith(\"dev-lead/issue-${issue_number}-\"))] | length" \
-    2>/dev/null || echo "0")
+  count=$(gh api --paginate "repos/${repo}/pulls?state=open&per_page=100" \
+    --jq "[.[] | select(.head.ref | startswith(\"dev-lead/issue-${issue_number}-\"))]" \
+    2>/dev/null | jq -s 'add | length' || echo "0")
   [ "${count:-0}" -gt 0 ]
 }
 

--- a/scripts/dev-lead-retry.sh
+++ b/scripts/dev-lead-retry.sh
@@ -340,8 +340,8 @@ scan_issue_for_retry() {
   # the last matching one is the most recent attempt — earlier ones superseded).
   local prefix="${ISSUE_MARKER_PREFIX}${issue_number} "
   local marker
-  marker=$(echo "$comments_json" | jq -r --arg p "$prefix" \
-    '[ .[] | select(. != null and (. | contains($p))) ] | last // ""' 2>/dev/null || echo "")
+  marker=$(echo "$comments_json" | jq -s -r --arg p "$prefix" \
+    '[ .[] | .[]? | select(. != null and (. | contains($p))) ] | last // ""' 2>/dev/null || echo "")
 
   if [ -z "$marker" ]; then
     # No failure marker → nothing failed (or it succeeded). Nothing to retry.
@@ -407,7 +407,7 @@ scan_repo_issues() {
     2>/dev/null || echo "[]")
 
   local issue_count
-  issue_count=$(echo "$issues_json" | jq 'length')
+  issue_count=$(echo "$issues_json" | jq -s 'add // [] | length')
   if [ "${issue_count:-0}" -eq 0 ]; then
     echo "  no open dev-lead issues in ${repo}"
     return 0

--- a/scripts/dev-lead-retry.sh
+++ b/scripts/dev-lead-retry.sh
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
-# dev-lead-retry.sh — scan open PRs for rate-limited markers and re-dispatch
+# dev-lead-retry.sh — scan open PRs + issues for failure markers and re-dispatch
 #
 # Called by the dev-lead-retry.yml scheduled cron workflow.
 # Scans all open PRs across TARGET_ORG (plus DELEGATION_ORGS if set) for
 # status=rate-limited markers on the current HEAD SHA, then re-dispatches the
 # appropriate dev-lead event so the run is retried once the rate limit clears.
+#
+# It ALSO scans open issues labeled `dev-lead` for failed initial implementations
+# (#781): an issue whose `Run issue` engine step failed carries a
+# `<!-- dev-lead-issue <N> status=<failed|rate-limited> attempt=<K> ... -->`
+# marker (written by dev-lead-fix-issue.sh). Those are re-dispatched as
+# dev-lead-issue-retry up to MAX_ATTEMPTS, after which fix-issue.sh escalates to
+# a human (dev-lead:needs-human) and the scan skips them.
 #
 # Env (required):
 #   GH_TOKEN            — PAT with repo + contents:write scopes
@@ -34,6 +41,14 @@ DRY_RUN="${DRY_RUN:-false}"
 
 CI_MARKER_PREFIX="<!-- dev-lead-fix-ci sha="
 REVIEWS_MARKER_PREFIX="<!-- dev-lead-fix-reviews pr="
+ISSUE_MARKER_PREFIX="<!-- dev-lead-issue "
+
+# Issue-retry config (#781). MAX_ATTEMPTS matches dev-lead-fix-issue.sh and the
+# auto-rebase-retry.sh convention: total attempts (initial + retries) before the
+# issue is escalated to a human and skipped here.
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-3}"
+DEV_LEAD_LABEL="${DEV_LEAD_LABEL:-dev-lead}"
+NEEDS_HUMAN_LABEL="${NEEDS_HUMAN_LABEL:-dev-lead:needs-human}"
 
 # Intents whose context can be fully reconstructed at retry time.
 # human-pr is included as a legacy alias for review-changes so that PRs already
@@ -140,6 +155,36 @@ dispatch_reviews_retry() {
     }')
   if ! echo "$payload" | gh api --method POST "repos/${repo}/dispatches" --input - >/dev/null 2>&1; then
     echo "  [warn] dispatch failed for PR ${pr_number} in ${repo}" >&2
+  fi
+}
+
+# dispatch_issue_retry <repo> <issue_number> <attempt>
+# Re-dispatches a failed initial issue implementation (#781). The reusable
+# workflow's intent classifier (dev-lead-intent.sh) recognises the
+# dev-lead-issue-retry type and routes it back to the `issue` intent.
+# All logging goes to stderr (same reason as dispatch_ci_retry above).
+dispatch_issue_retry() {
+  local repo="$1" issue_number="$2" attempt="$3"
+  echo "  -> dispatch issue-retry: repo=${repo} issue=${issue_number} attempt=${attempt}" >&2
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "  [dry-run] would dispatch dev-lead-issue-retry for issue ${issue_number} in ${repo} attempt=${attempt}" >&2
+    return 0
+  fi
+  local payload
+  payload=$(jq -n \
+    --argjson issue_number "$issue_number" \
+    --arg repo "$repo" \
+    --argjson attempt "$attempt" \
+    '{
+      event_type: "dev-lead-issue-retry",
+      client_payload: {
+        issue_number: $issue_number,
+        repo: $repo,
+        attempt: $attempt
+      }
+    }')
+  if ! echo "$payload" | gh api --method POST "repos/${repo}/dispatches" --input - >/dev/null 2>&1; then
+    echo "  [warn] dispatch failed for issue ${issue_number} in ${repo}" >&2
   fi
 }
 
@@ -250,21 +295,134 @@ scan_repo() {
   pr_count=$(echo "$prs_json" | jq 'length')
   if [ "$pr_count" -eq 0 ]; then
     echo "  no open PRs in ${repo}"
+  else
+    echo "  found ${pr_count} open PR(s)"
+    local total_dispatched=0
+    while IFS= read -r pr_entry; do
+      local pr_number
+      pr_number=$(echo "$pr_entry" | jq -r '.number')
+      local dispatched
+      dispatched=$(scan_pr_for_rate_limits "$repo" "$pr_number")
+      total_dispatched=$(( total_dispatched + dispatched ))
+    done < <(echo "$prs_json" | jq -c '.[]')
+    echo "  dispatched ${total_dispatched} PR retries from ${repo}"
+  fi
+
+  # Always scan open issues for failed initial implementations (#781) — even when
+  # the repo has no open PRs, which is the common case for a stalled issue.
+  scan_repo_issues "$repo"
+}
+
+# open_issue_pr_exists <repo> <issue_number>
+# Returns 0 if an open PR for this issue already exists (branch dev-lead/issue-<N>*),
+# meaning a prior attempt already produced — or is producing — a PR. In that case
+# the issue must NOT be re-dispatched (the PR path takes over).
+open_issue_pr_exists() {
+  local repo="$1" issue_number="$2" count
+  count=$(gh api "repos/${repo}/pulls?state=open&per_page=100" \
+    --jq "[.[] | select(.head.ref | startswith(\"dev-lead/issue-${issue_number}-\"))] | length" \
+    2>/dev/null || echo "0")
+  [ "${count:-0}" -gt 0 ]
+}
+
+# scan_issue_for_retry <repo> <issue_number>
+# Inspects the issue's newest dev-lead-issue marker and re-dispatches a bounded
+# retry when warranted. Prints only a single integer (retries dispatched) to
+# stdout; all other output goes to stderr so callers can capture the count.
+scan_issue_for_retry() {
+  local repo="$1" issue_number="$2"
+
+  local comments_json
+  comments_json=$(gh api --paginate "repos/${repo}/issues/${issue_number}/comments?per_page=100" \
+    --jq '[.[].body]' 2>/dev/null || echo "[]")
+
+  # Newest dev-lead-issue marker for this issue (comments are chronological, so
+  # the last matching one is the most recent attempt — earlier ones superseded).
+  local prefix="${ISSUE_MARKER_PREFIX}${issue_number} "
+  local marker
+  marker=$(echo "$comments_json" | jq -r --arg p "$prefix" \
+    '[ .[] | select(. != null and (. | contains($p))) ] | last // ""' 2>/dev/null || echo "")
+
+  if [ -z "$marker" ]; then
+    # No failure marker → nothing failed (or it succeeded). Nothing to retry.
+    echo "0"
     return 0
   fi
 
-  echo "  found ${pr_count} open PR(s)"
+  local status attempt reason reset
+  status=$(printf '%s' "$marker"  | grep -oE 'status=[^ ]+'  | head -1 | cut -d= -f2)
+  attempt=$(printf '%s' "$marker" | grep -oE 'attempt=[0-9]+' | head -1 | cut -d= -f2)
+  reason=$(printf '%s' "$marker"  | grep -oE 'reason=[^ ]+'  | head -1 | cut -d= -f2)
+  reset=$(printf '%s' "$marker"   | grep -oE 'reset=[0-9TZ:-]+' | head -1 | cut -d= -f2)
+
+  # Only failed / rate-limited markers are retryable. A status=needs-human marker
+  # (or any other) is terminal — skip (such issues also carry the needs-human
+  # label and are filtered before reaching here, but double-guard).
+  case "$status" in
+    failed|rate-limited) : ;;
+    *)
+      echo "  [skip] issue #${issue_number}: newest marker status=${status:-?} not retryable" >&2
+      echo "0"; return 0 ;;
+  esac
+
+  # Honour the rate-limit reset window for rate-limited markers.
+  if [ "$status" = "rate-limited" ] && is_reset_in_future "$reset"; then
+    echo "  [skip] issue #${issue_number} rate-limit not yet cleared (resets ${reset})" >&2
+    echo "0"; return 0
+  fi
+
+  # Enforce the attempt ceiling. attempt>=MAX means fix-issue.sh already escalated
+  # to a human on its last failure; do not re-dispatch.
+  if [ -z "$attempt" ] || [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+    echo "  [skip] issue #${issue_number}: attempts exhausted (attempt=${attempt:-?}/${MAX_ATTEMPTS})" >&2
+    echo "0"; return 0
+  fi
+
+  # Skip if a PR already exists for this issue (prior attempt succeeded, or a
+  # retry run is currently producing one).
+  if open_issue_pr_exists "$repo" "$issue_number"; then
+    echo "  [skip] issue #${issue_number}: an open dev-lead PR already exists" >&2
+    echo "0"; return 0
+  fi
+
+  echo "  [retry] issue #${issue_number}: status=${status} reason=${reason:-?} attempt=${attempt} < ${MAX_ATTEMPTS} → re-dispatching" >&2
+  dispatch_issue_retry "$repo" "$issue_number" "$attempt"
+  echo "1"
+}
+
+# scan_repo_issues <repo>: scan open issues labeled dev-lead for failed initial
+# implementations and re-dispatch bounded retries.
+scan_repo_issues() {
+  local repo="$1"
+
+  # Enumerate open issues carrying the dev-lead label but NOT the needs-human
+  # escalation label. The issues endpoint also returns PRs, so filter
+  # .pull_request==null to keep true issues only.
+  local issues_json
+  issues_json=$(gh api --paginate \
+    "repos/${repo}/issues?state=open&labels=${DEV_LEAD_LABEL}&per_page=100" \
+    --jq "[.[] | select(.pull_request == null)
+           | select([.labels[].name] | index(\"${NEEDS_HUMAN_LABEL}\") | not)
+           | {number: .number}]" \
+    2>/dev/null || echo "[]")
+
+  local issue_count
+  issue_count=$(echo "$issues_json" | jq 'length')
+  if [ "${issue_count:-0}" -eq 0 ]; then
+    echo "  no open dev-lead issues in ${repo}"
+    return 0
+  fi
+
+  echo "  found ${issue_count} open dev-lead issue(s)"
   local total_dispatched=0
-
-  while IFS= read -r pr_entry; do
-    local pr_number
-    pr_number=$(echo "$pr_entry" | jq -r '.number')
-    local dispatched
-    dispatched=$(scan_pr_for_rate_limits "$repo" "$pr_number")
+  while IFS= read -r issue_entry; do
+    local issue_number dispatched
+    issue_number=$(echo "$issue_entry" | jq -r '.number')
+    dispatched=$(scan_issue_for_retry "$repo" "$issue_number")
     total_dispatched=$(( total_dispatched + dispatched ))
-  done < <(echo "$prs_json" | jq -c '.[]')
+  done < <(echo "$issues_json" | jq -c '.[]')
 
-  echo "  dispatched ${total_dispatched} retries from ${repo}"
+  echo "  dispatched ${total_dispatched} issue retries from ${repo}"
 }
 
 # list_repos_for_org <org>: list all non-fork repos in the org.
@@ -323,4 +481,8 @@ main() {
   echo "[retry] done at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
 
-main "$@"
+# Run main only when executed directly (bash dev-lead-retry.sh), not when sourced
+# by unit tests that exercise individual functions (scan_issue_for_retry, etc.).
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+fi

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -1086,13 +1086,6 @@ run_writer() {
       ;;
   esac
 
-  # Map rate-limit to exit code 2 for caller to detect; parse reset time for
-  # marker embedding. Use the file-based helpers to avoid OOM on large captures.
-  if [ "$rc" -ne 0 ] && [ -n "$_tmp" ] && is_rate_limited_files "$_tmp"; then
-    parse_reset_time_files "$_tmp"
-    [ -n "$_tmp" ] && rm -f "$_tmp"
-    return 2
-  fi
   if [ "$rc" -eq 0 ]; then
     local _writer_used="$model"
     if [ "$REVIEW_ENGINE" = "claude" ] && [ -n "${_CLAUDE_CHAIN_MODEL_USED:-}" ]; then
@@ -1107,6 +1100,13 @@ run_writer() {
     # use that redacted file as the source for the step summary so credentials
     # cannot leak via /tmp persistence or the public run summary. Patterns
     # kept in sync with scripts/dev-lead-fix-reviews.sh:redact_secrets.
+    #
+    # This runs for ALL terminal paths — success, generic failure, AND the
+    # rate-limit early return below — so the session output (where the real
+    # failure cause appears) reaches the run summary and the persisted sidecar
+    # regardless of exit code. The rate-limit check further down reads the raw
+    # capture ($_tmp), which redaction leaves intact (separate file), so
+    # persisting first is safe.
     rm -f /tmp/dev-lead-session-output.txt
     if ! sed -E \
       -e 's/(gh[opsu]|ghr)_[A-Za-z0-9_]{20,}/***REDACTED-GH-TOKEN***/g' \
@@ -1138,8 +1138,18 @@ run_writer() {
       } >> "$GITHUB_STEP_SUMMARY" || \
         echo "::warning::Failed to append session output to GITHUB_STEP_SUMMARY" >&2
     fi
-    rm -f "$_tmp"
   fi
+
+  # Map rate-limit to exit code 2 for caller to detect; parse reset time for
+  # marker embedding. Use the file-based helpers to avoid OOM on large captures.
+  # Runs AFTER the persist/summary block above so a rate-limited session is also
+  # captured to the run summary; reads the raw capture ($_tmp) left intact above.
+  if [ "$rc" -ne 0 ] && [ -n "$_tmp" ] && is_rate_limited_files "$_tmp"; then
+    parse_reset_time_files "$_tmp"
+    rm -f "$_tmp"
+    return 2
+  fi
+  [ -n "$_tmp" ] && rm -f "$_tmp"
   return "$rc"
 }
 
@@ -1153,6 +1163,14 @@ run_writer_with_fallback() {
   local prompt_file="$1"
   local intent="${2:-}"
   local engines=("$REVIEW_ENGINE")
+
+  # Clear any stale failure-reason sidecar from a prior invocation in the same
+  # process. Before each terminal failure return below we write a one-line
+  # cause class (rate-limited | missing-binary | engine-error) to this path,
+  # mirroring the existing /tmp/dev-lead-rate-limit-reset sidecar. Downstream
+  # handlers (dev-lead-fix-issue.sh) read it to classify the failure and pick
+  # the right retry behavior. This is purely additive — no control-flow change.
+  rm -f /tmp/dev-lead-failure-reason
 
   for e in claude copilot gemini; do
     [ "$e" != "$REVIEW_ENGINE" ] && engines+=("$e")
@@ -1200,6 +1218,9 @@ run_writer_with_fallback() {
       [ "$rc" -eq 127 ] && any_missing=1
       continue
     fi
+    # A non-fallback engine error (e.g. 124=timeout kill, 137/143=signal,
+    # generic non-zero) — propagate immediately, classifying it as engine-error.
+    printf 'engine-error\n' > /tmp/dev-lead-failure-reason
     return "$rc"
   done
 
@@ -1208,8 +1229,15 @@ run_writer_with_fallback() {
   # downstream handlers do not post rate-limit retry markers for what is really a
   # configuration/environment problem.  Only return 2 when every failure was a
   # genuine quota/rate-limit so callers know a later retry may succeed.
-  [ "$any_missing" -eq 1 ] && return 1
-  [ "$any_rate_limited" -eq 1 ] && return 2
+  if [ "$any_missing" -eq 1 ]; then
+    printf 'missing-binary\n' > /tmp/dev-lead-failure-reason
+    return 1
+  fi
+  if [ "$any_rate_limited" -eq 1 ]; then
+    printf 'rate-limited\n' > /tmp/dev-lead-failure-reason
+    return 2
+  fi
+  printf 'engine-error\n' > /tmp/dev-lead-failure-reason
   return 1
 }
 

--- a/tests/dev-lead/e2e/scenarios/07-rate-limit-retry.sh
+++ b/tests/dev-lead/e2e/scenarios/07-rate-limit-retry.sh
@@ -504,16 +504,73 @@ GHEOF
     all_pass=false
   fi
 
+  # ── Part I: dev-lead-retry.sh dry-run requeues a failed initial issue (#781) ─
+  log ""
+  log "Part I: dev-lead-retry.sh dry-run identifies a failed dev-lead issue and would re-dispatch"
+
+  cat > "${STUB_ENGINE_DIR}/gh" << 'GHEOF'
+#!/usr/bin/env bash
+case "$*" in
+  *"repo list"*)
+    echo '[{"nameWithOwner":"petry-projects/test-repo","isFork":false}]' ;;
+  *startswith*)
+    # open_issue_pr_exists probe → no existing PR for the issue
+    echo "0" ;;
+  *"issues/478/comments"*)
+    # post-jq shape (gh applies --jq '[.[].body]'): array of comment-body strings
+    echo '["<!-- dev-lead-issue 478 status=failed attempt=1 reason=engine-error run=99 -->"]' ;;
+  *"issues?state=open"*)
+    # scan_repo_issues enumeration (post-jq shape: array of {number})
+    echo '[{"number":478}]' ;;
+  *"pulls?state=open"*)
+    # no open PRs (keeps the PR scan a no-op so we isolate the issue path)
+    echo '[]' ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "${STUB_ENGINE_DIR}/gh"
+
+  local output_i exit_i
+  set +e
+  output_i=$(
+    PATH="${STUB_ENGINE_DIR}:${PATH}" \
+    GITHUB_ENV="${GITHUB_ENV_FILE}" \
+    GITHUB_OUTPUT="/dev/null" \
+    TARGET_ORG="petry-projects" \
+    DRY_RUN="true" \
+    DISPATCH_DELAY_SEC="0" \
+    NOW_ISO="2026-05-16T20:00:00Z" \
+    bash "${RETRY_SCRIPT}" 2>&1
+  )
+  exit_i=$?
+  set -e
+
+  log "Part I exit code: ${exit_i}"
+  echo "${output_i}" | sed 's/^/  /'
+
+  if assert_eq "$exit_i" "0" "${SCENARIO_NAME}(I): retry script exits 0"; then
+    true
+  else
+    all_pass=false
+  fi
+
+  if echo "${output_i}" | grep -q "would dispatch dev-lead-issue-retry"; then
+    echo "[PASS] ${SCENARIO_NAME}(I): retry script identified failed issue #478 and would re-dispatch"
+  else
+    echo "[FAIL] ${SCENARIO_NAME}(I): retry script did not requeue failed issue #478"
+    all_pass=false
+  fi
+
   # ── Result ─────────────────────────────────────────────────────────────────
   if [ "${all_pass}" = "true" ]; then
     log "[PASS] ${SCENARIO_NAME}: rate-limit retry infrastructure works correctly"
     record_result "${SCENARIO_NAME}" "PASS" \
-      "rate-limited-exit2 no-exhaustion-count retriable-idempotency fix-reviews-marker on-mention-ack retry-scan human-pr-normalize"
+      "rate-limited-exit2 no-exhaustion-count retriable-idempotency fix-reviews-marker on-mention-ack retry-scan human-pr-normalize issue-retry-scan"
     exit 0
   else
     err "[FAIL] ${SCENARIO_NAME}: one or more assertions failed"
     record_result "${SCENARIO_NAME}" "FAIL" \
-      "exitA=${exit_a} exitB=${exit_b} exitC=${exit_c} exitD=${exit_d} exitE=${exit_e} exitF=${exit_f} exitG=${exit_g} exitH=${exit_h}"
+      "exitA=${exit_a} exitB=${exit_b} exitC=${exit_c} exitD=${exit_d} exitE=${exit_e} exitF=${exit_f} exitG=${exit_g} exitH=${exit_h} exitI=${exit_i}"
     exit 1
   fi
 }

--- a/tests/dev-lead/fixtures/events/repository_dispatch_issue_retry.json
+++ b/tests/dev-lead/fixtures/events/repository_dispatch_issue_retry.json
@@ -1,0 +1,11 @@
+{
+  "_test_expected_intent": "issue",
+  "action": "dev-lead-issue-retry",
+  "client_payload": {
+    "issue_number": 478,
+    "repo": "petry-projects/.github-private",
+    "attempt": 1
+  },
+  "repository": { "full_name": "petry-projects/.github-private" },
+  "sender": { "login": "github-actions[bot]", "type": "Bot" }
+}

--- a/tests/dev-lead/unit/test_dev_lead_retry.bats
+++ b/tests/dev-lead/unit/test_dev_lead_retry.bats
@@ -1,0 +1,161 @@
+#!/usr/bin/env bats
+# Unit tests for dev-lead-retry.sh — issue-retry scan/decision logic (#781)
+#
+# The script guards `main "$@"` behind a BASH_SOURCE check, so sourcing it here
+# exposes scan_issue_for_retry / dispatch_issue_retry / open_issue_pr_exists
+# without running the org-wide scan.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+RETRY_SCRIPT="$SCRIPT_DIR/scripts/dev-lead-retry.sh"
+
+setup() {
+  MOCK_BIN="$(mktemp -d)"
+  export PATH="$MOCK_BIN:$PATH"
+
+  # Defaults; individual tests override COMMENTS_JSON / OPEN_PR_COUNT / NOW_ISO.
+  export COMMENTS_JSON='[]'
+  export OPEN_PR_COUNT="0"
+  export DRY_RUN="true"
+  export NOW_ISO="2026-06-19T00:00:00Z"
+
+  # gh stub: emulates the *post-jq* output the script expects (the real gh
+  # applies --jq server/client-side; the stub returns the finished value).
+  #   …/issues/<n>/comments  -> $COMMENTS_JSON   (array of comment bodies)
+  #   …/pulls?state=open      -> $OPEN_PR_COUNT   (integer)
+  #   …/dispatches            -> capture payload to $PAYLOAD_FILE (POST path)
+  export PAYLOAD_FILE="$MOCK_BIN/payload.json"
+  cat > "$MOCK_BIN/gh" <<'GHEOF'
+#!/usr/bin/env bash
+args="$*"
+case "$args" in
+  *dispatches*) cat > "${PAYLOAD_FILE:-/dev/null}"; exit 0 ;;
+  *comments*)   printf '%s' "${COMMENTS_JSON}" ;;
+  *pulls*)      printf '%s' "${OPEN_PR_COUNT}" ;;
+  *)            echo "[]" ;;
+esac
+GHEOF
+  chmod +x "$MOCK_BIN/gh"
+
+  source "$RETRY_SCRIPT"
+}
+
+teardown() {
+  rm -rf "$MOCK_BIN"
+}
+
+_marker() {
+  # _marker <status> <attempt> [reset]
+  local status="$1" attempt="$2" reset="${3:-}"
+  local r=""
+  [ -n "$reset" ] && r=" reset=${reset}"
+  printf '<!-- dev-lead-issue 478 status=%s attempt=%s reason=engine-error run=99%s -->' \
+    "$status" "$attempt" "$r"
+}
+
+# ── scan_issue_for_retry decision matrix ──────────────────────────────────────
+
+@test "retry: failed marker, attempt 1, no PR → dispatches" {
+  COMMENTS_JSON="$(jq -nc --arg m "$(_marker failed 1)" '[$m]')"
+
+  run scan_issue_for_retry "petry-projects/.github" 478
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"would dispatch dev-lead-issue-retry"* ]]
+  [[ "$output" == *"attempt=1"* ]]
+}
+
+@test "retry: rate-limited marker with reset in the future → skips" {
+  COMMENTS_JSON="$(jq -nc --arg m "$(_marker rate-limited 1 2026-06-19T06:00:00Z)" '[$m]')"
+
+  run scan_issue_for_retry "petry-projects/.github" 478
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"not yet cleared"* ]]
+  [[ "$output" != *"would dispatch"* ]]
+}
+
+@test "retry: rate-limited marker with reset in the past → dispatches" {
+  COMMENTS_JSON="$(jq -nc --arg m "$(_marker rate-limited 1 2026-06-18T00:00:00Z)" '[$m]')"
+
+  run scan_issue_for_retry "petry-projects/.github" 478
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"would dispatch dev-lead-issue-retry"* ]]
+}
+
+@test "retry: attempt at the ceiling (attempt=3, MAX=3) → skips" {
+  COMMENTS_JSON="$(jq -nc --arg m "$(_marker failed 3)" '[$m]')"
+
+  run scan_issue_for_retry "petry-projects/.github" 478
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"attempts exhausted"* ]]
+  [[ "$output" != *"would dispatch"* ]]
+}
+
+@test "retry: newest marker wins (failed attempt=2 supersedes attempt=1)" {
+  COMMENTS_JSON="$(jq -nc \
+    --arg a "$(_marker failed 1)" \
+    --arg b "$(_marker failed 2)" '[$a, $b]')"
+
+  run scan_issue_for_retry "petry-projects/.github" 478
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"would dispatch dev-lead-issue-retry"* ]]
+  [[ "$output" == *"attempt=2"* ]]
+}
+
+@test "retry: non-retryable marker (status=needs-human) → skips" {
+  COMMENTS_JSON="$(jq -nc --arg m "$(_marker needs-human 2)" '[$m]')"
+
+  run scan_issue_for_retry "petry-projects/.github" 478
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"not retryable"* ]]
+  [[ "$output" != *"would dispatch"* ]]
+}
+
+@test "retry: an open dev-lead PR already exists → skips" {
+  COMMENTS_JSON="$(jq -nc --arg m "$(_marker failed 1)" '[$m]')"
+  OPEN_PR_COUNT="1"
+
+  run scan_issue_for_retry "petry-projects/.github" 478
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"open dev-lead PR already exists"* ]]
+  [[ "$output" != *"would dispatch"* ]]
+}
+
+@test "retry: no failure marker → no dispatch (returns 0)" {
+  COMMENTS_JSON='["just a normal human comment"]'
+
+  run scan_issue_for_retry "petry-projects/.github" 478
+
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"would dispatch"* ]]
+}
+
+# ── dispatch_issue_retry payload ──────────────────────────────────────────────
+
+@test "dispatch: issue-retry payload carries event_type + issue_number + attempt" {
+  export DRY_RUN="false"
+
+  run dispatch_issue_retry "petry-projects/.github" 478 2
+
+  [ "$status" -eq 0 ]
+  [ -f "$PAYLOAD_FILE" ]
+  [ "$(jq -r '.event_type' "$PAYLOAD_FILE")" = "dev-lead-issue-retry" ]
+  [ "$(jq -r '.client_payload.issue_number' "$PAYLOAD_FILE")" = "478" ]
+  [ "$(jq -r '.client_payload.attempt' "$PAYLOAD_FILE")" = "2" ]
+}
+
+@test "dispatch: DRY_RUN=true does not POST a dispatch" {
+  export DRY_RUN="true"
+  rm -f "$PAYLOAD_FILE"
+
+  run dispatch_issue_retry "petry-projects/.github" 478 1
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[dry-run] would dispatch"* ]]
+  [ ! -f "$PAYLOAD_FILE" ]
+}

--- a/tests/dev-lead/unit/test_engine_fallback.bats
+++ b/tests/dev-lead/unit/test_engine_fallback.bats
@@ -273,7 +273,7 @@ GHEOF
   # claude not installed (127); gemini skipped (no key); copilot skipped (classic PAT).
   _make_stub "claude" 127
   unset GEMINI_API_KEY GOOGLE_API_KEY 2>/dev/null || true
-  export COPILOT_GITHUB_TOKEN="ghp_classicPATplaceholder0000000000000000"
+  export COPILOT_GITHUB_TOKEN="ghp_stub"  # ghp_* → copilot fallback is skipped
   _source_engine "claude"
 
   run run_writer_with_fallback "$TEST_PROMPT"
@@ -320,7 +320,7 @@ exit 1
 STUB
   chmod +x "$STUB_BIN_DIR/claude"
   unset GEMINI_API_KEY GOOGLE_API_KEY 2>/dev/null || true
-  export COPILOT_GITHUB_TOKEN="ghp_classicPATplaceholder0000000000000000"
+  export COPILOT_GITHUB_TOKEN="ghp_stub"  # ghp_* → copilot fallback is skipped
   export GITHUB_STEP_SUMMARY="$(mktemp)"
   _source_engine "claude"
 

--- a/tests/dev-lead/unit/test_engine_fallback.bats
+++ b/tests/dev-lead/unit/test_engine_fallback.bats
@@ -27,6 +27,7 @@ setup() {
 
 teardown() {
   rm -f "$GITHUB_ENV" "$GITHUB_OUTPUT" "$TEST_PROMPT"
+  rm -f /tmp/dev-lead-failure-reason /tmp/dev-lead-session-output.txt /tmp/dev-lead-rate-limit-reset
   rm -rf "$STUB_BIN_DIR"
 }
 
@@ -240,4 +241,97 @@ GHEOF
 
   [ "$status" -eq 0 ]
   unset GEMINI_API_KEY
+}
+
+# ── failure-reason sidecar tests (#781) ───────────────────────────────────────
+# run_writer_with_fallback writes a one-line cause class to
+# /tmp/dev-lead-failure-reason before each terminal failure return, so callers
+# can classify the failure. Because `run` executes in a subshell, the sidecar
+# file (not the function's environment) is the contract we assert on.
+
+@test "sidecar: all rate-limited → reason=rate-limited" {
+  _make_stub "claude" 2
+  _make_stub "gemini" 2
+  export COPILOT_GITHUB_TOKEN="stub-token"
+  cat > "$STUB_BIN_DIR/gh" <<'GHEOF'
+#!/usr/bin/env bash
+case "$*" in
+  *"copilot"*) echo "rate limit exceeded"; exit 1 ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN_DIR/gh"
+  _source_engine "claude"
+
+  run run_writer_with_fallback "$TEST_PROMPT"
+
+  [ "$status" -eq 2 ]
+  [ "$(cat /tmp/dev-lead-failure-reason)" = "rate-limited" ]
+}
+
+@test "sidecar: missing binary (127) → reason=missing-binary" {
+  # claude not installed (127); gemini skipped (no key); copilot skipped (classic PAT).
+  _make_stub "claude" 127
+  unset GEMINI_API_KEY GOOGLE_API_KEY 2>/dev/null || true
+  export COPILOT_GITHUB_TOKEN="ghp_classicPATplaceholder0000000000000000"
+  _source_engine "claude"
+
+  run run_writer_with_fallback "$TEST_PROMPT"
+
+  [ "$status" -eq 1 ]
+  [ "$(cat /tmp/dev-lead-failure-reason)" = "missing-binary" ]
+}
+
+@test "sidecar: generic engine error (exit 1) → reason=engine-error" {
+  _make_stub "claude" 1
+  _source_engine "claude"
+
+  run run_writer_with_fallback "$TEST_PROMPT"
+
+  [ "$status" -eq 1 ]
+  [ "$(cat /tmp/dev-lead-failure-reason)" = "engine-error" ]
+}
+
+@test "sidecar: stale reason cleared on success" {
+  printf 'engine-error\n' > /tmp/dev-lead-failure-reason
+  _make_stub "claude" 0
+  _source_engine "claude"
+
+  run run_writer_with_fallback "$TEST_PROMPT"
+
+  [ "$status" -eq 0 ]
+  # The sidecar is removed at the start of every call → no stale reason survives.
+  [ ! -f /tmp/dev-lead-failure-reason ]
+}
+
+# ── session-output persistence on the rate-limit path (#781, Phase 1A.2) ──────
+# Previously run_writer's rate-limit early-return happened BEFORE the
+# redact/persist/STEP_SUMMARY block, so a rate-limited run left no session
+# output on the run page. The block now runs first, covering all exit paths.
+
+@test "rate-limit path: session output is persisted + written to step summary" {
+  # claude detected as rate-limited by CONTENT (exit 1 + rate-limit phrase),
+  # which forces run_writer's is_rate_limited early-return path. gemini/copilot
+  # are skipped so claude is the only engine and its output is the persisted one.
+  cat > "$STUB_BIN_DIR/claude" <<'STUB'
+#!/usr/bin/env bash
+echo "RLPROBE: You've hit your limit · resets 11:20pm (UTC)"
+exit 1
+STUB
+  chmod +x "$STUB_BIN_DIR/claude"
+  unset GEMINI_API_KEY GOOGLE_API_KEY 2>/dev/null || true
+  export COPILOT_GITHUB_TOKEN="ghp_classicPATplaceholder0000000000000000"
+  export GITHUB_STEP_SUMMARY="$(mktemp)"
+  _source_engine "claude"
+
+  run run_writer_with_fallback "$TEST_PROMPT"
+
+  [ "$status" -eq 2 ]
+  # Persisted session output exists and contains the engine output
+  [ -s /tmp/dev-lead-session-output.txt ]
+  grep -q "RLPROBE" /tmp/dev-lead-session-output.txt
+  # Step summary received the session-output block even on the rate-limit path
+  grep -q "Dev-Lead session output" "$GITHUB_STEP_SUMMARY"
+
+  rm -f "$GITHUB_STEP_SUMMARY"
 }

--- a/tests/dev-lead/unit/test_fix_issue.bats
+++ b/tests/dev-lead/unit/test_fix_issue.bats
@@ -482,7 +482,7 @@ GHEOF
   # Skip gemini (no key) and copilot (classic PAT) so the only failure is the
   # missing claude binary → run_writer_with_fallback returns missing-binary.
   unset GEMINI_API_KEY GOOGLE_API_KEY
-  export COPILOT_GITHUB_TOKEN="ghp_classicPATplaceholder0000000000000000"
+  export COPILOT_GITHUB_TOKEN="ghp_stub"  # ghp_* → copilot fallback is skipped
 
   run bash "$FIX_ISSUE_SCRIPT"
 

--- a/tests/dev-lead/unit/test_fix_issue.bats
+++ b/tests/dev-lead/unit/test_fix_issue.bats
@@ -370,6 +370,152 @@ GHEOF
   rm -f "$comment_sentinel" "$commit_sentinel" 2>/dev/null || true
 }
 
+# ── engine-failure visibility + retry-marker tests (#781) ─────────────────────
+
+# Shared stub: claude exits with the given code + message; git is stubbed for
+# branch creation; curl returns empty so the claude headroom probe is a no-op;
+# gh records every posted comment body to $COMMENT_FILE and label edits to
+# $LABEL_FILE, and serves prior issue comments from $PRIOR_COMMENTS_JSON.
+_setup_failure_stubs() {
+  local engine_rc="$1" engine_msg="$2"
+  cat > "$STUB_BIN_DIR/claude" <<STUB
+#!/usr/bin/env bash
+echo "${engine_msg}"
+exit ${engine_rc}
+STUB
+  chmod +x "$STUB_BIN_DIR/claude"
+
+  cat > "$STUB_BIN_DIR/curl" <<'CURLEOF'
+#!/usr/bin/env bash
+exit 0
+CURLEOF
+  chmod +x "$STUB_BIN_DIR/curl"
+
+  cat > "$STUB_BIN_DIR/git" <<'GITEOF'
+#!/usr/bin/env bash
+case "$*" in
+  "config"*)         exit 0 ;;
+  "checkout -b"*)    exit 0 ;;
+  "rev-parse HEAD")  echo "abc123deadbeef" ;;
+  *)                 exit 0 ;;
+esac
+GITEOF
+  chmod +x "$STUB_BIN_DIR/git"
+
+  COMMENT_FILE="$(mktemp)"; export COMMENT_FILE
+  LABEL_FILE="$(mktemp)"; export LABEL_FILE
+  : "${PRIOR_COMMENTS_JSON:=[]}"; export PRIOR_COMMENTS_JSON
+
+  cat > "$STUB_BIN_DIR/gh" <<GHEOF
+#!/usr/bin/env bash
+cmd="\$1"; shift || true
+case "\$cmd" in
+  copilot) echo "rate limit exceeded"; exit 1 ;;
+  label)   exit 0 ;;
+  api)
+    case "\$*" in
+      *"pulls?state=open"*) echo "0" ;;
+      *comments*)           printf '%s' '${PRIOR_COMMENTS_JSON}' ;;
+      *"users/"*)           echo '{"id":12345}' ;;
+      *"issues/"*)          echo '{"title":"Test Issue","body":"body"}' ;;
+      *)                    echo "{}" ;;
+    esac ;;
+  issue)
+    sub="\$1"; shift || true
+    case "\$sub" in
+      comment)
+        body=""
+        while [ \$# -gt 0 ]; do
+          if [ "\$1" = "--body" ]; then body="\$2"; shift 2; continue; fi
+          shift
+        done
+        printf '%s\n----8<----\n' "\$body" >> "${COMMENT_FILE}"
+        exit 0 ;;
+      edit)
+        printf '%s\n' "\$*" >> "${LABEL_FILE}"
+        exit 0 ;;
+      *) echo "{}" ;;
+    esac ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN_DIR/gh"
+
+  export DEV_LEAD_DRY_RUN="false"
+}
+
+@test "fix-issue: engine-error (attempt 1) → exits 1, posts retry marker + cause, no silent exit" {
+  _setup_failure_stubs 1 "boom: transient engine error"
+
+  run bash "$FIX_ISSUE_SCRIPT"
+
+  [ "$status" -eq 1 ]
+  local posted; posted=$(cat "$COMMENT_FILE")
+  # Machine-readable retry marker the cron scans for
+  [[ "$posted" == *"<!-- dev-lead-issue 100 status=failed attempt=1 reason=engine-error run="* ]]
+  # Human-readable cause + run deep-link
+  [[ "$posted" == *"engine-error"* ]]
+  [[ "$posted" == *"actions/runs/"* ]]
+  [[ "$posted" == *"will retry"* ]]
+  # Must NOT escalate to a human on the first attempt
+  [ ! -s "$LABEL_FILE" ] || [[ "$(cat "$LABEL_FILE")" != *"needs-human"* ]]
+
+  rm -f "$COMMENT_FILE" "$LABEL_FILE"
+}
+
+@test "fix-issue: engine-error embeds redacted session-output snippet in the comment" {
+  _setup_failure_stubs 1 "TRACE: writer step exploded at line 42"
+
+  run bash "$FIX_ISSUE_SCRIPT"
+
+  [ "$status" -eq 1 ]
+  local posted; posted=$(cat "$COMMENT_FILE")
+  # The engine layer persists/redacts session output to /tmp; a tail must appear
+  [[ "$posted" == *"Last 40 lines of engine output"* ]]
+  [[ "$posted" == *"TRACE: writer step exploded"* ]]
+
+  rm -f "$COMMENT_FILE" "$LABEL_FILE"
+}
+
+@test "fix-issue: missing-binary → escalates to needs-human, no retry marker" {
+  _setup_failure_stubs 127 "claude: command not found"
+  # Skip gemini (no key) and copilot (classic PAT) so the only failure is the
+  # missing claude binary → run_writer_with_fallback returns missing-binary.
+  unset GEMINI_API_KEY GOOGLE_API_KEY
+  export COPILOT_GITHUB_TOKEN="ghp_classicPATplaceholder0000000000000000"
+
+  run bash "$FIX_ISSUE_SCRIPT"
+
+  [ "$status" -eq 1 ]
+  local posted; posted=$(cat "$COMMENT_FILE")
+  [[ "$posted" == *"needs human attention"* ]]
+  [[ "$posted" == *"reason=missing-binary"* ]]
+  # Deterministic infra failure → must NOT post a retryable status=failed marker
+  [[ "$posted" != *"status=failed"* ]]
+  # needs-human label applied
+  [[ "$(cat "$LABEL_FILE")" == *"dev-lead:needs-human"* ]]
+
+  rm -f "$COMMENT_FILE" "$LABEL_FILE"
+}
+
+@test "fix-issue: attempt ceiling (prior attempt=2) → escalates to needs-human" {
+  export PRIOR_COMMENTS_JSON='[{"body":"<!-- dev-lead-issue 100 status=failed attempt=2 reason=engine-error run=1 -->"}]'
+  _setup_failure_stubs 1 "boom again"
+
+  run bash "$FIX_ISSUE_SCRIPT"
+
+  [ "$status" -eq 1 ]
+  local posted; posted=$(cat "$COMMENT_FILE")
+  # attempt becomes 3 (>= MAX_ATTEMPTS) → human escalation, not another retry marker
+  [[ "$posted" == *"needs human attention"* ]]
+  [[ "$posted" == *"attempt=3"* ]]
+  [[ "$posted" != *"status=failed attempt=3"* ]]
+  [[ "$(cat "$LABEL_FILE")" == *"dev-lead:needs-human"* ]]
+
+  rm -f "$COMMENT_FILE" "$LABEL_FILE"
+  unset PRIOR_COMMENTS_JSON
+}
+
 @test "fix-issue: lint fails → posts lint-failure comment on the issue" {
   cat > "$STUB_BIN_DIR/dev-lead-lint.sh" <<'LINTEOF'
 #!/usr/bin/env bash

--- a/tests/dev-lead/unit/test_intent_ci.bats
+++ b/tests/dev-lead/unit/test_intent_ci.bats
@@ -202,3 +202,57 @@ EOF
   [ "$(_get_context_field pr_number)" = "42" ]
   [ "$(_get_context_field head_sha)" = "abc123def456" ]
 }
+
+# ── repository_dispatch dev-lead-issue-retry (#781) ───────────────────────────
+
+@test "ci: repository_dispatch dev-lead-issue-retry → issue (issue-only payload not dropped)" {
+  export GITHUB_EVENT_NAME="repository_dispatch"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/repository_dispatch_issue_retry.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "issue" ]
+  [ "$(_get_env INTENT_REASON)" = "issue-retry-dispatch" ]
+  [ "$(_get_context_field issue_number)" = "478" ]
+}
+
+@test "ci: dev-lead-issue-retry with no issue_number → skip" {
+  local tmp_event
+  tmp_event=$(mktemp --suffix=.json)
+  cat > "$tmp_event" <<'EOF'
+{
+  "action": "dev-lead-issue-retry",
+  "client_payload": { "repo": "petry-projects/.github-private" }
+}
+EOF
+  export GITHUB_EVENT_NAME="repository_dispatch"
+  export GITHUB_EVENT_PATH="$tmp_event"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "skip" ]
+  rm -f "$tmp_event"
+}
+
+@test "ci: dev-lead-issue-retry respects hands-off label on the issue" {
+  # gh stub returns the hands-off label → must skip even for a valid payload.
+  cat > "$MOCK_BIN/gh" <<'GHEOF'
+#!/usr/bin/env bash
+# hands-off label lookup: repos/.../issues/<n>/labels
+case "$*" in
+  *labels*) echo "dev-lead:hands-off" ;;
+  *) exit 0 ;;
+esac
+GHEOF
+  chmod +x "$MOCK_BIN/gh"
+  export GITHUB_EVENT_NAME="repository_dispatch"
+  export GITHUB_EVENT_PATH="$FIXTURES_DIR/repository_dispatch_issue_retry.json"
+
+  run bash "$INTENT_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ "$(_get_env INTENT_TYPE)" = "skip" ]
+  [ "$(_get_env INTENT_REASON)" = "hands-off-label" ]
+}


### PR DESCRIPTION
## Summary

Failed **initial issue implementations** used to stall silently. When a dev-lead `issues`-labeled run failed at the `Run issue` engine step for any non-rate-limit reason, `dev-lead-fix-issue.sh` emitted only a generic `Engine failed to implement issue #N` / `exit 1` — no comment, no marker, no cause — and `dev-lead-retry` only ever scanned **PRs** for `status=rate-limited`. So the issue kept its `dev-lead` label, looked "in progress", and was never retried.

This PR makes failed issue implementations **never-silent, cause-aware, and auto-retried (bounded)**. Closes #781.

### Step 0 — confirmed live root cause (petry-projects/.github#478)
Pulled the failed `Run issue` job log for run `27733022075`. The generic `exit 1` was hiding a **600-second per-tier `timeout` SIGTERM-kill** of the opus 4.8 writer (`02:37:30 → 02:47:30` = a clean 600.2s wall; `[headroom] 0% — ok` rules out rate-limit). `DEEP_TIMEOUT_SEC=600` (`engine.sh:37`), and `124=GNU timeout` is classified transient (`engine.sh:43`). A transient failure with no retry path → permanent stall. Full trace in the [findings comment](https://github.com/petry-projects/.github-private/issues/781#issuecomment-4754132961).

## Phase 1 — never silent, with cause (no caller-interface change)
- **`engine.sh`** — `run_writer_with_fallback` writes a one-line cause class to `/tmp/dev-lead-failure-reason` (`rate-limited` | `missing-binary` | `engine-error`), mirroring the existing rate-limit-reset sidecar. `run_writer`'s redact + persist + `$GITHUB_STEP_SUMMARY` block now runs **before** the rate-limit early-return, so session output is captured for all failure classes.
- **`dev-lead-fix-issue.sh`** — replaces the silent `exit 1` and unifies the rate-limit branch with `handle_engine_failure`: reads cause + reset, computes attempt from prior markers, posts a comment with the cause + run deep-link + redacted 40-line snippet, and applies a decision matrix (`missing-binary` → `dev-lead:needs-human`; retryable & `attempt<MAX` → retryable marker; `attempt≥MAX` → `dev-lead:needs-human`). Exit codes unchanged.

## Phase 2 — bounded auto-retry
- **`dev-lead-retry.sh`** — new `scan_repo_issues` / `scan_issue_for_retry` / `dispatch_issue_retry`: enumerates open `dev-lead` issues (excludes PRs + `dev-lead:needs-human`), reads the newest `<!-- dev-lead-issue N … -->` marker, and re-dispatches `dev-lead-issue-retry` honouring the `reset=` window, `attempt < MAX_ATTEMPTS (3)`, and "skip if an open PR exists". Runs even when a repo has no open PRs.
- **`dev-lead-intent.sh`** — restructured so issue-only dispatch payloads aren't dropped; `dev-lead-issue-retry` routes back to the existing `issue` intent (full-fidelity re-run).
- **`dev-lead.yml`** (thin caller) — adds `dev-lead-issue-retry` to `repository_dispatch.types` (established pattern, allowed per AGENTS.md). **`dev-lead-reusable.yml`** — adds a `client_payload.issue_number → dev-lead-issue-<n>` concurrency lane.

## Tests & docs
- `tests/dev-lead/unit/test_dev_lead_retry.bats` (new, 10 cases — decision matrix + dispatch payload).
- Extended `test_fix_issue.bats` (+4) and `test_engine_fallback.bats` (+5); `test_intent_ci.bats` (+3); new fixture `repository_dispatch_issue_retry.json`; e2e scenario 07 Part I.
- **All 448 dev-lead unit tests pass; shellcheck clean (`--severity=warning -x`); workflow YAML validates.**
- `docs/dev-lead/spec.md`: dispatch table, §7.5 failure matrix, §10.1a issue-retry path.

## Follow-up (separate PR, other repo)
The org-level `standards/ci-standards.md` / `AGENTS.md` in `petry-projects/.github` should document the new `dev-lead-issue-retry` dispatch type and `dev-lead:needs-human` semantics for consumer repos — out of scope for this `.github-private` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added issue-specific retry dispatch with attempt tracking, machine-readable retry markers, and escalation to human review after retries
  * Expanded repository dispatch handling to support new issue-retry events and improved routing for retry scenarios
* **Documentation**
  * Updated the Dev-Lead architecture spec with the new event→intent mapping and failure/retry behavior
* **Tests**
  * Added unit and end-to-end coverage for issue retry scanning, dispatch gating, marker precedence, and engine-failure classification/summary behavior
* **Chores**
  * Updated security scanning configuration to suppress a known token placeholder false positive
<!-- end of auto-generated comment: release notes by coderabbit.ai -->