### PR TITLE
pr-review: enable the downstream-impact pass (default-on + kill switch)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -178,6 +178,12 @@ jobs:
       # server yet blocks the tool calls ("not permitted"); set the repo variable
       # REVIEW_MCP_ALLOWED_TOOLS (e.g. `mcp__github__*`) to permit them.
       REVIEW_MCP_ALLOWED_TOOLS: ${{ vars.REVIEW_MCP_ALLOWED_TOOLS || '' }}
+      # Downstream-impact pass (epic #748 / discussion #653): annotate a review
+      # with the consumer repos that pin a shared surface the PR changes. Enabled
+      # by default here; set the repo variable DOWNSTREAM_IMPACT_ENABLED=false to
+      # kill-switch it without a code change. Operator guide:
+      # docs/pr-review-agent/downstream-impact.md.
+      DOWNSTREAM_IMPACT_ENABLED: ${{ vars.DOWNSTREAM_IMPACT_ENABLED || 'true' }}
       # Pin via vars.CLAUDE_CODE_VERSION for fully reproducible caching; default
       # 'latest' caches an install indefinitely under that key — flush via the
       # Actions cache UI or bump the variable to pick up new releases.


### PR DESCRIPTION
## Why

The downstream-impact pass (epic #748, discussion #653) shipped **default-off**: `review-one-pr.sh` reads `DOWNSTREAM_IMPACT_ENABLED`, but **no workflow set it**, so the feature was dormant in production. This wires it on.

## What

One line in the pr-review job env:

```yaml
DOWNSTREAM_IMPACT_ENABLED: ${{ vars.DOWNSTREAM_IMPACT_ENABLED || 'true' }}
```

- **On by default** — active for every PR this review job processes, as requested.
- **No-code kill switch** — because it runs on *every* review org-wide, set a repo Actions variable `DOWNSTREAM_IMPACT_ENABLED=false` to disable instantly without a revert PR. (If you'd rather it be a literal hardcoded `"true"` with no variable, say so and I'll drop the `vars.` fallback.)

Prerequisites are already in place: the consumer manifest (`scripts/lib/consumer-manifest.json`) is populated, and this job already carries the `GH_PAT` cross-repo read used by the fetch step. When a PR touches no shared surface, the pass is a no-op (`(none)`), so enabling it is low-blast-radius.

## Verification

- Downstream-impact offline suite passes on `main` (mapper, assembler, **flag-on triage inlining**, regression guard).
- `pr-review.yml` YAML parses; the only change is the additive env var.
- Live verification to follow per the test plan in the PR thread (a PR touching a shared surface should now show a **Downstream impact** section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014djuNDBa3GASVDLQPXXg9L

---
_Generated by [Claude Code](https://claude.ai/code/session_014djuNDBa3GASVDLQPXXg9L)_