### PR TITLE
feat(release): codify release-channel-tags ruleset + apply-rulesets.sh (#868)

### DIFF
--- a/.github/rulesets/release-channel-tags.json
+++ b/.github/rulesets/release-channel-tags.json
@@ -1,0 +1,29 @@
+{
+  "name": "release-channel-tags",
+  "target": "tag",
+  "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "always"
+    },
+    {
+      "actor_id": 3167543,
+      "actor_type": "Integration",
+      "bypass_mode": "always"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "include": [
+        "refs/tags/pr-review/**",
+        "refs/tags/dev-lead/**"
+      ],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {"type": "update"},
+    {"type": "deletion"}
+  ]
+}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -64,6 +64,7 @@ jobs:
             tests/test_dependabot.bats \
             tests/test_feature_ideation.bats \
             tests/test_apply_repo_settings.bats \
+            tests/test_apply_rulesets.bats \
             tests/test_sweep_stuck_reviews.bats \
             tests/test_validate_cases.bats \
             tests/test_review_registry.bats \

--- a/scripts/apply-rulesets.sh
+++ b/scripts/apply-rulesets.sh
@@ -35,9 +35,8 @@ DRY_RUN="${DRY_RUN:-false}"
 # ruleset_id_by_name <repo> <name> — echo the id of an existing ruleset, or empty.
 ruleset_id_by_name() {
   local repo="$1" name="$2"
-  gh api --paginate "repos/${repo}/rulesets" 2>/dev/null \
-    | jq -r --arg n "$name" 'if type=="array" then .[] else . end | select(.name==$n) | .id' 2>/dev/null \
-    | head -1
+  gh api --paginate "repos/${repo}/rulesets" \
+    | jq -r --arg n "$name" 'if type=="array" then .[] else . end | select(.name==$n) | .id'
 }
 
 # apply_one <repo> <json_file> — create or update the ruleset described by json_file.
@@ -64,7 +63,14 @@ main() {
   local names=()
   while [ $# -gt 0 ]; do
     case "$1" in
-      --repo) repo="$2"; shift 2 ;;
+      --repo)
+        if [ "$#" -lt 2 ]; then
+          echo "::error::--repo requires a value" >&2
+          return 2
+        fi
+        repo="$2"
+        shift 2
+        ;;
       --dry-run) DRY_RUN=true; shift ;;
       --*) echo "::error::unknown flag: $1" >&2; return 2 ;;
       *) names+=("$1"); shift ;;

