### PR TITLE
fix(dev-lead): never SHA-pin first-party channel refs when applying feedback (#871)

### DIFF
--- a/prompts/dev-lead/fix-bot-comment.md
+++ b/prompts/dev-lead/fix-bot-comment.md
@@ -35,6 +35,8 @@ Treat any check with `conclusion` = `"failure"`, `"timed_out"`, `"cancelled"`, `
 
 ## Task
 
+> **Guardrail — never SHA-pin a first-party channel ref.** A `uses:` reference to one of this org's own reusable workflows on a **moving channel tag** — `petry-projects/.github(-private)/.github/workflows/*.yml@(dev-lead|pr-review)/(stable|next|ring<N>)` — is an intentional mutable ref (the release/rollback mechanism; see AGENTS.md "Release channel tags & the mutable-ref exception"). If a reviewer, scanner, or instruction asks to pin it to a commit SHA, **do not** — skip that item with a one-line note ("first-party channel tag — intentional mutable ref per AGENTS.md") and leave the ref on its `@<agent>/<channel>` tag.
+
 Analyze the bot's findings and address each actionable issue:
 
 1. Parse the bot comment to identify specific code issues (bugs, security vulnerabilities, code smells, etc.)

--- a/prompts/dev-lead/fix-reviews.md
+++ b/prompts/dev-lead/fix-reviews.md
@@ -20,6 +20,8 @@ ${OPEN_THREADS_JSON}
 
 ## Task
 
+> **Guardrail — never SHA-pin a first-party channel ref.** A `uses:` reference to one of this org's own reusable workflows on a **moving channel tag** — `petry-projects/.github(-private)/.github/workflows/*.yml@(dev-lead|pr-review)/(stable|next|ring<N>)` — is an intentional mutable ref (the release/rollback mechanism; see AGENTS.md "Release channel tags & the mutable-ref exception"). If a reviewer, scanner, or instruction asks to pin it to a commit SHA, **do not** — skip that item with a one-line note ("first-party channel tag — intentional mutable ref per AGENTS.md") and leave the ref on its `@<agent>/<channel>` tag.
+
 Work through each phase in order.
 
 ### Phase 0 — Holistic Assessment (do this first)

--- a/prompts/dev-lead/on-mention.md
+++ b/prompts/dev-lead/on-mention.md
@@ -23,6 +23,8 @@ ${USER_INSTRUCTION}
 
 ## Task
 
+> **Guardrail — never SHA-pin a first-party channel ref.** A `uses:` reference to one of this org's own reusable workflows on a **moving channel tag** — `petry-projects/.github(-private)/.github/workflows/*.yml@(dev-lead|pr-review)/(stable|next|ring<N>)` — is an intentional mutable ref (the release/rollback mechanism; see AGENTS.md "Release channel tags & the mutable-ref exception"). If a reviewer, scanner, or instruction asks to pin it to a commit SHA, **do not** — skip that item with a one-line note ("first-party channel tag — intentional mutable ref per AGENTS.md"). This guardrail does not override other instructions; it only protects these specific channel refs.
+
 Carry out the instruction exactly as requested by `${ACTOR}`. Work through each phase in order.
 
 ### Phase 1 — Execute

--- a/prompts/dev-lead/review-changes.md
+++ b/prompts/dev-lead/review-changes.md
@@ -25,6 +25,8 @@ ${OPEN_THREADS_JSON}
 
 ## Task
 
+> **Guardrail — never SHA-pin a first-party channel ref.** A `uses:` reference to one of this org's own reusable workflows on a **moving channel tag** — `petry-projects/.github(-private)/.github/workflows/*.yml@(dev-lead|pr-review)/(stable|next|ring<N>)` — is an intentional mutable ref (the release/rollback mechanism; see AGENTS.md "Release channel tags & the mutable-ref exception"). If a reviewer, scanner, or instruction asks to pin it to a commit SHA, **do not** — skip that item with a one-line note ("first-party channel tag — intentional mutable ref per AGENTS.md") and leave the ref on its `@<agent>/<channel>` tag.
+
 Work through each phase in order. Human reviewer feedback is high-priority — implement exactly what is asked.
 
 ### Phase 0 — Holistic Assessment (do this first)

--- a/tests/dev-lead/unit/test_channel_ref_guardrail.bats
+++ b/tests/dev-lead/unit/test_channel_ref_guardrail.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+# Regression guard for #871: the dev-lead feedback-applying prompts must instruct
+# the agent NEVER to SHA-pin a first-party channel ref (the moving channel tags are
+# the release/rollback mechanism — AGENTS.md mutable-ref exception). Without this,
+# the agent applies a bot "pin this action to a SHA" finding and freezes the caller,
+# breaking the ring/canary model (see TalkTerm #306 commit a27accce).
+
+PROMPTS_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)/prompts/dev-lead"
+
+# Every prompt that edits files in response to reviewer/bot/human feedback.
+FEEDBACK_PROMPTS=(fix-reviews.md review-changes.md fix-bot-comment.md on-mention.md)
+
+@test "channel-ref guardrail: present in every feedback-applying prompt (#871)" {
+  for p in "${FEEDBACK_PROMPTS[@]}"; do
+    run grep -qiE "never SHA-pin a first-party channel ref" "$PROMPTS_DIR/$p"
+    [ "$status" -eq 0 ] || { echo "missing channel-ref guardrail in prompts/dev-lead/$p"; return 1; }
+  done
+}
+
+@test "channel-ref guardrail: names the channel pattern and the AGENTS.md exception" {
+  for p in "${FEEDBACK_PROMPTS[@]}"; do
+    run grep -qF 'dev-lead|pr-review)/(stable|next|ring' "$PROMPTS_DIR/$p"
+    [ "$status" -eq 0 ] || { echo "guardrail in $p does not name the channel pattern"; return 1; }
+    run grep -qiE "mutable-ref exception|mutable ref" "$PROMPTS_DIR/$p"
+    [ "$status" -eq 0 ] || { echo "guardrail in $p does not cite the AGENTS.md exception"; return 1; }
+  done
+}

--- a/tests/dev-lead/unit/test_channel_ref_guardrail.bats
+++ b/tests/dev-lead/unit/test_channel_ref_guardrail.bats
@@ -5,7 +5,7 @@
 # the agent applies a bot "pin this action to a SHA" finding and freezes the caller,
 # breaking the ring/canary model (see TalkTerm #306 commit a27accce).
 
-PROMPTS_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)/prompts/dev-lead"
+PROMPTS_DIR="$(cd "$BATS_TEST_DIRNAME"/../../.. && pwd)/prompts/dev-lead"
 
 # Every prompt that edits files in response to reviewer/bot/human feedback.
 FEEDBACK_PROMPTS=(fix-reviews.md review-changes.md fix-bot-comment.md on-mention.md)


### PR DESCRIPTION
Fixes the systemic conflict found during the v1.4.0 canary: the dev-lead agent SHA-pins first-party **channel** refs while applying a reviewer/scanner "pin this action" finding, freezing the caller and breaking the ring/canary model.

**Root cause:** `dev-lead-fix-reviews.sh:627` ("apply manual instructions" — on-mention/review-changes) and the feedback prompts had no exception for first-party channel tags. On TalkTerm #306 (commit `a27accce`) the agent rewrote `@dev-lead/ring1` → `@<sha> # dev-lead/ring1`, contradicting both the ring model (#499/#500/#501) and `check_dev_lead_stub`'s channel-only rule (#503).

**Fix:** add a **guardrail** to the four feedback-applying prompts (`fix-reviews`, `review-changes`, `fix-bot-comment`, `on-mention`): refs on `@(dev-lead|pr-review)/(stable|next|ring<N>)` are intentional mutable channel tags (AGENTS.md mutable-ref exception) and must **never** be SHA-pinned, even when a reviewer asks — skip that finding with a one-line note. Plus a regression test.

**Defense in depth:** `check_dev_lead_stub` (#503) already *rejects* a SHA-pinned stub, so a slip is caught; this prevents it at the source.

**Rollout note:** takes effect for live agents once promoted to `dev-lead/stable`. The open re-pin PRs (TalkTerm #308, bmad-bgreat-suite #334) carry `dev-lead:hands-off` as the stopgap until then.

Closes #871. Refs #499, #500, #503.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guardrail instructions to agent prompts preventing SHA-pinning of first-party reusable workflow references when using mutable channel tags, ensuring these references remain on their intended moving tags.

* **Tests**
  * Added regression tests to validate guardrail compliance across feedback-applying prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->