### PR TITLE
feat: implement issue #896 — triage skill: add a risk-severity rubric to prompts/triage.md (model systematically under-rates risk)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -73,6 +73,7 @@ jobs:
             tests/test_plan_critic.bats \
             tests/test_skill_review.bats \
             tests/test_skill_evals.bats \
+            tests/test_triage_prompt.bats \
             tests/test_holdout_guard.bats \
             tests/test_skill_eval_report.bats \
             tests/test_eval_health_notify.bats \

--- a/prompts/triage.md
+++ b/prompts/triage.md
@@ -55,6 +55,31 @@ pin. Treat this as an **informational signal to annotate**, exactly like
   file — even one with many consumers — does not by itself require escalation.
 - When the block is `(none)`, there is no downstream impact; do not mention it.
 
+## Risk rating
+
+The `risk` field is independent of `escalate`: it rates how *dangerous* the
+change is, not merely whether it needs a second look. A PR can escalate for a
+process reason and still be MEDIUM. Pick exactly one band, anchored to the
+escalate criteria above:
+
+- **HIGH** — a criterion-1 high-risk area is touched (authentication,
+  authorization, secrets/credentials/crypto/tokens, database migrations or
+  schema, GitHub Actions workflows handling secrets or `pull_request_target`,
+  or files matching the criterion-1 path globs), **or** a criterion-3 security
+  anti-pattern is present (SQL string concatenation, `eval`/`exec` on dynamic
+  input, `shell=True` with user input, hardcoded secrets, disabled TLS
+  verification, `dangerouslySetInnerHTML`, etc.).
+- **MEDIUM** — no criterion-1 area or criterion-3 anti-pattern is present, and
+  either: the PR escalates for a process signal (unresolved review threads,
+  unaddressed advisory-bot findings, incomplete or missing context), **or** it
+  is a clean, non-trivial logic/code change that does not escalate.
+- **LOW** — a trivial change with no logic impact: documentation, comments,
+  formatting, or test-only additions.
+
+When a change spans more than one band, use the highest that applies (a
+criterion-1 or criterion-3 hit is always HIGH, regardless of how small the diff
+looks).
+
 ## Output format
 
 Output EXACTLY one JSON object, nothing else. No markdown fences, no

--- a/tests/test_triage_prompt.bats
+++ b/tests/test_triage_prompt.bats
@@ -52,14 +52,14 @@ _risk_section() {
   # MEDIUM must capture BOTH the escalate:true-but-not-dangerous case
   # (unresolved-thread) and the escalate:false clean-logic-fix case — otherwise
   # the model collapses one of them to HIGH or LOW.
-  grep -Eiq 'process|unresolved|advisory|incomplete context' <<<"$section"
+  grep -Eiq 'process|unresolved|advisory|incomplete.*context' <<<"$section"
   grep -Eiq 'clean|non-trivial|logic' <<<"$section"
 }
 
 @test "LOW band is restricted to trivial / docs / test-only changes" {
   section="$(_risk_section)"
   grep -Eiq 'trivial' <<<"$section"
-  grep -Eiq 'docs|comment|formatting|test-only' <<<"$section"
+  grep -Eiq 'doc|comment|formatting|test-only' <<<"$section"
 }
 
 @test "the escalate criteria (1-7) remain intact alongside the new section" {

--- a/tests/test_triage_prompt.bats
+++ b/tests/test_triage_prompt.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+# Structural guard for the triage skill prompt (prompts/triage.md), #896.
+#
+# The held-out eval regressed to 2/5 because the model systematically under-rated
+# `risk` by one band: prompts/triage.md defined WHEN to escalate (criteria 1-7)
+# but the `risk` field appeared ONLY in the output schema with no rubric, so the
+# model guessed — and guessed low. The fix adds one additive `## Risk rating`
+# section anchored to the existing escalate criteria.
+#
+# These checks are deterministic and offline (the live 5/5 held-out confirmation
+# needs the real Haiku-tier model). They guard against the rubric section being
+# silently removed or hollowed out by a future edit/template sync — the same
+# silent-revert regression class the repo defends against elsewhere (#655, #823).
+
+setup() {
+  ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  PROMPT="$ROOT/prompts/triage.md"
+}
+
+@test "triage prompt has a Risk rating section" {
+  grep -Eq '^##[[:space:]]+Risk rating' "$PROMPT"
+}
+
+# Extract the body of the Risk rating section (from its heading up to the next
+# `## ` heading) so band assertions cannot accidentally match text elsewhere in
+# the prompt (e.g. the LOW|MEDIUM|HIGH token in the output schema).
+_risk_section() {
+  awk '
+    /^##[[:space:]]+Risk rating/ { insec=1; next }
+    insec && /^##[[:space:]]/    { insec=0 }
+    insec                        { print }
+  ' "$PROMPT"
+}
+
+@test "Risk rating section defines all three bands (HIGH, MEDIUM, LOW)" {
+  section="$(_risk_section)"
+  grep -q 'HIGH'   <<<"$section"
+  grep -q 'MEDIUM' <<<"$section"
+  grep -q 'LOW'    <<<"$section"
+}
+
+@test "HIGH band is anchored to criterion-1 high-risk areas or criterion-3 anti-patterns" {
+  section="$(_risk_section)"
+  # The defining property of HIGH per the case data: a high-risk area (criterion
+  # 1) is touched OR a security anti-pattern (criterion 3) is present.
+  grep -Eiq 'high-risk' <<<"$section"
+  grep -Eiq 'anti-pattern' <<<"$section"
+}
+
+@test "MEDIUM band covers process-driven escalation AND clean non-trivial changes" {
+  section="$(_risk_section)"
+  # MEDIUM must capture BOTH the escalate:true-but-not-dangerous case
+  # (unresolved-thread) and the escalate:false clean-logic-fix case — otherwise
+  # the model collapses one of them to HIGH or LOW.
+  grep -Eiq 'process|unresolved|advisory|incomplete context' <<<"$section"
+  grep -Eiq 'clean|non-trivial|logic' <<<"$section"
+}
+
+@test "LOW band is restricted to trivial / docs / test-only changes" {
+  section="$(_risk_section)"
+  grep -Eiq 'trivial' <<<"$section"
+  grep -Eiq 'docs|comment|formatting|test-only' <<<"$section"
+}
+
+@test "the escalate criteria (1-7) remain intact alongside the new section" {
+  # The escalate behavior is already correct and must stay untouched — guard that
+  # the Decision criteria section and its escalate switch still exist.
+  grep -q '## Decision criteria' "$PROMPT"
+  grep -q '"escalate": true' "$PROMPT"
+}


### PR DESCRIPTION
Closes #896

Implemented by dev-lead agent. Please review.