### PR TITLE
feat(release): health-gated ring promotion automation — canary-rollout (#501/#502)

### DIFF
--- a/.github/workflows/canary-rollout.yml
+++ b/.github/workflows/canary-rollout.yml
@@ -1,0 +1,97 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Canary Rollout — ring-staged, health-gated promotion of agent releases by moving
+# channel tags only. Initiative #495 · issues #501 (promotion) / #502 (rollback).
+#
+# The ONLY mutation this performs is moving a channel tag (`git tag -f` + push).
+# It never writes consumer files. The mover credential is GH_PAT_WORKFLOWS (the
+# existing cross-org write PAT), NOT GITHUB_TOKEN — so the protected channel-tag
+# ruleset can scope its bypass to this workflow's identity (see #868).
+#
+#   - schedule (every 4h): read-only `evaluate` ONLY — emits the per-version gate
+#     + health report (#502 observability). Never promotes on the timer.
+#   - workflow_dispatch: `evaluate` | `promote` | `rollback`, human-gated.
+# ─────────────────────────────────────────────────────────────────────────────
+name: Canary Rollout
+
+on:
+  schedule:
+    - cron: "0 */4 * * *"   # every 4 hours — evaluate only
+  workflow_dispatch:
+    inputs:
+      command:
+        description: "evaluate (read-only) | promote (gated tag move) | rollback"
+        type: choice
+        options: [evaluate, promote, rollback]
+        default: evaluate
+      agent:
+        description: "agent to act on"
+        type: choice
+        options: [dev-lead]
+        default: dev-lead
+      override:
+        description: "promote: advance even if the gate is not PROMOTE (records a warning)"
+        type: boolean
+        default: false
+      dry_run:
+        description: "promote/rollback: show the tag move but do not push"
+        type: boolean
+        default: true
+      ring:
+        description: "rollback: which ring channel to move (e.g. ring1, stable)"
+        type: string
+        default: ""
+      to:
+        description: "rollback: target immutable release (e.g. v1.3.0)"
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: canary-rollout-${{ github.event.inputs.agent || 'dev-lead' }}
+  cancel-in-progress: false
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout (with tags)
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          # Mover identity: GH_PAT_WORKFLOWS so pushing protected channel tags is
+          # authorized under the release-channel-tags ruleset bypass (#868).
+          token: ${{ secrets.GH_PAT_WORKFLOWS || github.token }}
+
+      - name: Run canary-rollout
+        env:
+          # On the 4h timer, force read-only evaluate — never promote on a schedule.
+          CMD: ${{ github.event_name == 'schedule' && 'evaluate' || github.event.inputs.command }}
+          AGENT: ${{ github.event.inputs.agent || 'dev-lead' }}
+          OVERRIDE: ${{ github.event.inputs.override }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          RING: ${{ github.event.inputs.ring }}
+          TO: ${{ github.event.inputs.to }}
+          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS || github.token }}
+        run: |
+          set -euo pipefail
+          args=()
+          case "$CMD" in
+            evaluate) args=(evaluate "$AGENT") ;;
+            promote)
+              args=(promote "$AGENT")
+              [ "$OVERRIDE" = "true" ] && args+=(--override)
+              [ "$DRY_RUN" != "false" ] && args+=(--dry-run)   # default-safe: dry unless explicitly false
+              ;;
+            rollback)
+              [ -n "$RING" ] && [ -n "$TO" ] || { echo "::error::rollback needs ring + to"; exit 2; }
+              args=(rollback "$AGENT" "$RING" --to "$TO")
+              [ "$DRY_RUN" != "false" ] && args+=(--dry-run)
+              ;;
+            *) echo "::error::unknown command: $CMD"; exit 2 ;;
+          esac
+          echo "::notice::canary-rollout ${args[*]}"
+          bash scripts/canary-rollout.sh "${args[@]}"

--- a/.github/workflows/canary-rollout.yml
+++ b/.github/workflows/canary-rollout.yml
@@ -87,7 +87,7 @@ jobs:
               [ "$DRY_RUN" != "false" ] && args+=(--dry-run)   # default-safe: dry unless explicitly false
               ;;
             rollback)
-              [ -n "$RING" ] && [ -n "$TO" ] || { echo "::error::rollback needs ring + to"; exit 2; }
+              if [ -z "$RING" ] || [ -z "$TO" ]; then echo "::error::rollback needs ring + to"; exit 2; fi
               args=(rollback "$AGENT" "$RING" --to "$TO")
               [ "$DRY_RUN" != "false" ] && args+=(--dry-run)
               ;;

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,6 +44,7 @@ jobs:
           scripts/run-bats.sh \
             tests/fleet_report.bats \
             tests/fleet_stub_drift.bats \
