### PR TITLE
fix(dev-lead): repair auto-rebase conflict detection and applied-rate signal

### DIFF
--- a/prompts/dev-lead/rebase.md
+++ b/prompts/dev-lead/rebase.md
@@ -9,9 +9,11 @@ You are the dev-lead agent for the `${REPO}` repository. A pull request has merg
 - **Head Branch:** `${HEAD_REF}`
 - **Base Branch:** `${BASE_REF}`
 
-## Conflicting Files
+## Conflicting Files (advisory)
 
-The following files have merge conflicts:
+These files are *likely* to conflict — best-effort detection that may be empty,
+incomplete, or stale. Treat it as a hint, not an authoritative set; resolve
+whatever `git rebase` actually reports as conflicted.
 
 ```
 ${CONFLICTING_FILES}
@@ -37,7 +39,7 @@ Resolve the merge conflicts and rebase the branch onto `${BASE_REF}`:
 - Never silently drop code from either side — if both sides add code to the same location, merge them intelligently
 - Do not squash or otherwise rewrite the PR commit history beyond rebasing
 - If a conflict cannot be resolved safely, abort the rebase and comment on the PR explaining why
-- Only modify the conflicting files listed above — do not touch other files during conflict resolution
+- Limit edits to files that `git rebase` actually flags as conflicted. The advisory list above is only a hint — never skip a real conflict just because its file is not listed, and do not edit files that are not genuinely in conflict
 
 ## Output Format
 

--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -657,6 +657,20 @@ commit_and_push() {
   return 0
 }
 
+# detect_conflicting_paths <base_ref> — list paths that conflict when merging
+# origin/<base_ref> into the current HEAD, one per line. Uses a trial merge
+# (immediately aborted) because it is robust across git versions: the former
+# `git merge-tree <base> HEAD <base>` 3-arg form prints a "changed in both"
+# section header whose last field is the literal word "both" (the filename is on
+# the indented our/their lines), so `awk '{print $NF}'` produced a bogus "both"
+# path that was fed to the rebase prompt. Leaves the worktree clean.
+detect_conflicting_paths() {
+  local base="$1"
+  git merge --no-commit --no-ff "origin/${base}" >/dev/null 2>&1 || true
+  git diff --name-only --diff-filter=U || true
+  git merge --abort >/dev/null 2>&1 || true
+}
+
 # expire_stale_terminal_markers: deletes any existing terminal comments (applied,
 # no-changes, or failed) for this SHA+intent before a hard-blocker retry marker is
 # posted. Without this, the retry cron sees a stale terminal and skips re-dispatch
@@ -1053,16 +1067,28 @@ case "$INTENT_TYPE" in
       exit 1
     fi
     git fetch origin "$BASE_REF"
-    CONFLICTING_FILES=$(git merge-tree "$(git merge-base HEAD "origin/${BASE_REF}")" HEAD "origin/${BASE_REF}" 2>/dev/null | grep "^changed in both" | awk '{print $NF}' || true)
+    CONFLICTING_FILES=$(detect_conflicting_paths "$BASE_REF")
     export CONFLICTING_FILES
     rc=0
     build_and_run "rebase" || rc=$?
     [ "$rc" -eq 2 ] && handle_rate_limit "rebase"
     if [ "$rc" -eq 0 ]; then
       if commit_and_push "rebase"; then
+        # Engine left commits/changes for the script to push — resolution applied.
         post_reviews_terminal "rebase" "applied" "Rebase completed and pushed."
       else
-        post_no_changes "rebase"
+        # The rebase prompt has the engine force-push the rebased branch itself
+        # (rebase.md step 6), so commit_and_push finds nothing to push on success.
+        # Relying on it alone recorded EVERY successful rebase as "no-changes"
+        # (0% applied — discussion #735 telemetry). Distinguish a real resolution
+        # (no conflicts remain against the base) from an abort/no-op (conflicts
+        # persist) by re-checking the base conflict state after the run.
+        git fetch origin "$BASE_REF" >/dev/null 2>&1 || true
+        if [ -z "$(detect_conflicting_paths "$BASE_REF")" ]; then
+          post_reviews_terminal "rebase" "applied" "Rebase completed and pushed."
+        else
+          post_no_changes "rebase"
+        fi
       fi
     fi
     exit "$rc"

--- a/scripts/dev-lead-fix-reviews.sh
+++ b/scripts/dev-lead-fix-reviews.sh
@@ -666,6 +666,7 @@ commit_and_push() {
 # path that was fed to the rebase prompt. Leaves the worktree clean.
 detect_conflicting_paths() {
   local base="$1"
+  [[ -z "$base" ]] && return 0
   git merge --no-commit --no-ff "origin/${base}" >/dev/null 2>&1 || true
   git diff --name-only --diff-filter=U || true
   git merge --abort >/dev/null 2>&1 || true


### PR DESCRIPTION
## Why

The #737 auto-rebase health report (tracking issue #767) shows **0% applied** every day despite 50–86 conflict sentinels/week and ~70% "responses". Investigation (discussion #735) found the agentic conflict-resolution path is both **mis-instrumented** and carrying a **real conflict-detection bug** — so "0% applied" was not a clean signal that resolution fails, but it *was* hiding genuine breakage.

## Root cause

1. **Bogus conflict-file detection.** `scripts/dev-lead-fix-reviews.sh` used the deprecated 3-arg `git merge-tree <base> HEAD <base>` and parsed it with `grep "^changed in both" | awk '{print $NF}'`. The last field of the `changed in both` **section header** is the literal word `both` — the filenames are on the indented `our`/`their` lines. So `CONFLICTING_FILES` was set to `both` (a nonexistent path) on every conflict.
2. **Prompt then weaponized the garbage.** `prompts/dev-lead/rebase.md` injected that list and constrained the engine to *"only modify the conflicting files listed above"* — i.e. only `both` — so the engine couldn't touch the actually-conflicted files and aborted → `no-changes`.
3. **`applied` was structurally unreachable.** The prompt has the engine force-push the rebased branch itself (step 6), so on success `commit_and_push` finds nothing to push and posts `no-changes`. `status=applied` only fired if the engine committed but forgot to push — so **even successful rebases were recorded as `no-changes`**, making the metric ~0 by construction.

## Changes

- **`scripts/dev-lead-fix-reviews.sh`**
  - New `detect_conflicting_paths <base_ref>` helper: version-robust trial merge (`git merge --no-commit --no-ff` → `git diff --name-only --diff-filter=U` → `git merge --abort`).
  - Rebase path uses it for `CONFLICTING_FILES`, and after a successful run re-checks the base conflict state to record `applied` (no conflicts remain) vs `no-changes` (conflicts persist) instead of relying on `commit_and_push` seeing leftover work.
- **`prompts/dev-lead/rebase.md`**
  - Conflicting-file list is now **advisory** (may be empty/incomplete/stale); the engine is told to resolve whatever `git rebase` actually flags and not to skip a real conflict just because it isn't listed.

## Verification

- `shellcheck --severity=warning -x scripts/dev-lead-fix-reviews.sh` — clean.
- `bats tests/dev-lead/unit/test_fix_reviews.bats` (86), `test_intent_reviews.bats`, `test_auto_rebase_retry.bats` — pass.
- `tests/dev-lead/integration/test_prompt_coverage.sh` — pass (rebase.md variable declarations intact).

## Note for the initiative (epic #736 / story #739)

This corrects the premise behind the earlier "0% applied" reading: that number was **not** evidence that agentic conflict-resolution is non-functional — it was a measurement artifact plus the detection bug. Story #739's decision record should source resolution-rate numbers from the **post-fix** report window, not the broken metric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QrRBgQJ7QqjMsRySzkPqwJ)_