### PR TITLE
revert(dogfood): clean up ci-status.sh comment + re-prove downstream-impact

### DIFF
--- a/scripts/lib/ci-status.sh
+++ b/scripts/lib/ci-status.sh
@@ -4,9 +4,6 @@
 # blocks on itself (issue #469).
 #
 # Usage: source this file, then call compute_ci_status with the rollup array.
-#
-# (Ring-0 dogfood: comment-only touch to exercise the downstream-impact pass on
-# the `next` channel — see PR description. Safe to revert.)
 
 # compute_ci_status <rollup_json>
 #


### PR DESCRIPTION
## Two birds

1. **Cleanup:** removes the throwaway `Ring-0 dogfood` comment that merged via #850 into the shared lib `scripts/lib/ci-status.sh`. The diff restores the file to its pre-dogfood state exactly.
2. **Re-prove:** this revert is itself a comment-only change to `ci-status.sh` — a `surface_source` of `.github/workflows/pr-review.yml` — so it doubles as the **retry dogfood** for the downstream-impact pass (#748 / #815), now live on `@pr-review/next`.

## Why a retry was needed

#850 merged before its verdict rendered: the review job kept getting **cancelled by dev-lead's auto-rebase churn** (main was very active). This PR is labeled **`dev-lead:hands-off`** so dev-lead skips it and the `review / review` job can run to completion uninterrupted.

## Expected verdict annotation

`compute_downstream_impact` (deterministic, unit-tested) predicts the agent's verdict should carry a **Downstream impact** section naming:

- **Surface:** `.github/workflows/pr-review.yml`
- **Consumers (5):** `petry-projects/.github-private`, `petry-projects/ContentTwin`, `petry-projects/bmad-bgreat-suite`, `petry-projects/google-app-scripts`, `petry-projects/markets`

The dogfood **passes** when that section appears in the self-host agent's review. Safe to merge on its own merits (it's a clean revert).

https://claude.ai/code/session_014djuNDBa3GASVDLQPXXg9L

---
_Generated by [Claude Code](https://claude.ai/code/session_014djuNDBa3GASVDLQPXXg9L)_