+            tests/canary_rollout.bats \
             tests/test_initiative_canary.bats \
             tests/token_report.bats \
             tests/lsp_pilot_compare.bats \

--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# canary-rollout.sh — ring-staged, health-gated promotion of agent releases by
+# moving channel tags only (initiative #495, issue #501; rollback/observability #502).
+#
+# The ONLY action this performs is moving a channel tag (`git tag -f <agent>/<ring>
+# <vX.Y.Z-commit> && git push -f`) — it never writes consumer files. A ring advances
+# only when the rings already on the candidate pass the soak/health gate (see
+# scripts/lib/canary-rollout.sh for the pure decision core).
+#
+# Channel tags ARE the rollout state (#502): the frontier is derived from where each
+# channel tag resolves; there is no separate state store.
+#
+# Usage:
+#   canary-rollout.sh evaluate <agent>                 # read-only gate + health report (also the #502 report)
+#   canary-rollout.sh promote  <agent> [--override] [--dry-run]
+#   canary-rollout.sh rollback <agent> <ring> --to <vX.Y.Z> [--dry-run]
+#   canary-rollout.sh resolve  <agent> <channel>       # debug: print resolved member repos
+#
+# Env:
+#   CANARY_RINGS        path to ring SoT (default: standards/canary-rings.json next to this repo)
+#   SOAK_WINDOW_DAYS    trailing window for the health gate (default 7)
+#   GH_TOKEN / GH_PAT_WORKFLOWS   credential; the workflow passes GH_PAT_WORKFLOWS as the mover
+
+_HERE="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=lib/canary-rollout.sh
+source "${_HERE}/lib/canary-rollout.sh"
+DEFAULT_RINGS="$(cd "${_HERE}/.." && pwd)/standards/canary-rings.json"
+CANARY_RINGS="${CANARY_RINGS:-$DEFAULT_RINGS}"
+
+_jq()  { jq "$@" "$CANARY_RINGS"; }
+_agent_field() { _jq -r --arg a "$1" ".agents[\$a].$2"; }
+
+# ordered_channels <agent> — e.g. "next,ring0,ring1,stable"
+ordered_channels() {
+  _jq -r --arg a "$1" '.agents[$a].rings | sort_by(.order) | map(.channel) | join(",")'
+}
+
+# resolve_members <agent> <channel> — print the member repos, expanding the
+# host-relative tokens $host / $org_infra / * (one repo per line).
+resolve_members() {
+  local agent="$1" channel="$2" host t r
+  host="$(_agent_field "$agent" host)"
+  while IFS= read -r t; do
+    [ -z "$t" ] && continue
+    case "$t" in
+      '$host') printf '%s\n' "$host" ;;
+      '$org_infra')
+        while IFS= read -r r; do
+          if [ "$r" != "$host" ]; then printf '%s\n' "$r"; fi
+        done < <(_jq -r '.org_infra_repos[]') ;;
+      '*') printf '%s\n' '*' ;;
+      *) printf '%s\n' "$t" ;;
+    esac
+  done < <(_jq -r --arg a "$agent" --arg c "$channel" \
+            '.agents[$a].rings[] | select(.channel==$c) | .members[]')
+  return 0
+}
+
+# channel_commit <agent> <channel> — commit a channel tag resolves to (short-circuits
+# to empty if the tag does not exist).
+channel_commit() {
+  git rev-parse -q --verify "refs/tags/$1/$2^{commit}" 2>/dev/null \
+    || git rev-parse -q --verify "$1/$2^{commit}" 2>/dev/null || true
+}
+
+# ring_health <agent> <repo...> — aggregate run health over the trailing soak window
+# across the given member repos. Prints "<healthy> <failures> <total>" where healthy =
+# success, failures = failure, total = healthy+failures (skipped/cancelled are noise,
+# excluded — consistent with the canary classification in #781).
+ring_health() {
+  local agent="$1"; shift
+  local wf since healthy=0 fail=0 repo json
+  wf="$(_agent_field "$agent" run_workflow)"
+  since="$(date -u -d "-${SOAK_WINDOW_DAYS:-7} days" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")"
+  for repo in "$@"; do
+    [ "$repo" = '*' ] && continue
+    json="$(gh run list --repo "$repo" --workflow "$wf" ${since:+--created ">=$since"} \
+              -L 300 --json conclusion 2>/dev/null || echo '[]')"
+    healthy=$(( healthy + $(printf '%s' "$json" | jq '[.[]|select(.conclusion=="success")]|length' 2>/dev/null || echo 0) ))
+    fail=$(( fail + $(printf '%s' "$json" | jq '[.[]|select(.conclusion=="failure")]|length' 2>/dev/null || echo 0) ))
+  done
+  echo "$healthy $fail $(( healthy + fail ))"
+}
+
+# _frontier_state <agent> — compute the rollout frontier and gate, echoing:
+#   "<candidate_commit> <frontier_channel> <state> <healthy> <min_healthy> <cand‰> <base‰>"
+# frontier = first ring (after next) not yet on the candidate commit.
+_frontier_state() {
+  local agent="$1"
+  local cand chans frontier="" prev_on=()
+  cand="$(channel_commit "$agent" next)"
+  chans="$(ordered_channels "$agent")"
+
+  # Collect the rings already on the candidate (starting at next) and find the frontier.
+  local IFS=,
+  local ch
+  for ch in $chans; do
+    local c; c="$(channel_commit "$agent" "$ch")"
+    if [ "$ch" = "next" ] || [ "$c" = "$cand" ]; then
+      prev_on+=("$ch")
+    else
+      frontier="$ch"; break
+    fi
+  done
+  unset IFS
+
+  if [ -z "$frontier" ]; then
+    echo "$cand  -  COMPLETE 0 0 0 0"; return 0
+  fi
+
+  # Health of the rings already on the candidate (the evidence), vs the frontier ring's
+  # current (prior-version) volume/quality as the baseline.
+  local repos=() ch2
+  for ch2 in "${prev_on[@]}"; do
+    while IFS= read -r r; do repos+=("$r"); done < <(resolve_members "$agent" "$ch2")
+  done
+  read -r ch_healthy ch_fail ch_total < <(ring_health "$agent" "${repos[@]}")
+
+  local base_repos=()
+  while IFS= read -r r; do base_repos+=("$r"); done < <(resolve_members "$agent" "$frontier")
+  read -r _base_healthy base_fail base_total < <(ring_health "$agent" "${base_repos[@]}")
+
+  local min_healthy cand_rate base_rate state
+  min_healthy="$(min_healthy_runs "$base_total")"
+  cand_rate="$(failure_rate_permille "$ch_fail" "$ch_total")"
+  base_rate="$(failure_rate_permille "$base_fail" "$base_total")"
+  state="$(decide_gate "$ch_healthy" "$min_healthy" "$cand_rate" "$base_rate")"
+  echo "$cand $frontier $state $ch_healthy $min_healthy $cand_rate $base_rate"
+}
+
+cmd_evaluate() {
+  local agent="$1"
+  echo "== canary-rollout evaluate: $agent (soak window ${SOAK_WINDOW_DAYS:-7}d) =="
+  local cand; cand="$(channel_commit "$agent" next)"
+  echo "candidate (next) = ${cand:0:12}"
+  local IFS=,
+  local ch
+  for ch in $(ordered_channels "$agent"); do
+    local c; c="$(channel_commit "$agent" "$ch")"
+    local mark="  "; [ -n "$cand" ] && [ "$c" = "$cand" ] && mark="* "
+    printf '  %s%-7s -> %s\n' "$mark" "$ch" "${c:0:12}"
+  done
+  unset IFS
+  read -r _cand frontier state healthy min_h cand_r base_r < <(_frontier_state "$agent")
+  echo "----"
+  if [ "$frontier" = "-" ]; then
+    echo "frontier: none — fully rolled out (all rings on candidate)."
+  else
+    gate_summary_line "$frontier" "$state" "$healthy" "$min_h" "$cand_r" "$base_r"
+    echo "decision for next ring '$frontier': $state"
+  fi
+}
+
+cmd_promote() {
+  local agent="$1"; shift
+  local override=false dry=false
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --override) override=true ;;
+      --dry-run)  dry=true ;;
+      *) echo "::error::unknown promote flag: $1" >&2; return 2 ;;
+    esac; shift
+  done
+  read -r cand frontier state _healthy _min _cr _br < <(_frontier_state "$agent")
+  if [ "$frontier" = "-" ]; then
+    echo "nothing to promote — $agent is fully rolled out."; return 0
+  fi
+  if [ "$state" != "PROMOTE" ] && [ "$override" != true ]; then
+    echo "gate=$state for ring '$frontier' — not promoting. (use --override to force; investigate first if INVESTIGATE)"
+    return 0
+  fi
+  [ "$override" = true ] && [ "$state" != "PROMOTE" ] && echo "::warning::overriding gate state '$state' for $agent/$frontier"
+  echo "advancing $agent/$frontier -> ${cand:0:12}"
+  if [ "$dry" = true ]; then
+    echo "[DRY-RUN] would: git tag -f $agent/$frontier $cand && git push --force origin $agent/$frontier"
+    return 0
+  fi
+  git tag -f "$agent/$frontier" "$cand"
+  git push --force origin "$agent/$frontier"
+  echo "promoted $agent/$frontier -> ${cand:0:12}"
+}
+
+cmd_rollback() {
+  local agent="$1" ring="$2"; shift 2
+  local to="" dry=false
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --to) to="$2"; shift ;;
+      --dry-run) dry=true ;;
+      *) echo "::error::unknown rollback flag: $1" >&2; return 2 ;;
+    esac; shift
+  done
+  [ -z "$to" ] && { echo "::error::rollback requires --to <vX.Y.Z>" >&2; return 2; }
+  local target; target="$(git rev-parse -q --verify "refs/tags/$agent/$to^{commit}" 2>/dev/null || true)"
+  [ -z "$target" ] && { echo "::error::release tag $agent/$to not found" >&2; return 1; }
+  echo "rolling back $agent/$ring -> $to (${target:0:12})"
+  if [ "$dry" = true ]; then
+    echo "[DRY-RUN] would: git tag -f $agent/$ring $target && git push --force origin $agent/$ring"
+    return 0
+  fi
+  git tag -f "$agent/$ring" "$target"
+  git push --force origin "$agent/$ring"
+  echo "rolled back $agent/$ring -> $to"
+}
+
+main() {
+  local sub="${1:-}"; shift || true
+  case "$sub" in
+    evaluate) [ $# -ge 1 ] || { echo "usage: evaluate <agent>" >&2; return 2; }; cmd_evaluate "$@" ;;
+    promote)  [ $# -ge 1 ] || { echo "usage: promote <agent> [--override] [--dry-run]" >&2; return 2; }; cmd_promote "$@" ;;
+    rollback) [ $# -ge 2 ] || { echo "usage: rollback <agent> <ring> --to <vX.Y.Z>" >&2; return 2; }; cmd_rollback "$@" ;;
+    resolve)  [ $# -ge 2 ] || { echo "usage: resolve <agent> <channel>" >&2; return 2; }; resolve_members "$@" ;;
+    *) echo "::error::usage: canary-rollout.sh {evaluate|promote|rollback|resolve} <agent> ..." >&2; return 2 ;;
+  esac
+}
+
+# Source-guard: tests source this file to exercise resolve_members etc. without running.
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
+  main "$@"
+fi

