### PR TITLE
feat: S6 stale-base guards — test-deletion CI signal + fleet pipeline docs

### DIFF
--- a/.github/workflows/test-deletion-guard.yml
+++ b/.github/workflows/test-deletion-guard.yml
@@ -1,0 +1,58 @@
+# Test-Deletion Guard — flag PRs that delete test files for explicit human ack.
+#
+# Rationale (#655): a PR merged from a stale base silently reverted a shipped fix
+# AND deleted its regression test in the same diff — so CI stayed green because
+# the guard test was gone. This check fails when a PR deletes any file under
+# tests/ unless a maintainer adds the `ack-test-deletion` label, turning a silent
+# test removal into a deliberate, reviewable decision.
+#
+# Pairs with the "require branches up to date before merging" ruleset (the other
+# half of the #655 prevention) — see AGENTS.md.
+name: Test-Deletion Guard
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: test-deletion-guard-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Flag deleted test files (acknowledge via the `ack-test-deletion` label)
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          ACK: ${{ contains(github.event.pull_request.labels.*.name, 'ack-test-deletion') }}
+        run: |
+          set -euo pipefail
+          deleted="$(git diff --diff-filter=D --name-only "$BASE_SHA" "$HEAD_SHA" -- 'tests/' || true)"
+          if [ -z "$deleted" ]; then
+            echo "No files deleted under tests/. OK."
+            exit 0
+          fi
+          echo "::warning title=Test files deleted::This PR deletes file(s) under tests/:"
+          printf '%s\n' "$deleted"
+          if [ "$ACK" = "true" ]; then
+            echo "::notice::Deletion acknowledged via the 'ack-test-deletion' label."
+            exit 0
+          fi
+          {
+            echo "::error title=Unacknowledged test deletion::This PR deletes test file(s) under tests/ without acknowledgement."
+            echo "A maintainer must add the 'ack-test-deletion' label to confirm the removal is intentional."
+            echo "Guard rationale (#655): a stale-base PR once reverted a shipped fix AND deleted its regression test in the same diff — CI stayed green because the guard was gone."
+          } >&2
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,12 @@ This is the `.github-private` org infrastructure repo for `petry-projects`. It c
   workflow with no corresponding org template in `standards/workflows/`. It must not be removed by template
   syncs. If the org template gains a token-report equivalent, remove this exception and defer to the
   template instead.
