### PR TITLE
chore(auto-rebase): pin caller to @auto-rebase/stable channel (was frozen @v2)

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -6,9 +6,11 @@
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. All branch-update logic lives in the
 #     reusable workflow above.
-#   • You MAY change: the tag in the `uses:` line when upgrading the reusable
-#     workflow version (e.g. `@v1` → `@v2`).
-#   • You MUST NOT change: trigger event, the concurrency group name,
+#   • You MUST NOT change: the `uses:` ref — it is pinned to the
+#     `auto-rebase/stable` channel, a moving tag advanced centrally. Never
+#     repoint it to `@main`, a SHA, or a frozen `@vX` (see ci-standards.md →
+#     Reusable workflow versioning). Also do not change the trigger event,
+#     the concurrency group name,
 #     or the job-level `permissions:` block — reusable workflows can be
 #     granted no more permissions than the calling job has, so removing
 #     the stanza breaks the reusable's gh API calls.
@@ -19,6 +21,16 @@
 # Auto-rebase non-Dependabot PRs — thin caller for the org-level reusable.
 # To adopt: copy this file to .github/workflows/auto-rebase.yml in your repo.
 # No secrets required — uses GITHUB_TOKEN only.
+#
+# By default the reusable only updates *review-ready* PRs: non-draft AND
+# (carrying a current APPROVED review OR the `auto-rebase:ready` label). This
+# keeps the workflow from fanning out branch-update CI runs to every behind PR.
+# To tune it, pass inputs to the reusable, e.g.:
+#
+#   with:
+#     eligibility: review-ready      # default; or `all` to update every behind PR
+#     ready_label: auto-rebase:ready # label that opts a non-draft PR in
+#
 name: Auto-rebase non-Dependabot PRs
 
 on:
@@ -38,5 +50,5 @@ jobs:
     permissions:
       contents: write      # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write # post comments on PRs
-    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@v2
+    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@auto-rebase/stable
     secrets: inherit

--- a/.github/workflows/test-dev-lead.yml
+++ b/.github/workflows/test-dev-lead.yml
@@ -150,5 +150,5 @@ jobs:
           persist-credentials: false
       - name: Install PyYAML
         run: python3 -m pip install --quiet pyyaml