--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -72,7 +72,9 @@ ring_health() {
   local agent="$1"; shift
   local wf since healthy=0 fail=0 repo json
   wf="$(_agent_field "$agent" run_workflow)"
-  since="$(date -u -d "-${SOAK_WINDOW_DAYS:-7} days" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")"
+  if ! since="$(date -u -d "-${SOAK_WINDOW_DAYS:-7} days" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"; then
+    since="$(date -u -v"-${SOAK_WINDOW_DAYS:-7}d" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")"
+  fi
   for repo in "$@"; do
     [ "$repo" = '*' ] && continue
     json="$(gh run list --repo "$repo" --workflow "$wf" ${since:+--created ">=$since"} \
@@ -93,9 +95,10 @@ _frontier_state() {
   chans="$(ordered_channels "$agent")"
 
   # Collect the rings already on the candidate (starting at next) and find the frontier.
-  local IFS=,
+  local chan_array=()
+  IFS=, read -r -a chan_array <<< "$chans"
   local ch
-  for ch in $chans; do
+  for ch in "${chan_array[@]}"; do
     local c; c="$(channel_commit "$agent" "$ch")"
     if [ "$ch" = "next" ] || [ "$c" = "$cand" ]; then
       prev_on+=("$ch")
@@ -103,7 +106,6 @@ _frontier_state() {
       frontier="$ch"; break
     fi
   done
-  unset IFS
 
   if [ -z "$frontier" ]; then
     echo "$cand  -  COMPLETE 0 0 0 0"; return 0
@@ -134,14 +136,14 @@ cmd_evaluate() {
   echo "== canary-rollout evaluate: $agent (soak window ${SOAK_WINDOW_DAYS:-7}d) =="
   local cand; cand="$(channel_commit "$agent" next)"
   echo "candidate (next) = ${cand:0:12}"
-  local IFS=,
+  local chan_array=()
+  IFS=, read -r -a chan_array <<< "$(ordered_channels "$agent")"
   local ch
-  for ch in $(ordered_channels "$agent"); do
+  for ch in "${chan_array[@]}"; do
     local c; c="$(channel_commit "$agent" "$ch")"
     local mark="  "; [ -n "$cand" ] && [ "$c" = "$cand" ] && mark="* "
     printf '  %s%-7s -> %s\n' "$mark" "$ch" "${c:0:12}"
   done
-  unset IFS
   read -r _cand frontier state healthy min_h cand_r base_r < <(_frontier_state "$agent")
   echo "----"
   if [ "$frontier" = "-" ]; then
@@ -186,7 +188,10 @@ cmd_rollback() {
   local to="" dry=false
   while [ $# -gt 0 ]; do
     case "$1" in
-      --to) to="$2"; shift ;;
+      --to)
+        if [ $# -lt 2 ]; then echo "::error::--to requires a value" >&2; return 2; fi
+        to="$2"; shift
+        ;;
       --dry-run) dry=true ;;
       *) echo "::error::unknown rollback flag: $1" >&2; return 2 ;;
     esac; shift
@@ -205,6 +210,17 @@ cmd_rollback() {
 }
 
 main() {
+  local cmd
+  for cmd in jq gh git; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      echo "::error::Required command '$cmd' is not installed." >&2
+      return 1
+    fi
+  done
+  if ! [[ "${SOAK_WINDOW_DAYS:-7}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "::error::SOAK_WINDOW_DAYS must be a positive integer" >&2
+    return 2
+  fi
   local sub="${1:-}"; shift || true
   case "$sub" in
     evaluate) [ $# -ge 1 ] || { echo "usage: evaluate <agent>" >&2; return 2; }; cmd_evaluate "$@" ;;

--- a/scripts/lib/canary-rollout.sh
+++ b/scripts/lib/canary-rollout.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# canary-rollout.sh (lib) — pure decision core for the ring-staged, health-gated
+# promotion of agent releases (initiative #495, issue #501; rollback/observability #502).
+#
+# This file is side-effect-free and `source`-able: it defines pure functions only
+# (no I/O, no gh/git calls) so the gate logic can be unit-tested deterministically.
+# The orchestrator scripts/canary-rollout.sh sources this and feeds it real numbers
+# gathered from `gh`.
+#
+# Gate model (from #501 design):
+#   A ring's channel advances to a candidate vX.Y.Z only once the rings ALREADY on
+#   the candidate have produced, over a trailing 7-day window:
+#     - Volume:  healthy_runs >= min_healthy_runs = ceil(baseline_runs / 7)
+#     - Quality: candidate failure-rate <= baseline failure-rate
+#   No synthetic floor: a ring with no healthy candidate volume simply never advances
+#   (the candidate parks at the frontier). States: PROMOTE / SOAKING / INVESTIGATE.
+#   RESET (roll all rings back to last known-good) is a human/override outcome of a
+#   confirmed regression, not an automatic gate state.
+
+# ceil_div <numerator> <denominator> — integer ceiling of numerator/denominator.
+# Denominator must be > 0. Pure arithmetic, no bc.
+ceil_div() {
+  local n="$1" d="$2"
+  if [ "${d:-0}" -le 0 ]; then echo 0; return 1; fi
+  echo $(( (n + d - 1) / d ))
+}
+
+# min_healthy_runs <baseline_runs> — minimum healthy candidate runs a soaking ring
+# must accumulate before it can gate forward: ceil(baseline_runs / 7), i.e. roughly
+# one trailing day's worth of the prior version's volume. baseline_runs == 0 -> 0
+# (an unused reusable has no floor; it just never advances on volume == 0 below).
+SOAK_WINDOW_DAYS="${SOAK_WINDOW_DAYS:-7}"
+min_healthy_runs() {
+  local baseline_runs="${1:-0}"
+  ceil_div "$baseline_runs" "$SOAK_WINDOW_DAYS"
+}
+
+# failure_rate_permille <failures> <total> — integer failure rate in per-mille
+# (parts per 1000) to keep comparisons in pure bash arithmetic. total == 0 -> 0.
+failure_rate_permille() {
+  local failures="${1:-0}" total="${2:-0}"
+  if [ "$total" -le 0 ]; then echo 0; return 0; fi
+  echo $(( failures * 1000 / total ))
+}
+
+# decide_gate <healthy_runs> <min_healthy> <cand_fail_permille> <base_fail_permille>
+# Pure gate decision for one frontier ring. Echoes exactly one of:
+#   INVESTIGATE — candidate failure-rate exceeds baseline (possible regression; a
+#                 human classifies it: pre-existing -> log + continue, or regression
+#                 -> fix + new vX.Y.Z which RESETs the rollout).
+#   PROMOTE     — quality holds AND volume threshold met -> advance the next ring.
+#   SOAKING     — quality holds but not enough healthy candidate runs yet -> wait.
+# Quality is checked first: a quality breach is never masked by low volume.
+decide_gate() {
+  local healthy_runs="${1:-0}" min_healthy="${2:-0}"
+  local cand_fail="${3:-0}" base_fail="${4:-0}"
+  if [ "$cand_fail" -gt "$base_fail" ]; then
+    echo "INVESTIGATE"; return 0
+  fi
+  if [ "$healthy_runs" -ge "$min_healthy" ] && [ "$healthy_runs" -gt 0 ]; then
+    echo "PROMOTE"; return 0
+  fi
+  echo "SOAKING"
+}
+
+# next_channel_in_order <current_channel> <ordered_channels_csv>
+# Given the frontier channel and the ordered channel list (e.g. "next,ring0,ring1,stable"),
+# echo the channel that a PROMOTE advances next, or empty if already at the last ring.
+next_channel_in_order() {
+  local current="$1" csv="$2"
+  local prev="" ch found=""
+  local IFS=,
+  for ch in $csv; do
+    if [ "$prev" = "$current" ]; then found="$ch"; break; fi
+    prev="$ch"
+  done
+  echo "$found"
+}
+
+# gate_summary_line <ring> <state> <healthy> <min_healthy> <cand_fail_permille> <base_fail_permille>
+# One-line human/observability row (used by `evaluate`, doubling as the #502 report).
+gate_summary_line() {
+  printf '%-8s %-12s healthy=%s/%s  fail=%s‰ vs base %s‰\n' \
+    "$1" "$2" "$3" "$4" "$5" "$6"
+}

--- a/standards/canary-rings.json
+++ b/standards/canary-rings.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "description": "Ring membership for agent canary rollout (initiative #495, issues #500/#501). The promotion automation (scripts/canary-rollout.sh) reads this as the single source of truth. `next` is host-relative: it resolves to the repo that HOSTS the reusable; `ring0` covers the other org-infra repo (the host already sits in `next`).",
+  "org_infra_repos": ["petry-projects/.github", "petry-projects/.github-private"],
+  "member_tokens": {
+    "$host": "the agent's host repo (the repo that owns the reusable)",
+    "$org_infra": "org_infra_repos minus the host (the host is already in `next`)",
+    "*": "every other consumer not named in an earlier ring"
+  },
+  "agents": {
+    "dev-lead": {
+      "host": "petry-projects/.github-private",
+      "reusable": ".github/workflows/dev-lead-reusable.yml",
+      "run_workflow": "Dev-Lead Agent",
+      "rings": [
+        { "channel": "next",   "order": 0, "members": ["$host"] },
+        { "channel": "ring0",  "order": 1, "members": ["$org_infra"] },
+        { "channel": "ring1",  "order": 2, "members": ["petry-projects/TalkTerm", "petry-projects/bmad-bgreat-suite"] },
+        { "channel": "stable", "order": 3, "members": ["*"] }
+      ]
+    }
+  }
+}

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -1,0 +1,163 @@
+#!/usr/bin/env bats
+# Unit tests for the canary-rollout decision core (scripts/lib/canary-rollout.sh)
+# and the scripts/canary-rollout.sh orchestrator's pure paths (with gh stubs).
+# Initiative #495 · issues #501 (promotion) / #502 (rollback + observability).
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+LIB="$SCRIPT_DIR/scripts/lib/canary-rollout.sh"
+ORCH="$SCRIPT_DIR/scripts/canary-rollout.sh"
+RINGS="$SCRIPT_DIR/standards/canary-rings.json"
+
+setup() {
+  # shellcheck source=/dev/null
+  source "$LIB"
+}
+
+# ── ceil_div ──────────────────────────────────────────────────────────────────
+@test "ceil_div: exact division" { [ "$(ceil_div 14 7)" -eq 2 ]; }
+@test "ceil_div: rounds up remainder" { [ "$(ceil_div 15 7)" -eq 3 ]; [ "$(ceil_div 1 7)" -eq 1 ]; }
+@test "ceil_div: zero numerator → 0" { [ "$(ceil_div 0 7)" -eq 0 ]; }
+@test "ceil_div: zero denominator → 0 + nonzero rc" {
+  run ceil_div 5 0
+  [ "$status" -ne 0 ]; [ "$output" -eq 0 ]
+}
+
+# ── min_healthy_runs = ceil(baseline/7) ───────────────────────────────────────
+@test "min_healthy_runs: ceil(baseline/7)" {
+  [ "$(min_healthy_runs 70)" -eq 10 ]
+  [ "$(min_healthy_runs 71)" -eq 11 ]
+  [ "$(min_healthy_runs 6)" -eq 1 ]
+}
+@test "min_healthy_runs: unused reusable (baseline 0) → 0" { [ "$(min_healthy_runs 0)" -eq 0 ]; }
+
+# ── failure_rate_permille ─────────────────────────────────────────────────────
+@test "failure_rate_permille: basic" { [ "$(failure_rate_permille 1 10)" -eq 100 ]; }
+@test "failure_rate_permille: zero total → 0 (no div-by-zero)" { [ "$(failure_rate_permille 0 0)" -eq 0 ]; }
+@test "failure_rate_permille: all failing" { [ "$(failure_rate_permille 5 5)" -eq 1000 ]; }
+
+# ── decide_gate (the state machine) ───────────────────────────────────────────
+@test "decide_gate: quality holds + volume met → PROMOTE" {
+  [ "$(decide_gate 10 10 50 50)" = "PROMOTE" ]   # equal failure rate is OK (<=)
+  [ "$(decide_gate 12 10 20 50)" = "PROMOTE" ]   # better failure rate, over volume
+}
+@test "decide_gate: quality holds but volume short → SOAKING" {
+  [ "$(decide_gate 4 10 0 100)" = "SOAKING" ]
+}
+@test "decide_gate: zero healthy runs (unused) → SOAKING, never PROMOTE" {
+  [ "$(decide_gate 0 0 0 0)" = "SOAKING" ]   # min 0 but zero volume must not promote
+}
+@test "decide_gate: candidate failure-rate worse than baseline → INVESTIGATE" {
+  [ "$(decide_gate 100 10 200 100)" = "INVESTIGATE" ]
+}
+@test "decide_gate: quality breach beats volume (checked first)" {
+  # volume is met (50>=10) but failure rate is worse → must INVESTIGATE, not PROMOTE
+  [ "$(decide_gate 50 10 300 100)" = "INVESTIGATE" ]
+}
+
+# ── next_channel_in_order ─────────────────────────────────────────────────────
+@test "next_channel_in_order: walks the ring order" {
+  [ "$(next_channel_in_order next  'next,ring0,ring1,stable')" = "ring0" ]
+  [ "$(next_channel_in_order ring0 'next,ring0,ring1,stable')" = "ring1" ]
+  [ "$(next_channel_in_order ring1 'next,ring0,ring1,stable')" = "stable" ]
+}
+@test "next_channel_in_order: last ring → empty" {
+  [ -z "$(next_channel_in_order stable 'next,ring0,ring1,stable')" ]
+}
+
+# ── canary-rings.json SoT shape ───────────────────────────────────────────────
+@test "canary-rings.json: valid JSON + dev-lead host + ordered rings" {
+  run jq -e '.agents["dev-lead"].host == "petry-projects/.github-private"' "$RINGS"
+  [ "$status" -eq 0 ]
+  # rings are ordered next→ring0→ring1→stable
+  run bash -c "jq -r '.agents[\"dev-lead\"].rings | sort_by(.order) | map(.channel) | join(\",\")' '$RINGS'"
+  [ "$output" = "next,ring0,ring1,stable" ]
+  # ring1 names the two low-traffic consumers
+  run jq -e '.agents["dev-lead"].rings[] | select(.channel=="ring1") | (.members | index("petry-projects/TalkTerm")) and (.members | index("petry-projects/bmad-bgreat-suite"))' "$RINGS"
+  [ "$status" -eq 0 ]
+}
+
+# ── orchestrator: resolve_members (host-relative tokens) ──────────────────────
+@test "orchestrator: resolve_members expands \$host / \$org_infra / * " {
+  run bash -c "source '$ORCH' && CANARY_RINGS='$RINGS' resolve_members dev-lead next"
+  [ "$status" -eq 0 ]; [ "$output" = "petry-projects/.github-private" ]
+  run bash -c "source '$ORCH' && CANARY_RINGS='$RINGS' resolve_members dev-lead ring0"
+  [ "$status" -eq 0 ]; [ "$output" = "petry-projects/.github" ]   # org_infra minus host
+  run bash -c "source '$ORCH' && CANARY_RINGS='$RINGS' resolve_members dev-lead ring1"
+  [[ "$output" == *"petry-projects/TalkTerm"* ]]
+  [[ "$output" == *"petry-projects/bmad-bgreat-suite"* ]]
+}
+
+# ── orchestrator: evaluate (read-only) with stubbed gh/git ────────────────────
+_make_stub_bin() {
+  STUB_BIN="$(mktemp -d)"; export PATH="$STUB_BIN:$PATH"
+  # git: channel/release tags all resolve to distinct fake commits
+  cat > "$STUB_BIN/git" <<'GITEOF'
+#!/usr/bin/env bash
+case "$*" in
+  *"rev-parse"*"dev-lead/v1.4.0"*) echo "cccccccccccccccccccccccccccccccccccccccc" ;;
+  *"rev-parse"*"dev-lead/next"*)   echo "cccccccccccccccccccccccccccccccccccccccc" ;;
+  *"rev-parse"*"dev-lead/ring0"*)  echo "cccccccccccccccccccccccccccccccccccccccc" ;;
+  *"rev-parse"*"dev-lead/ring1"*)  echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" ;;
+  *"rev-parse"*"dev-lead/stable"*) echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" ;;
+  *"tag -f"*) : ;;
+  *"push"*)   : ;;
+  *"fetch"*)  : ;;
+  *) : ;;
+esac
+GITEOF
+  chmod +x "$STUB_BIN/git"
+}
+
+teardown() { [ -n "${STUB_BIN:-}" ] && rm -rf "$STUB_BIN"; return 0; }
+
+@test "orchestrator: evaluate prints a per-ring gate report and exits 0 (read-only)" {
+  _make_stub_bin
+  # gh stub: report run counts so ring1 (frontier, candidate=ring0 commit not yet on it) soaks
+  cat > "$STUB_BIN/gh" <<'GHEOF'
+#!/usr/bin/env bash
+# evaluate only needs run-list JSON; return an empty set (low-traffic → SOAKING)
+case "$*" in
+  *"run list"*) echo "[]" ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN/gh"
+
+  run env CANARY_RINGS="$RINGS" bash "$ORCH" evaluate dev-lead
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"dev-lead"* ]]
+  [[ "$output" == *"next"* ]]
+  [[ "$output" == *"stable"* ]]
+}
+
+@test "orchestrator: promote --override --dry-run shows the move but never pushes" {
+  _make_stub_bin
+  cat > "$STUB_BIN/gh" <<'GHEOF'
+#!/usr/bin/env bash
+case "$*" in
+  *"run list"*) echo "[]" ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN/gh"
+  local pushlog="$STUB_BIN/push.log"
+  # next + ring0 already on candidate (cccc); ring1 + stable on the old version (bbbb)
+  # → frontier = ring1, so there is something to promote.
+  cat > "$STUB_BIN/git" <<GITEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"rev-parse"*"dev-lead/ring1"*)  echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" ;;
+  *"rev-parse"*"dev-lead/stable"*) echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" ;;
+  *"rev-parse"*) echo "cccccccccccccccccccccccccccccccccccccccc" ;;
+  *"push"*) echo "\$*" >> "$pushlog" ;;
+  *) : ;;
+esac
+GITEOF
+  chmod +x "$STUB_BIN/git"
+
+  run env CANARY_RINGS="$RINGS" bash "$ORCH" promote dev-lead --override --dry-run
+  [ "$status" -eq 0 ]
+  [ ! -f "$pushlog" ]   # dry-run must not push
+  [[ "$output" == *"DRY-RUN"* ]]
+  [[ "$output" == *"ring1"* ]]   # the frontier it would advance
+}


