### PR TITLE
feat: implement issue #881 — pr-review engine: `COPILOT_API_MODEL` unbound var silently disables the cross-engine rubber-duck tier (engine.sh:431)

### DIFF
--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -163,7 +163,7 @@ set_engine_config() {
   # openai/o4-mini is the April-2025 o4-generation reasoning model; it is not a
   # typo for o1-mini or gpt-4o-mini.
   #
-  # Defaulted UNCONDITIONALLY (not just in the copilot) branch) because the
+  # Defaulted UNCONDITIONALLY (not just in the copilot branch) because the
   # cross-engine rubber-duck uses copilot even when it is not primary — e.g. the
   # claude) branch sets DUCK_ENGINE=copilot — and copilot_chat references a bare
   # $COPILOT_API_MODEL under `set -u`. Leaving it unset on a non-copilot primary

--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -139,13 +139,6 @@ set_engine_config() {
       ENGINE_AUDIT_MODEL="o4-mini"
       ENGINE_ACTION_MODEL="o4-mini"
       ENGINE_SINGLE_MODEL="o4-mini"
-      # GitHub Models API model identifier — must match a model available at
-      # https://models.github.ai (see GitHub Models marketplace).
-      # Override via COPILOT_API_MODEL env var if the default is unavailable.
-      # openai/o4-mini is the April-2025 o4-generation reasoning model; it is
-      # not a typo for o1-mini or gpt-4o-mini.
-      COPILOT_API_MODEL="${COPILOT_API_MODEL:-openai/o4-mini}"
-      export COPILOT_API_MODEL
       ENGINE_LABEL="triage: o4-mini → deep: o4-mini + duck: gemini-3.5-flash → audit: o4-mini (GitHub Models API)"
       ENGINE_SINGLE_LABEL="single-reviewer mode: o4-mini (GitHub Models API)"
       # Cross-engine rubber duck: use Gemini when Copilot is primary
@@ -163,6 +156,19 @@ set_engine_config() {
       exit 1
       ;;
   esac
+
+  # GitHub Models API model identifier for the copilot engine — must match a
+  # model available at https://models.github.ai (see GitHub Models marketplace).
+  # Override via COPILOT_API_MODEL env var if the default is unavailable.
+  # openai/o4-mini is the April-2025 o4-generation reasoning model; it is not a
+  # typo for o1-mini or gpt-4o-mini.
+  #
+  # Defaulted UNCONDITIONALLY (not just in the copilot) branch) because the
+  # cross-engine rubber-duck uses copilot even when it is not primary — e.g. the
+  # claude) branch sets DUCK_ENGINE=copilot — and copilot_chat references a bare
+  # $COPILOT_API_MODEL under `set -u`. Leaving it unset on a non-copilot primary
+  # silently aborts the duck subprocess and skips tier-2 (#881).
+  COPILOT_API_MODEL="${COPILOT_API_MODEL:-openai/o4-mini}"
 
   export ENGINE_TRIAGE_MODEL ENGINE_DEEP_MODEL ENGINE_AUDIT_MODEL
   export ENGINE_ACTION_MODEL ENGINE_SINGLE_MODEL

--- a/tests/dev-lead/unit/test_engine_duck_model.bats
+++ b/tests/dev-lead/unit/test_engine_duck_model.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+# Regression tests for engine.sh — COPILOT_API_MODEL must stay bound for the
+# cross-engine rubber-duck path even when copilot is NOT the primary engine.
+#
+# Bug (#881): the claude) branch wires the duck to copilot (DUCK_ENGINE=copilot)
+# but COPILOT_API_MODEL's default was assigned ONLY inside the copilot) branch.
+# Under a claude-primary review (the default), COPILOT_API_MODEL stayed unset, so
+# copilot_chat's bare `$COPILOT_API_MODEL` reference (engine.sh:431/436) aborted
+# under `set -u` → invalid duck JSON → tier-2 silently skipped.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+ENGINE_SCRIPT="$SCRIPT_DIR/scripts/engine.sh"
+
+setup() {
+  # Clear any inherited value so engine.sh defaults are evaluated fresh.
+  unset COPILOT_API_MODEL
+}
+
+teardown() {
+  unset COPILOT_API_MODEL
+}
+
+_source_engine() {
+  local engine="${1:-claude}"
+  export REVIEW_ENGINE="$engine"
+  source "$ENGINE_SCRIPT"
+}
+
+@test "duck-model: claude-primary config leaves COPILOT_API_MODEL bound to default" {
+  _source_engine "claude"
+  # ${VAR-x} (no colon) distinguishes unset from empty: unset → marker.
+  [ "${COPILOT_API_MODEL-__UNSET__}" = "openai/o4-mini" ]
+}
+
+@test "duck-model: sourcing as claude under set -u does not trip on COPILOT_API_MODEL (engine.sh:431 regression)" {
+  # Reproduce the production failure: a bare reference to $COPILOT_API_MODEL
+  # under `set -u` (which engine.sh enables) must not abort.
+  run bash -c "set -euo pipefail; unset COPILOT_API_MODEL; REVIEW_ENGINE=claude; source '$ENGINE_SCRIPT'; echo \"model=\$COPILOT_API_MODEL\""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"model=openai/o4-mini"* ]]
+  [[ "$output" != *"unbound variable"* ]]
+}
+
+@test "duck-model: explicit COPILOT_API_MODEL override is honored under claude" {
+  export COPILOT_API_MODEL="openai/gpt-5-mini"
+  _source_engine "claude"
+  [ "$COPILOT_API_MODEL" = "openai/gpt-5-mini" ]
+}
+
+@test "duck-model: copilot-primary still binds COPILOT_API_MODEL to default (no regression)" {
+  _source_engine "copilot"
+  [ "${COPILOT_API_MODEL-__UNSET__}" = "openai/o4-mini" ]
+}
+
+@test "duck-model: gemini-primary also leaves COPILOT_API_MODEL bound (latent non-copilot duck path)" {
+  _source_engine "gemini"
+  [ "${COPILOT_API_MODEL-__UNSET__}" = "openai/o4-mini" ]
+}


### PR DESCRIPTION
Closes #881

Implemented by dev-lead agent. Please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of engine configuration handling to prevent script failures in cross-engine scenarios

* **Tests**
  * Added regression tests to ensure engine configuration variables remain properly bound across different engine types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->