+- **Exception:** `test-deletion-guard.yml` (#823) is a documented repo-specific workflow with no org template.
+  It is one half of the #655 **stale-base / semantic-revert** guard: it fails a PR that deletes any file under
+  `tests/` unless a maintainer adds the `ack-test-deletion` label, so a silent test removal becomes a deliberate,
+  reviewable decision. The other half is the **"require branches up to date before merging"** ruleset on `main`
+  (already enabled). Together they close the gap behind #655, where a PR merged from a stale base reverted a
+  shipped fix and deleted its regression test in the same green-CI diff. Do not remove either guard.
 - **Exception:** `pr-review-sweep.yml` (scheduled stuck-review sweep, #573) is a documented repo-specific
   workflow with no corresponding org template in `standards/workflows/`. It re-dispatches reviews for PRs
   that went green after a ci-pending/ci-failing skip. It must not be removed by template syncs. If the org

--- a/docs/initiatives/idea-to-initiative-pipeline.md
+++ b/docs/initiatives/idea-to-initiative-pipeline.md
@@ -137,8 +137,7 @@ unit-tested.
 
 The pipeline runs for any BMAD-enabled org repo, not just this one. The BMAD
 frameworks, the planner, and the triage/enhancer tooling stay vendored **once**
-here; each fleet repo ships only thin **caller stubs**
-(`petry-projects/.github/standards/workflows/{initiative-planner,idea-triage,idea-enhancer}.yml`).
+here; each fleet repo ships only thin **caller stubs** (copied from petry-projects/.github/standards/workflows/{initiative-planner,idea-triage,idea-enhancer}.yml into their local .github/workflows/ directory).
 
 ```
 fleet repo: ★ human adds idea:approved to an Ideas Discussion

--- a/docs/initiatives/idea-to-initiative-pipeline.md
+++ b/docs/initiatives/idea-to-initiative-pipeline.md
@@ -132,3 +132,39 @@ unit-tested.
   (enforced by `tests/test_initiative_planner.bats`).
 - **DAG is validated** (acyclic, has an entry point, no dangling edges) before
   any issue is created.
+
+## Fleet enablement (any org repo)
+
+The pipeline runs for any BMAD-enabled org repo, not just this one. The BMAD
+frameworks, the planner, and the triage/enhancer tooling stay vendored **once**
+here; each fleet repo ships only thin **caller stubs**
+(`petry-projects/.github/standards/workflows/{initiative-planner,idea-triage,idea-enhancer}.yml`).
+
+```
+fleet repo: ★ human adds idea:approved to an Ideas Discussion
+   │
+   ▼
+initiative-planner.yml (stub) ──> initiative-planner-reusable.yml (@initiative-planner/stable)
+   │   (claude-code-action can't run on `discussion` events, so the reusable
+   │    re-DISPATCHES the central planner instead of planning inline)
+   ▼
+petry-projects/.github-private  initiative-planner.yml  -f target_repo=<fleet repo> -f dry_run=false
+   │   reads the fleet repo's Discussion, writes the epic + DAG THERE
+   │   (cross-repo writes use GH_PAT_WORKFLOWS; self path uses GITHUB_TOKEN)
+   ▼
+inert epic + story DAG in the fleet repo  ──> ★ human adds initiative:auto ──> driver ──> dev-lead
+```
+
+- **`target_repo`** parameterizes the central planner/triage/enhancer; empty ⇒ the
+  dogfood/self path (`.github-private` plans its own Discussions), non-empty ⇒ the
+  named fleet repo.
+- **Project-board funnel (hybrid):** epics in **consumer (fleet) repos** land on
+  that repo's own project; epics in **`petry-projects/.github` and
+  `petry-projects/.github-private`** land on the org-level "Initiatives" project
+  (`orgs/petry-projects/projects/1`).
+- **Regression detection:** `initiative-planner-canary.yml` smoke-tests the live
+  `idea:approved` → dispatch path, and Fleet Monitor watches each adopted stub for
+  drift — so a silent revert of the trigger (the [#655](https://github.com/petry-projects/.github-private/issues/655)
+  class) surfaces immediately rather than on a maintainer noticing nothing planned.
+- **Adoption + the full enrollment runbook:** see
+  `petry-projects/.github` → `standards/ci-standards.md` §10 (Idea → Initiative pipeline).


### PR DESCRIPTION
## Summary
Implements **S6 (#823)** — the test-deletion half of the #655 stale-base / semantic-revert prevention — plus the fleet pipeline-doc update.

- **`test-deletion-guard.yml`** — fails a PR that deletes any file under `tests/` unless a maintainer adds the **`ack-test-deletion`** label (label created). Turns a silent test removal into a deliberate, reviewable decision.
- **AGENTS.md** — documents both #655 guards: this signal + the already-enabled *"require branches up to date before merging"* ruleset on `main` (#655 prevention item 1, confirmed in place).
- **`docs/initiatives/idea-to-initiative-pipeline.md`** — adds the **Fleet enablement** section: per-repo stub → central dispatch topology, `target_repo`, the hybrid board funnel (consumer → repo project; `.github`/`.github-private` → org project #1), and canary/monitor coverage.

## Context
Closes the gap behind #655, where a PR merged from a stale base reverted a shipped fix **and** deleted its regression test in the same diff — CI stayed green because the guard was gone.

Closes #823. Refs #817, #824, #825.

🤖 Generated with [Claude Code](https://claude.com/claude-code)