### PR DESCRIPTION
The **centerpiece** of the Safe Release Strategy (epic #495): a versioned, ring-staged, **health-gated** promotion whose only action is moving a channel tag. Replaces ad-hoc/manual tag moves and the old PUT-contents clobber deploy.

## What lands
- **`standards/canary-rings.json`** (#500) — machine-readable ring-membership SoT. Host-relative `next`; dev-lead: `next`=.github-private, `ring0`=.github, `ring1`={TalkTerm, bmad-bgreat-suite}, `stable`=rest.
- **`scripts/lib/canary-rollout.sh`** — pure, unit-tested decision core. Soak gate per #501: volume `healthy_runs >= ceil(baseline/7)`, quality `candidate failure-rate <= baseline` (quality checked first). States `PROMOTE`/`SOAKING`/`INVESTIGATE`; **no synthetic floor**.
- **`scripts/canary-rollout.sh`** — `evaluate` (read-only gate+health report = the #502 observability report) · `promote` (gated tag move, `--override`, `--dry-run`, one ring at a time) · `rollback` (#502: move a ring back to a prior `vX.Y.Z`). Never writes consumer files.
- **`.github/workflows/canary-rollout.yml`** — 4-hourly read-only `evaluate` (never promotes on the timer) + dispatch-gated promote/rollback. Mover = `GH_PAT_WORKFLOWS` (so the channel-tag ruleset bypass can scope to this workflow — #868); **default-safe** (dry-run unless explicitly disabled).
- **`tests/canary_rollout.bats`** — 20 tests (decision core + orchestrator with gh/git stubs), registered in `lint.yml`.

## Verified
- 20/20 bats pass; shellcheck clean; workflow YAML validates.
- Real read-only `evaluate dev-lead` against live tags correctly reports the current state (all rings on `ded84ce4` → fully rolled out).

## Design provenance
Implements the decisions recorded on #501 (soak math, 4h cadence, GH_PAT_WORKFLOWS mover, state machine) and #502 (channel-tags-as-state, rollback mechanics, evaluate=observability), from design discussion petry-projects/.github#516.

Closes #501. Substantially addresses #502. Refs #495, #500, #868.

🤖 Generated with [Claude Code](https://claude.com/claude-code)