-      - name: Validate auto-rebase.yml uses @v1 (not a SHA)
+      - name: Validate auto-rebase.yml uses @auto-rebase/stable (not a SHA or frozen tag)
         run: python3 tests/dev-lead/integration/test_auto_rebase_stub.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,15 +27,12 @@ This is the `.github-private` org infrastructure repo for `petry-projects`. It c
   may be made to `dev-lead.yml` per the stub's header comment.
 - All other workflow changes must use templates from
   [`standards/workflows/`](https://github.com/petry-projects/.github/tree/main/standards/workflows) verbatim.
-- **Exception:** `.github/workflows/auto-rebase.yml` deliberately pins the reusable workflow at `@v2`, ahead of the
-  canonical org stub in `standards/workflows/auto-rebase.yml` (which still pins `@v1`). The `@v2` reusable workflow posts a
-  base-SHA-keyed conflict sentinel that triggers dev-lead's agentic rebase (the `rebase` intent in
-  `dev-lead.yml`) and accepts the optional `GH_PAT_WORKFLOWS` secret; `@v1` only posts a static "resolve
-  manually" comment. The repo-specific `auto-rebase-retry.yml` and `auto-rebase-health.yml` workflows are built
-  on this `@v2` sentinel-trigger behavior, and the `@v2` pin is locked by
-  `tests/dev-lead/integration/test_auto_rebase_stub.py` (#139). Downgrading to the canonical `@v1` — e.g. via a
-  template sync or a compliance-audit remediation — is a behavioral regression and must not be applied. When the
-  org canonical stub is bumped to `@v2`, remove this exception and defer to the template instead.
+- **Note:** `.github/workflows/auto-rebase.yml` pins the reusable workflow at the `@auto-rebase/stable`
+  moving channel tag, matching the canonical org stub in `standards/workflows/auto-rebase.yml`. Do not
+  repoint it to a frozen `@vX` tag, `@main`, or a SHA — `tests/dev-lead/integration/test_auto_rebase_stub.py`
+  (#139) enforces this. The repo-specific `auto-rebase-retry.yml` and `auto-rebase-health.yml` workflows
+  depend on the sentinel-trigger behavior provided by the current channel; downgrading to a pre-sentinel
+  frozen tag is a behavioral regression.
 - **Exception:** The `gh-aw-compile` job in `lint.yml` is a documented repo-specific addition that gates
   agentic workflow compilation. It is not covered by the org template and must not be removed by template
   syncs. If the org template gains a `gh-aw-compile` equivalent, remove this exception and defer to the

--- a/tests/dev-lead/integration/test_auto_rebase_stub.py
+++ b/tests/dev-lead/integration/test_auto_rebase_stub.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-"""Validate that auto-rebase.yml uses the @v2 version tag, not a SHA.
+"""Validate that auto-rebase.yml uses the @auto-rebase/stable channel tag, not a SHA or frozen @vX.
 
 AGENTS.md §"Release channel tags & the mutable-ref exception" exempts first-party
 reusable workflows from the SHA-pin standard. The correct reference for the
-auto-rebase reusable is the versioned tag `@v2`, matching the canonical stub at
-standards/workflows/auto-rebase.yml in petry-projects/.github.
+auto-rebase reusable is the moving channel tag `@auto-rebase/stable`, matching the
+canonical stub at standards/workflows/auto-rebase.yml in petry-projects/.github.
 
-Regression guard: a SHA-pinned reference is a compliance violation (issue #139).
+Regression guard: a SHA-pinned or frozen-tag reference is a compliance violation (issue #139).
 """
 from __future__ import annotations
 
@@ -20,7 +20,7 @@ except ImportError:
 
 WORKFLOW = ".github/workflows/auto-rebase.yml"
 REUSABLE = "petry-projects/.github/.github/workflows/auto-rebase-reusable.yml"
-EXPECTED_REF = "@v2"
+EXPECTED_REF = "@auto-rebase/stable"
 SHA_PATTERN = re.compile(r"@[0-9a-f]{40}\b")
 
 
@@ -63,8 +63,8 @@ def main() -> int:
             failures.append(
                 f"  SHA-pinned: {ref!r}\n"
                 f"  Expected:   '{REUSABLE}{EXPECTED_REF}'\n"
-                "  Reason: first-party reusable workflows must use the @v2 version\n"
-                "  tag, not a SHA (AGENTS.md §Release channel tags)."
+                "  Reason: first-party reusable workflows must use the @auto-rebase/stable\n"
+                "  channel tag, not a SHA (AGENTS.md §Release channel tags)."
             )
         elif not ref.endswith(EXPECTED_REF):
             failures.append(


### PR DESCRIPTION
## What

Re-syncs this repo's `.github/workflows/auto-rebase.yml` caller stub from the canonical `standards/workflows/auto-rebase.yml`. The only functional change is the reusable pin:

```
- uses: ...auto-rebase-reusable.yml@v2
+ uses: ...auto-rebase-reusable.yml@auto-rebase/stable
```

plus corrected header guidance and documentation of the `eligibility` / `ready_label` inputs.

## Why

This caller was pinned to the frozen **`@v2`** tag (376a4fcb, 2026-05-19), which:
- **predates** the review-ready eligibility gate (#465/#468) — so this repo still runs the **original unrestricted fan-out** (verified: PR#744, no approval / no `auto-rebase:ready` label, was auto-updated on the 3 most recent runs); and
- **violates the org standard**, which requires callers to pin the centrally-advanced `auto-rebase/stable` channel and **never** a frozen `@vX` (see `standards/ci-standards.md` → Reusable workflow versioning).

## Rollout interaction

Part of the auto-rebase review-ready rollout. Ordering is safe either way:
- **Before** `auto-rebase/stable` is promoted to the fixed reusable: this repo runs the current channel head — same unrestricted behavior as today, no regression.
- **After** promotion (channel → a commit with petry-projects/.github#528 + #468): this repo **automatically** adopts the review-ready restriction, no further change needed.

Depends on petry-projects/.github#528 (keystone `tooling_ref` fix) being merged and the channel promoted before the restriction takes effect here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)