### PR TITLE
pr-review: dogfood ring-0 on @pr-review/next (self-host canary)

### DIFF
--- a/.github/workflows/pr-review-trigger.yml
+++ b/.github/workflows/pr-review-trigger.yml
@@ -3,18 +3,23 @@ name: PR Review Agent — Trigger
 # Thin trigger stub for .github-private's OWN pr-review duty (ring 0 / self-host).
 #
 # It fires on the review events and invokes the reusable pinned to
-# `pr-review.yml@pr-review/stable`, passing `agent_ref: pr-review/stable` so the
-# agent's scripts (engine.sh, review-one-pr.sh, …) also run at the pinned
-# version. The result: this repo's PRs are always reviewed by the known-good
-# `stable` release, independent of whatever pr-review.yml is on the branch under
-# review — which is what breaks the self-hosting circular dependency (#497).
+# `pr-review.yml@pr-review/next`, passing `agent_ref: pr-review/next` so the
+# agent's scripts (engine.sh, review-one-pr.sh, …) also run at the same channel.
+# Per the ring strategy (docs/initiatives/agentic-release-strategy.md §5),
+# .github-private is the ring-0 canary: it dogfoods the `next` channel so a new
+# pr-review release is exercised on this repo's own PRs before it is promoted to
+# `pr-review/stable` (the fleet). The pin is independent of whatever pr-review.yml
+# is on the branch under review — which is what breaks the self-hosting circular
+# dependency (#497).
 #
 # pr-review.yml itself is reusable-only; this stub owns the triggering. The
 # @mention flow (pr-review-mention.yml -> org reusable -> repository_dispatch)
 # still lands on the repository_dispatch trigger below.
 #
-# To promote a new pr-review version, move the pr-review/stable channel tag
-# (scripts/cut-release.sh … --channel stable). This file never changes.
+# Rollout is driven by central tag moves (scripts/cut-release.sh … --channel):
+# cut a release and advance `next` to dogfood here, then advance `stable` to
+# promote to the fleet once this ring proves healthy. This file only changes when
+# the ring-0 channel itself changes (e.g. next <-> stable).
 
 on:
   check_suite:
@@ -53,11 +58,7 @@ permissions:
 
 jobs:
   review:
-    # Ring 0 (canary): .github-private dogfoods the `next` channel before a
-    # release is promoted to `pr-review/stable` (the fleet). Per the ring strategy
-    # (docs/initiatives/agentic-release-strategy.md §5), self-host runs `next` so
-    # regressions surface here first. Promotion to `stable` is a central tag move
-    # after this ring proves healthy.
+    # Ring-0 channel — see the header block for the dogfooding rationale.
     uses: petry-projects/.github-private/.github/workflows/pr-review.yml@pr-review/next
     with:
       # Pin the agent's own script checkout to the same channel (#506).

--- a/.github/workflows/pr-review-trigger.yml
+++ b/.github/workflows/pr-review-trigger.yml
@@ -53,10 +53,15 @@ permissions:
 
 jobs:
   review:
-    uses: petry-projects/.github-private/.github/workflows/pr-review.yml@pr-review/stable
+    # Ring 0 (canary): .github-private dogfoods the `next` channel before a
+    # release is promoted to `pr-review/stable` (the fleet). Per the ring strategy
+    # (docs/initiatives/agentic-release-strategy.md §5), self-host runs `next` so
+    # regressions surface here first. Promotion to `stable` is a central tag move
+    # after this ring proves healthy.
+    uses: petry-projects/.github-private/.github/workflows/pr-review.yml@pr-review/next
     with:
       # Pin the agent's own script checkout to the same channel (#506).
-      agent_ref: pr-review/stable
+      agent_ref: pr-review/next
       # Forward manual/dispatch inputs; empty for event triggers (the reusable
       # then derives everything from the inherited github.event context).
       pr_url: ${{ inputs.pr_url || '' }}


### PR DESCRIPTION
## Why

Enabling the downstream-impact pass (#748 / #815) should roll out **ring-by-ring**, not fleet-wide at once. Per `docs/initiatives/agentic-release-strategy.md` §5, **Ring 0 = `.github-private` self-host runs `@pr-review/next`**; a release only reaches `@pr-review/stable` (the fleet) after the ring-0 soak proves healthy.

Today the self-host trigger pins `@pr-review/stable`, so there is **no canary** — there's no way to dogfood a new pr-review version on this repo before everyone gets it.

## What

Repin `pr-review-trigger.yml` (this repo's own review caller) from `@pr-review/stable` → **`@pr-review/next`** (workflow + `agent_ref`). That makes `.github-private` the ring-0 canary: its own PR reviews run `next` first.

This is the code half of enabling downstream-impact via the ring approach; the tag operations are the other half (below).

## ⚠️ Merge ordering (the `next` tag must exist first)

`@pr-review/next` must resolve, or self-host reviews break. These tag ops are **OrgAdmin/automation-gated** (an agent on `GITHUB_TOKEN` is 403-blocked by the `pr-review/**` ruleset), so they're yours:

```bash
# 1. Immutable release at current main (carries DOWNSTREAM_IMPACT_ENABLED)
scripts/cut-release.sh pr-review 1.7.0 --ref origin/main --push
# 2. Point ring-0 (next) at it
git tag -f pr-review/next pr-review/v1.7.0 && git push -f origin pr-review/next
# 3. THEN merge this PR
# 4. Dogfood on .github-private PRs; verify the “Downstream impact” annotation
# 5. After a healthy soak, promote to the fleet:
git tag -f pr-review/stable pr-review/v1.7.0 && git push -f origin pr-review/stable
```

## Live test (after this lands on `next`)

Open a PR here touching a mapped shared surface (e.g. a comment-only edit to `scripts/lib/ci-status.sh`, which `pr-review.yml`'s `surface_sources` lists). The verdict should then carry a **Downstream impact** section naming consumer repos. I'll drive and verify that once `next` is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014djuNDBa3GASVDLQPXXg9L

---
_Generated by [Claude Code](https://claude.ai/code/session_014djuNDBa3GASVDLQPXXg9L)_