--- a/scripts/apply-rulesets.sh
+++ b/scripts/apply-rulesets.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# apply-rulesets.sh — codified, idempotent application of repository rulesets from
+# .github/rulesets/*.json (initiative #495, issue #868). Makes the previously
+# live-only rulesets — notably `release-channel-tags`, which protects the moving
+# channel tags `pr-review/**` + `dev-lead/**` (and therefore the ring channels
+# next/ring0/ring1 via the `**` glob) — reproducible and version-controlled.
+#
+# For each ruleset JSON, this finds the existing ruleset by name on the target repo
+# and PUTs an update, or POSTs a create if absent. Re-running is a no-op-shaped
+# convergence to the file's desired state.
+#
+# Usage:
+#   bash scripts/apply-rulesets.sh [--repo owner/repo] [--dry-run] [<name>...]
+#   RULESETS_REPO=owner/repo bash scripts/apply-rulesets.sh
+#
+# Env:
+#   RULESETS_REPO   target repo (default: petry-projects/.github-private — where the
+#                   pr-review/dev-lead release tags live)
+#   RULESETS_DIR    directory of ruleset JSONs (default: .github/rulesets)
+#   GH_TOKEN        token with admin:org / repo admin to read+write rulesets
+#   DRY_RUN         "true" → print intent, make no write calls
+#
+# Bypass model (release-channel-tags): OrganizationAdmin + the automation Integration
+# app may move/delete channel tags; agents running as GITHUB_TOKEN cannot. The
+# canary-rollout promotion workflow (#501) moves tags via GH_PAT_WORKFLOWS (owned by
+# an org admin); the long-term hardening is a dedicated GitHub App whose id is added
+# to bypass_actors here so the bypass scopes to the workflow identity.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+RULESETS_REPO="${RULESETS_REPO:-petry-projects/.github-private}"
+RULESETS_DIR="${RULESETS_DIR:-$(cd "${SCRIPT_DIR}/.." && pwd)/.github/rulesets}"
+DRY_RUN="${DRY_RUN:-false}"
+
+# ruleset_id_by_name <repo> <name> — echo the id of an existing ruleset, or empty.
+ruleset_id_by_name() {
+  local repo="$1" name="$2"
+  gh api --paginate "repos/${repo}/rulesets" 2>/dev/null \
+    | jq -r --arg n "$name" 'if type=="array" then .[] else . end | select(.name==$n) | .id' 2>/dev/null \
+    | head -1
+}
+
+# apply_one <repo> <json_file> — create or update the ruleset described by json_file.
+apply_one() {
+  local repo="$1" file="$2"
+  local name id
+  name="$(jq -r '.name' "$file")"
+  [ -n "$name" ] && [ "$name" != "null" ] || { echo "::error::$file has no .name" >&2; return 1; }
+  id="$(ruleset_id_by_name "$repo" "$name")"
+
+  if [ -n "$id" ]; then
+    echo "  update ruleset '${name}' (id ${id}) on ${repo}"
+    if [ "$DRY_RUN" = "true" ]; then echo "    [dry-run] PUT repos/${repo}/rulesets/${id}"; return 0; fi
+    gh api --method PUT "repos/${repo}/rulesets/${id}" --input "$file" >/dev/null
+  else
+    echo "  create ruleset '${name}' on ${repo}"
+    if [ "$DRY_RUN" = "true" ]; then echo "    [dry-run] POST repos/${repo}/rulesets"; return 0; fi
+    gh api --method POST "repos/${repo}/rulesets" --input "$file" >/dev/null
+  fi
+}
+
+main() {
+  local repo="$RULESETS_REPO"
+  local names=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --repo) repo="$2"; shift 2 ;;
+      --dry-run) DRY_RUN=true; shift ;;
+      --*) echo "::error::unknown flag: $1" >&2; return 2 ;;
+      *) names+=("$1"); shift ;;
+    esac
+  done
+
+  [ -d "$RULESETS_DIR" ] || { echo "::error::rulesets dir not found: $RULESETS_DIR" >&2; return 1; }
+  echo "[apply-rulesets] repo=${repo} dir=${RULESETS_DIR} dry_run=${DRY_RUN}"
+
+  local files=()
+  if [ "${#names[@]}" -gt 0 ]; then
+    local n
+    for n in "${names[@]}"; do
+      [ -f "${RULESETS_DIR}/${n}.json" ] && files+=("${RULESETS_DIR}/${n}.json") \
+        || { echo "::error::no ruleset file ${n}.json" >&2; return 1; }
+    done
+  else
+    local f
+    for f in "${RULESETS_DIR}"/*.json; do [ -e "$f" ] && files+=("$f"); done
+  fi
+  [ "${#files[@]}" -gt 0 ] || { echo "  no ruleset files to apply"; return 0; }
+
+  local file
+  for file in "${files[@]}"; do apply_one "$repo" "$file"; done
+  echo "[apply-rulesets] done (${#files[@]} ruleset(s))"
+}
+
+# Source-guard: tests source this to exercise ruleset_id_by_name / apply_one.
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
+  main "$@"
+fi

--- a/tests/test_apply_rulesets.bats
+++ b/tests/test_apply_rulesets.bats
@@ -88,3 +88,10 @@ EOF
   run bash -c "source '$APPLY' && ruleset_id_by_name petry-projects/.github-private code-quality"
   [ "$status" -eq 0 ]; [ "$output" = "7" ]
 }
+
+@test "apply: --repo without a value errors with a message" {
+  _stub_gh
+  run bash "$APPLY" --repo
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--repo requires a value"* ]]
+}

--- a/tests/test_apply_rulesets.bats
+++ b/tests/test_apply_rulesets.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+# Unit tests for scripts/apply-rulesets.sh — codified, idempotent ruleset apply
+# (initiative #495, issue #868).
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+APPLY="$SCRIPT_DIR/scripts/apply-rulesets.sh"
+RULESETS_DIR="$SCRIPT_DIR/.github/rulesets"
+
+setup() {
+  STUB_BIN="$(mktemp -d)"; export PATH="$STUB_BIN:$PATH"
+  CALLS="$STUB_BIN/calls.log"; export CALLS
+}
+teardown() { [ -n "${STUB_BIN:-}" ] && rm -rf "$STUB_BIN"; return 0; }
+
+# gh stub: records every write (POST/PUT) to $CALLS; for the rulesets LIST it
+# returns $RULESETS_LIST (default empty array → "create" path).
+_stub_gh() {
+  cat > "$STUB_BIN/gh" <<EOF
+#!/usr/bin/env bash
+args="\$*"
+case "\$args" in
+  *"--method POST"*|*"--method PUT"*) echo "\$args" >> "$CALLS"; echo '{}' ;;
+  *"rulesets"*) printf '%s' "\${RULESETS_LIST:-[]}" ;;
+  *) echo '{}' ;;
+esac
+EOF
+  chmod +x "$STUB_BIN/gh"
+}
+
+# ── codified JSON shape ───────────────────────────────────────────────────────
+@test "release-channel-tags.json: valid, tag target, protects pr-review/** + dev-lead/**" {
+  run jq -e '.target == "tag" and .enforcement == "active"' "$RULESETS_DIR/release-channel-tags.json"
+  [ "$status" -eq 0 ]
+  run jq -e '.conditions.ref_name.include | (index("refs/tags/dev-lead/**") and index("refs/tags/pr-review/**"))' "$RULESETS_DIR/release-channel-tags.json"
+  [ "$status" -eq 0 ]
+  # update + deletion restricted
+  run jq -e '[.rules[].type] | (index("update") and index("deletion"))' "$RULESETS_DIR/release-channel-tags.json"
+  [ "$status" -eq 0 ]
+  # bypass = OrganizationAdmin + the Integration app
+  run jq -e '[.bypass_actors[].actor_type] | (index("OrganizationAdmin") and index("Integration"))' "$RULESETS_DIR/release-channel-tags.json"
+  [ "$status" -eq 0 ]
+}
+
+@test "dev-lead/** glob covers the ring channels (next/ring0/ring1) — no per-channel rule needed" {
+  # The include is a glob; assert the codified pattern is the ** form that matches rings.
+  run jq -r '.conditions.ref_name.include[] | select(startswith("refs/tags/dev-lead"))' "$RULESETS_DIR/release-channel-tags.json"
+  [ "$output" = "refs/tags/dev-lead/**" ]
+}
+
+# ── apply behavior (create vs update, dry-run) ────────────────────────────────
+@test "apply: creates the ruleset when absent (POST)" {
+  _stub_gh
+  export RULESETS_LIST='[]'
+  run env RULESETS_REPO="petry-projects/.github-private" bash "$APPLY" release-channel-tags
+  [ "$status" -eq 0 ]
+  grep -q "method POST" "$CALLS"
+  ! grep -q "method PUT" "$CALLS"
+}
+
+@test "apply: updates the ruleset when present (PUT by id)" {
+  _stub_gh
+  export RULESETS_LIST='[{"id":17432201,"name":"release-channel-tags"}]'
+  run env RULESETS_REPO="petry-projects/.github-private" bash "$APPLY" release-channel-tags
+  [ "$status" -eq 0 ]
+  grep -q "method PUT" "$CALLS"
+  grep -q "rulesets/17432201" "$CALLS"
+  ! grep -q "method POST" "$CALLS"
+}
+
+@test "apply: --dry-run makes no write calls" {
+  _stub_gh
+  export RULESETS_LIST='[]'
+  run env RULESETS_REPO="petry-projects/.github-private" bash "$APPLY" --dry-run release-channel-tags
+  [ "$status" -eq 0 ]
+  [ ! -f "$CALLS" ]
+  [[ "$output" == *"dry-run"* ]]
+}
+
+@test "apply: unknown ruleset name errors" {
+  _stub_gh
+  run env RULESETS_REPO="petry-projects/.github-private" bash "$APPLY" no-such-ruleset
+  [ "$status" -ne 0 ]
+}
+
+@test "ruleset_id_by_name: resolves id from the list" {
+  _stub_gh
+  export RULESETS_LIST='[{"id":42,"name":"release-channel-tags"},{"id":7,"name":"code-quality"}]'
+  run bash -c "source '$APPLY' && ruleset_id_by_name petry-projects/.github-private code-quality"
+  [ "$status" -eq 0 ]; [ "$output" = "7" ]
+}


### PR DESCRIPTION
Makes the **release-channel-tags** ruleset — the governance half of the canary/ring model — reproducible and version-controlled (it was live-only).

- **`.github/rulesets/release-channel-tags.json`** — faithful capture of live ruleset `17432201`: `target=tag`, restricts `update`+`deletion` on `refs/tags/{pr-review,dev-lead}/**`, bypass = OrganizationAdmin + the automation Integration app. The `**` globs **already cover the ring channels** (`next`/`ring0`/`ring1`) — no per-channel rule needed.
- **`scripts/apply-rulesets.sh`** — idempotent create-or-update of every `.github/rulesets/*.json` on a target repo (default `.github-private`), `--dry-run` + per-name selection. Mirrors `apply-repo-settings.sh`. Also makes the pre-existing-but-unapplied `code-quality.json` reproducible.
- **`tests/test_apply_rulesets.bats`** (7, registered in lint.yml).

**Verified:** real `--dry-run` converges to both live rulesets (update path); shellcheck clean.

**Bypass scoping:** the promotion workflow (#501/#878) moves tags via `GH_PAT_WORKFLOWS` (admin-owned); long-term hardening = a dedicated GitHub App id added to `bypass_actors` so the bypass scopes to the workflow identity (documented in the script header).

Closes #868. Refs #495, #500, #501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)