### PR TITLE
ci(dev-lead): pin self-host caller to @dev-lead/next (canary)

### DIFF
--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -48,9 +48,9 @@ jobs:
     # fix (the circular dependency). Promotion = moving the dev-lead/stable tag
     # centrally; this caller is never edited on release. agent_ref pins the
     # dev-lead scripts/prompts checkout to the same channel.
-    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable
+    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/next
     with:
-      agent_ref: dev-lead/stable
+      agent_ref: dev-lead/next
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
Canary rollout of dev-lead **v1.4.0** (the #781 release + accumulated main).

Pins this repo's self-host dev-lead caller to the new **`dev-lead/next`** channel (candidate/green channel per [versioning.md](docs/release/versioning.md) Phase 2). `dev-lead/next` → `dev-lead/v1.4.0` (= main HEAD `ded84ce4`).

Staged ring plan (channels all cut at v1.4.0; `stable` untouched):
- **.github-private → `next`** (this PR — canary)
- petry-projects/.github → `ring0`
- TalkTerm → `ring1`
- everyone else → `stable` (unchanged, old version)

Trigger-only stub change; rollback is a central tag move (no caller edit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)