### PR TITLE
fix(evals): tolerate fenced/wrapped JSON in the deterministic scorer (triage 0/5)

### DIFF
--- a/scripts/evals/run-eval.sh
+++ b/scripts/evals/run-eval.sh
@@ -119,24 +119,39 @@ work_prompt="$(mktemp)"
 work_judge="$(mktemp)"
 trap 'rm -f "$results" "$work_prompt" "$work_judge"' EXIT
 
+# extract_json <raw> — strip markdown code-fence lines so a fenced (```json … ```)
+# or lightly wrapped JSON payload parses as bare JSON. Live Haiku-tier models
+# routinely fence their output despite a "no fences" instruction, which the strict
+# jq parse below would otherwise reject — a null actual for EVERY case (the triage
+# 0/5 production failure, #762). Shared by both scorer modes so they tolerate
+# output identically. `|| true` keeps an all-fence/empty input (grep selects no
+# lines, exit 1) from tripping `set -e`.
+extract_json() { grep -v $'^[[:space:]]*\x60\x60\x60' <<<"$1" || true; }
+
 # score_deterministic <expected_json> <raw_output> <case_id>
 # Equality scorer (triage). Parses the model output; a non-JSON-object output
 # yields a null actual decision (an automatic failure). Every result carries a
 # numeric `score` (1 pass / 0 fail) so the report shape matches the judge mode.
 score_deterministic() {
   local expected="$1" raw="$2" cid="$3"
-  local exp_esc exp_risk actual pass score
+  local exp_esc exp_risk actual pass score cleaned raw_excerpt=""
   exp_esc="$(jq -r '.escalate' <<<"$expected")"
   exp_risk="$(jq -r '.risk' <<<"$expected")"
 
-  # Parse only if the raw output is a single JSON object exposing the decision
-  # fields. Anything else (prose, fences, partial JSON) -> null actual -> fail.
+  # Tolerate markdown-fenced output (strip fences), then parse only if the result
+  # is a single JSON object exposing the decision fields. Anything else (prose,
+  # no JSON object, partial JSON) -> null actual -> fail.
+  cleaned="$(extract_json "$raw")"
   actual="$(jq -ce 'if type=="object" and has("escalate") and has("risk")
-                    then {escalate, risk} else empty end' <<<"$raw" 2>/dev/null || true)"
+                    then {escalate, risk} else empty end' <<<"$cleaned" 2>/dev/null || true)"
 
   if [ -z "$actual" ]; then
     pass=false
     actual=null
+    # Capture a short single-line excerpt of the unparseable output so a blind
+    # null-everywhere failure (engine/format drift) is diagnosable from the
+    # eval-health report instead of needing the (undownloadable) artifact.
+    raw_excerpt="$(printf '%s' "$raw" | tr '\n' ' ' | cut -c1-160)"
   elif [ "$(jq -r '.escalate' <<<"$actual")" = "$exp_esc" ] \
        && [ "$(jq -r '.risk' <<<"$actual")" = "$exp_risk" ]; then
     pass=true
@@ -145,10 +160,13 @@ score_deterministic() {
   fi
   [ "$pass" = true ] && score=1 || score=0
 
+  # raw_excerpt is attached ONLY when the output failed to parse (actual=null), so
+  # passing/mismatch cases keep the lean shape the report and tests expect.
   jq -cn --arg id "$cid" --argjson pass "$pass" --argjson score "$score" \
         --argjson exp_esc "$exp_esc" --arg exp_risk "$exp_risk" \
-        --argjson actual "$actual" \
-        '{id:$id, score:$score, pass:$pass, expected:{escalate:$exp_esc, risk:$exp_risk}, actual:$actual}'
+        --argjson actual "$actual" --arg raw_excerpt "$raw_excerpt" \
+        '{id:$id, score:$score, pass:$pass, expected:{escalate:$exp_esc, risk:$exp_risk}, actual:$actual}
+         + (if $raw_excerpt == "" then {} else {raw_excerpt: $raw_excerpt} end)'
 }
 
 # score_llm_judge <expected_json> <raw_output> <case_id>
@@ -174,7 +192,7 @@ score_llm_judge() {
   # then accept only a single JSON object with a numeric score. A number outside
   # [0,1] is clamped; anything unparseable -> null judge -> score 0 -> fail.
   local cleaned_raw
-  cleaned_raw="$(grep -v $'^[[:space:]]*\x60\x60\x60' <<<"$judge_raw")"
+  cleaned_raw="$(extract_json "$judge_raw")"
   judge_obj="$(jq -ce 'if type=="object" and (.score|type=="number")
                        then {score: ([[.score,0]|max,1]|min), reason: (.reason // null)}
                        else empty end' <<<"$cleaned_raw" 2>/dev/null || true)"

--- a/scripts/evals/run-eval.sh
+++ b/scripts/evals/run-eval.sh
@@ -151,7 +151,8 @@ score_deterministic() {
     # Capture a short single-line excerpt of the unparseable output so a blind
     # null-everywhere failure (engine/format drift) is diagnosable from the
     # eval-health report instead of needing the (undownloadable) artifact.
-    raw_excerpt="$(printf '%s' "$raw" | tr '\n' ' ' | cut -c1-160)"
+    raw_excerpt="${raw//[$'\r\n']/ }"
+    raw_excerpt="${raw_excerpt:0:160}"
   elif [ "$(jq -r '.escalate' <<<"$actual")" = "$exp_esc" ] \
        && [ "$(jq -r '.risk' <<<"$actual")" = "$exp_risk" ]; then
     pass=true

--- a/scripts/evals/run-eval.sh
+++ b/scripts/evals/run-eval.sh
@@ -200,7 +200,7 @@ score_llm_judge() {
   local cleaned_raw
   cleaned_raw="$(extract_json "$judge_raw")"
   judge_obj="$(jq -cse '
-      if length==1 and (.[0]|type=="object" and (.[0].score|type=="number"))
+      if length==1 and (.[0]|type=="object" and (.score|type=="number"))
       then (.[0] | {score: ([[.score,0]|max,1]|min), reason: (.reason // null)})
       else empty
       end

--- a/scripts/evals/run-eval.sh
+++ b/scripts/evals/run-eval.sh
@@ -142,8 +142,13 @@ score_deterministic() {
   # is a single JSON object exposing the decision fields. Anything else (prose,
   # no JSON object, partial JSON) -> null actual -> fail.
   cleaned="$(extract_json "$raw")"
-  actual="$(jq -ce 'if type=="object" and has("escalate") and has("risk")
-                    then {escalate, risk} else empty end' <<<"$cleaned" 2>/dev/null || true)"
+  actual="$(jq -cse '
+      if length==1
+         and (.[0]|type=="object" and has("escalate") and has("risk"))
+      then .[0] | {escalate, risk}
+      else empty
+      end
+    ' <<<"$cleaned" 2>/dev/null || true)"
 
   if [ -z "$actual" ]; then
     pass=false
@@ -194,9 +199,12 @@ score_llm_judge() {
   # [0,1] is clamped; anything unparseable -> null judge -> score 0 -> fail.
   local cleaned_raw
   cleaned_raw="$(extract_json "$judge_raw")"
-  judge_obj="$(jq -ce 'if type=="object" and (.score|type=="number")
-                       then {score: ([[.score,0]|max,1]|min), reason: (.reason // null)}
-                       else empty end' <<<"$cleaned_raw" 2>/dev/null || true)"
+  judge_obj="$(jq -cse '
+      if length==1 and (.[0]|type=="object" and (.[0].score|type=="number"))
+      then (.[0] | {score: ([[.score,0]|max,1]|min), reason: (.reason // null)})
+      else empty
+      end
+    ' <<<"$cleaned_raw" 2>/dev/null || true)"
 
   if [ -z "$judge_obj" ]; then
     judge_obj=null

--- a/tests/test_skill_evals.bats
+++ b/tests/test_skill_evals.bats
@@ -56,6 +56,24 @@ set -euo pipefail
 echo 'This PR looks fine to me, I would approve it.'
 SH
   chmod +x "$STUB_PROSE"
+
+  # Stub engine that wraps its (correct) JSON decision in a ```json markdown
+  # fence — the live Haiku-tier output the strict parser used to reject, which
+  # produced the production triage 0/5 (every case `got null`, #762).
+  STUB_FENCED="$TMP/stub_fenced.sh"
+  cat >"$STUB_FENCED" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+prompt="$1"
+if grep -q MARKER_APPROVE "$prompt"; then
+  printf '```json\n{"escalate": false, "risk": "LOW", "signals": [], "summary": "docs only"}\n```\n'
+elif grep -q MARKER_ESCALATE "$prompt"; then
+  printf '```json\n{"escalate": true, "risk": "HIGH", "signals": ["auth"], "summary": "auth/secrets touched"}\n```\n'
+else
+  echo 'no marker found'
+fi
+SH
+  chmod +x "$STUB_FENCED"
 }
 
 teardown() { rm -rf "$TMP"; }
@@ -68,6 +86,8 @@ teardown() { rm -rf "$TMP"; }
   [ "$(jq '.passed' <<<"$output")" -eq 2 ]
   [ "$(jq '.failed' <<<"$output")" -eq 0 ]
   [ "$(jq '.score'  <<<"$output")" = "1" ]
+  # Passing cases stay lean — no raw_excerpt field.
+  [ "$(jq '.cases[0] | has("raw_excerpt")' <<<"$output")" = "false" ]
 }
 
 @test "per-case results carry id, pass, expected and actual decisions" {
@@ -100,6 +120,22 @@ teardown() { rm -rf "$TMP"; }
   [ "$(jq '.failed' <<<"$output")" -eq 2 ]
   # Unparseable output yields a null actual decision.
   [ "$(jq -r '.cases[0].actual' <<<"$output")" = "null" ]
+  # …and captures a short excerpt of the raw output for diagnosis.
+  [[ "$(jq -r '.cases[0].raw_excerpt' <<<"$output")" == *"would approve it"* ]]
+}
+
+@test "fenced JSON output is tolerated and scored — regression for the live triage 0/5 (#762)" {
+  EVALS_DIR="$TMP/evals" EVAL_ENGINE_CMD="$STUB_FENCED" \
+    run --separate-stderr bash "$SCORER" triage
+  [ "$status" -eq 0 ]
+  [ "$(jq '.passed' <<<"$output")" -eq 2 ]
+  [ "$(jq '.failed' <<<"$output")" -eq 0 ]
+  approve="$(jq -c '.cases[] | select(.id=="case-approve")'  <<<"$output")"
+  [ "$(jq -r '.actual.escalate' <<<"$approve")" = "false" ]
+  [ "$(jq -r '.actual.risk'     <<<"$approve")" = "LOW" ]
+  esc="$(jq -c '.cases[] | select(.id=="case-escalate")' <<<"$output")"
+  [ "$(jq -r '.actual.escalate' <<<"$esc")" = "true" ]
+  [ "$(jq -r '.actual.risk'     <<<"$esc")" = "HIGH" ]
 }
 
 @test "aggregate score is passed/total across a mixed set" {


### PR DESCRIPTION
## Why

`skill-eval-report.yml` has reported **`triage` holdout 0/5 — every held-out case `got null`** — *every day since 2026-06-15* (eval-health tracking issue **#762**). This is a **scorer machinery failure, not a skill regression**, and it silently neutered the Phase-1 eval gate that Phase 3 (the proposer, #753/#787) depends on.

## Root cause

`score_deterministic()` in `scripts/evals/run-eval.sh` parsed the engine output **strictly as a bare JSON object with no markdown-fence stripping**, while the sibling `score_llm_judge()` path already strips fences. `prompts/triage.md` asks for bare JSON, but the live Haiku-tier `run_triage` wraps its decision in a ```json fence anyway — so the strict parse yielded `null` for **every** case. The offline bats tests passed only because their stub emits bare JSON, so CI never reproduced the live-only failure.

Evidence: run [27822776378](https://github.com/petry-projects/.github-private/actions/runs/27822776378) — engine loaded, 5 real model calls, **no auth/rate-limit error**, exit 1, all 5 `got null`.

## What

- **Shared `extract_json()` helper** — strips code-fence lines (`|| true` so an all-fence/empty input can't trip `set -e`), used in **both** scorer paths (deterministic + llm-judge), replacing the judge path's inline `grep`.
- **`raw_excerpt`** — attached to a case result **only** when the output failed to parse (`actual=null`), so the next blind null-everywhere failure is diagnosable straight from eval-health #762 (the raw model output otherwise lives only in the undownloadable artifact).
- **Tests** — new fenced-JSON stub + regression test reproducing the live 0/5; assertions that pure prose still fails (with a captured excerpt) and that passing cases carry no `raw_excerpt`.

No change to `prompts/triage.md` (its contract is already correct — harden the parser, don't fight the model), the workflow, or held-out data.

## Verification

- `shellcheck --severity=warning -x scripts/evals/run-eval.sh` — clean.
- `bats tests/test_skill_evals.bats` — **26/26 pass** (new fenced test green; prose-fails test still holds).
- **Post-merge (the real proof):** dispatch **Skill Eval Report** (skill=`triage`) and read #762 — score should become **> 0**; a genuine per-case miss may now surface (the actual efficacy signal), and on all-pass `notify-eval-health.sh` auto-closes #762.

Refs #762, #583, epic #581.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtKqCFHPEShgswWynw5bbD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened evaluation scoring to accept Markdown-fenced JSON produced by models.
  * Improved failure diagnostics by recording a concise excerpt of unparseable output when scoring can’t determine a decision.
* **Tests**
  * Added regression coverage for fenced JSON handling.
  * Expanded assertions to verify diagnostic fields are present only on parse failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->