### PR TITLE
chore: repin centralized stubs to next ring channel (#870)

### DIFF
--- a/.github/workflows/agent-shield.yml
+++ b/.github/workflows/agent-shield.yml
@@ -30,6 +30,6 @@ permissions:
 
 jobs:
   agent-shield:
-    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@761dd4a1a484a239429ed15d44d068de04fe2ee1 # v1
+    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@agent-shield/next
     with:
       required-files: AGENTS.md

--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -50,5 +50,5 @@ jobs:
     permissions:
       contents: write      # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write # post comments on PRs
-    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@auto-rebase/next
+    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@auto-rebase/stable
     secrets: inherit

--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -50,5 +50,5 @@ jobs:
     permissions:
       contents: write      # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write # post comments on PRs
-    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@auto-rebase/stable
+    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@auto-rebase/next
     secrets: inherit

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -35,5 +35,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@dependabot-automerge/next
     secrets: inherit

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   dependency-audit:
-    uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@dependency-audit/next

--- a/.github/workflows/pr-review-mention.yml
+++ b/.github/workflows/pr-review-mention.yml
@@ -37,7 +37,7 @@ jobs:
   pr-review-mention:
     permissions:
       pull-requests: write
-    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@v2
+    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@pr-review-mention/next
     secrets:
       GH_PAT_WORKFLOWS: ${{ secrets.GH_PAT_WORKFLOWS }}
       DON_PETRY_BOT_GH_PAT: ${{ secrets.DON_PETRY_BOT_GH_PAT }}

--- a/.github/workflows/test-dev-lead.yml
+++ b/.github/workflows/test-dev-lead.yml
@@ -137,7 +137,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install PyYAML
         run: python3 -m pip install --quiet pyyaml
-      - name: Validate dependency-audit.yml is pinned to the canonical @v1 ref
+      - name: Validate dependency-audit.yml is pinned to the canonical @dependency-audit/next ref
         run: python3 tests/dev-lead/integration/test_dependency_audit_stub.py
 
   auto-rebase-stub:

--- a/.github/workflows/test-dev-lead.yml
+++ b/.github/workflows/test-dev-lead.yml
@@ -150,5 +150,5 @@ jobs:
           persist-credentials: false
       - name: Install PyYAML
         run: python3 -m pip install --quiet pyyaml
-      - name: Validate auto-rebase.yml uses @auto-rebase/stable (not a SHA or frozen tag)
+      - name: Validate auto-rebase.yml uses @auto-rebase/next (not a SHA or frozen tag)
         run: python3 tests/dev-lead/integration/test_auto_rebase_stub.py

--- a/tests/dev-lead/integration/test_auto_rebase_stub.py
+++ b/tests/dev-lead/integration/test_auto_rebase_stub.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Validate that auto-rebase.yml uses the @auto-rebase/stable channel tag, not a SHA or frozen @vX.
+"""Validate that auto-rebase.yml uses the @auto-rebase/next channel tag, not a SHA or frozen @vX.
 
 AGENTS.md §"Release channel tags & the mutable-ref exception" exempts first-party
-reusable workflows from the SHA-pin standard. The correct reference for the
-auto-rebase reusable is the moving channel tag `@auto-rebase/stable`, matching the
+reusable workflows from the SHA-pin standard. This repo (.github-private) is the
+`next` ring tier (epic #495), so the correct reference for the auto-rebase
+reusable is the moving channel tag `@auto-rebase/next` (#870), matching the
 canonical stub at standards/workflows/auto-rebase.yml in petry-projects/.github.
 
 Regression guard: a SHA-pinned or frozen-tag reference is a compliance violation (issue #139).
@@ -20,7 +21,7 @@ except ImportError:
 
 WORKFLOW = ".github/workflows/auto-rebase.yml"
 REUSABLE = "petry-projects/.github/.github/workflows/auto-rebase-reusable.yml"
-EXPECTED_REF = "@auto-rebase/stable"
+EXPECTED_REF = "@auto-rebase/next"
 SHA_PATTERN = re.compile(r"@[0-9a-f]{40}\b")
 
 

--- a/tests/dev-lead/integration/test_dependency_audit_stub.py
+++ b/tests/dev-lead/integration/test_dependency_audit_stub.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Validate that dependency-audit.yml is the canonical org stub pinned to @v1.
+"""Validate that dependency-audit.yml is the canonical org stub pinned to @dependency-audit/next.
 
 The org standard requires dependency-audit.yml to be a thin caller stub that
-delegates to the reusable at @v1 (not a SHA or any other ref).
+delegates to the reusable at @dependency-audit/next (not a SHA or any other ref).
 
 Standard: petry-projects/.github/standards/ci-standards.md#centralization-tiers
 Source of truth: petry-projects/.github/standards/workflows/dependency-audit.yml
@@ -18,7 +18,7 @@ except ImportError:
     sys.exit(2)
 
 WORKFLOW = ".github/workflows/dependency-audit.yml"
-EXPECTED_USES = "petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@v1"
+EXPECTED_USES = "petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@dependency-audit/next"
 
 
 def main() -> int:
@@ -53,7 +53,7 @@ def main() -> int:
                 print(
                     f"FAIL: {WORKFLOW} job '{job_key}' uses '{uses}'\n"
                     f"  Expected: '{EXPECTED_USES}'\n"
-                    f"  Fix: replace the `uses:` value with the canonical @v1 ref."
+                    f"  Fix: replace the `uses:` value with the canonical @dependency-audit/next ref."
                 )
                 return 1
 

--- a/tests/test_dependabot.bats
+++ b/tests/test_dependabot.bats
@@ -8,6 +8,10 @@
 
 DEPENDABOT_YML=".github/dependabot.yml"
 AUTOMERGE_YML=".github/workflows/dependabot-automerge.yml"
+# This repo (.github-private) is the `next` ring tier (epic #495), so its stub
+# pins the dependabot-automerge/next channel rather than the former @v1 SHA
+# (#870). The org compliance audit is ring-aware (petry-projects/.github#529).
+AUTOMERGE_CHANNEL="dependabot-automerge/next"
 
 setup() {
   # Run tests from repo root so relative paths resolve correctly.
@@ -42,12 +46,14 @@ setup() {
   [ -f "$AUTOMERGE_YML" ]
 }
 
-@test "dependabot-automerge.yml pins the reusable at @v1 (compliance-audit check)" {
-  grep -qE '^\s*uses:[[:space:]]*petry-projects/\.github/\.github/workflows/dependabot-automerge-reusable\.yml@v1[[:space:]]*$' "$AUTOMERGE_YML"
+@test "dependabot-automerge.yml pins the reusable to the next ring channel (compliance-audit check)" {
+  grep -qE "^[[:space:]]*uses:[[:space:]]*petry-projects/\.github/\.github/workflows/dependabot-automerge-reusable\.yml@${AUTOMERGE_CHANNEL}[[:space:]]*\$" "$AUTOMERGE_YML"
 }
 
-@test "dependabot-automerge.yml does not reference a non-v1 pin" {
-  ! grep -qE 'dependabot-automerge-reusable\.yml@(v1[a-zA-Z0-9._/-]+|[^v]|v[^1])' "$AUTOMERGE_YML"
+@test "dependabot-automerge.yml does not reference an off-channel pin" {
+  # Reject the pre-ring @vN pins, raw SHAs, and any non-next ring channel
+  # (stable/ring0/ring1); only dependabot-automerge/next is acceptable here.
+  ! grep -qE 'dependabot-automerge-reusable\.yml@(v[0-9]|[0-9a-f]{7,}|[a-z-]+/(stable|ring[0-9]))' "$AUTOMERGE_YML"
 }
 
 @test "dependabot-automerge.yml triggers on pull_request_target" {


### PR DESCRIPTION
Repins this repo's #482 reusable caller stubs onto the canary-ring `<name>/next` channels (epic #495).

The `next` channels were cut at the currently-running proven version (`376a4fcb`), so this is a **zero-behavior-change** repin — promotion to newer code is a separate soak-gated step. The ring-aware audit (petry-projects/.github#529, merged) already accepts these channels, so dev-lead remediation will not revert them (#482 lesson).

Refs #870

🤖 Generated with [Claude Code](https://claude.com/claude-code)