### PR TITLE
docs: post-mortem + prevention proposals for runaway PR #860

### DIFF
--- a/docs/postmortems/2026-06-pr-860-runaway.md
+++ b/docs/postmortems/2026-06-pr-860-runaway.md
@@ -1,0 +1,274 @@
+# Post-mortem: Runaway PR #860 (self-mention comment loop + dev-lead autofix commit loop)
+
+**Status:** Analysis / proposal — no production behavior changed by this document.
+**PR:** [petry-projects/.github-private#860](https://github.com/petry-projects/.github-private/pull/860)
+ — *feat: implement issue #846 — [Phase 2] Cache the LSP index and enforce the 30s cold-start SLA with auto-skip*
+**Window:** opened 2026-06-21, still open/`blocked` on 2026-06-25 (4 days).
+**Author of analysis:** Claude Code (branch `claude/pr-860-runaway-analysis-a513i0`).
+**Method:** all 378 commits, all 1,582 issue comments (16 API pages, none sampled), 33 reviews,
+and review-thread payloads were retrieved and parsed; workflow/script wiring read from the repo.
+
+---
+
+## 1. Executive summary
+
+A routine Phase-2 PR accumulated **378 commits** and **1,582 comments** over four days while
+its **net diff stayed tiny — 18 files, +524/−982**. This was not one runaway run and not a
+human; it was **two of our own agents looping**, one on comments and one on commits:
+
+1. **The dominant loop — self-mention comment storm.** The `pr-review` cascade posts an
+   acknowledgement comment that **@-mentions the bot itself**:
+   > `<!-- pr-review-agent mention-ack -->`
+   > `@donpetry-bot I'm on it — starting a fresh review now. Results will appear in a few minutes.`
+
+   That self-mention is an `issue_comment: created` event, which `pr-review-mention.yml`
+   treats as a request to review — so it re-triggers the cascade, which posts **another**
+   self-mentioning ack. **1,481 of the 1,582 comments (93.6%) are this one byte-identical
+   comment**, posted at a **~9-second cadence for ~4.5 hours** on 2026-06-24 (1,487 comments
+   that day alone). The bot was talking to itself.
+
+2. **The secondary loop — dev-lead autofix commit storm.** Every push by `dev-lead-fix-*`
+   re-fired the cascade (on `synchronize`), and every review re-triggered `dev-lead` — 378
+   commits of `fix(reviews): address review comments`, `fix(bot): address bot feedback`,
+   `chore: apply manual instructions`, repeated `merge main`, and **direction reversals**
+   (`lsp-verification` → `lsp-coldstart-sla`, `revert: restore all …`). This loop actively
+   **corrupted the code**: CodeRabbit and dev-lead's own cleanup caught **14 functions
+   defined 2–4× each**, bloating one file to 2,513 lines before a manual cut back to 1,454.
+
+**A loop-breaker existed and was defeated.** The `pr-review` 3-cycle cap (#467) *did* fire
+once and post an escalation — but its documented re-engagement path is **"mention the bot
+(`@donpetry-bot review`) for an immediate re-review"**, which is *exactly* what the
+self-mention-ack does. The safety cap's escape hatch was a bot-reachable action, so the bot
+re-armed itself every cycle.
+
+**There was no human in the thread at all.** Even the 47 comments from the `don-petry`
+account are machine markers (`<!-- dev-lead-fix-reviews … -->`, `<!-- auto-rebase-conflict … -->`).
+The only "stop" signals were machine-generated: the bot's own escalation, Codex "usage
+limits" walls (re-hit 34×), rate-limited notices, and finally **GitHub's own ceilings** —
+CodeRabbit hit *"limits when posting large numbers of comments"* and the PR neared the same
+2,500-comment wall that disabled commenting in incident #855.
+
+This is a **recurring class of failure**: #855 (pr-review comment storm, ~2,493 duplicate
+comments) and #916 (100-run trigger storm in 15 min) are the same root cause —
+**unbounded agent-to-agent / agent-to-self feedback** — on different surfaces.
+
+---
+
+## 2. The facts
+
+| Metric | Value | Note |
+|---|---|---|
+| Comments | **1,582** | **1,481 (93.6%) are one identical self-mention ack** |
+| Commits ahead of `main` | **378** | Net diff is 18 files → ~95% churn |
+| Files / additions / deletions | 18 / +524 / **−982** | Net code *removal*; large deletion → `ack-test-deletion` label |
+| Comment authors | `donpetry-bot` 1,498 · `don-petry` 47 (machine markers) · `chatgpt-codex-connector[bot]` 34 (all "usage limits") · `coderabbitai` 1 · `github-actions` 1 · `sonarqubecloud` 1 | **Zero genuine human comments** |
+| Peak rate | **~1,487 comments on 2026-06-24** (~408/hr peak, ~1 every 9s for ~4.5h) | The self-mention loop running away |
+| Days open | 4 (06-21 → 06-25) | Loop survived restarts |
+| Commit-date span | **2026-04-08 → 2026-06-25** | Branch built on a **stale April base**, never squashed/rebased clean |
+| Mergeable state | `blocked` | Never converged |
+| Code corruption | **14 functions defined 2–4×**, file 2,513→1,454 lines after cleanup | The autofix loop re-appended instead of replacing |
+
+**The cascade involved** (named in the reviews): `triage (haiku 4.5) → deep (opus 4.8) +
+duck (o4-mini) → audit (fable 5)` — the "duck" stage is the rubber-duck reviewer. Exhausted
+advisory engines (Codex, CodeRabbit) were **re-invoked after they were already rate-limited**,
+each replying with an identical error until they hit their own posting limits.
+
+---
+
+## 3. Root cause
+
+### Loop A — self-mention acknowledgement (the dominant, 93.6% of comments)
+
+```
+ pr-review cascade starts a review
+        │  posts ack comment:  "@donpetry-bot I'm on it — starting a fresh review now…"
+        ▼
+ GitHub emits `issue_comment: created`
+        ▼
+ pr-review-mention.yml   ← on: issue_comment [created]  (mention listener)
+        │  sees "@donpetry-bot" → interprets as a review request → repository_dispatch pr-review-mention
+        ▼
+ pr-review cascade starts again → posts another identical ack
+        └───────────────────────────────► ~1 every 9s, for hours
+```
+
+**Two design faults made this self-sustaining:**
+
+1. **The bot @-mentions itself in its own ack, and the mention listener does not exclude the
+   bot's own comments / its own `<!-- pr-review-agent mention-ack -->` marker.** A comment the
+   agent posts about itself should never be a trigger for the agent.
+2. **The anti-loop cap's re-engagement path is a bot-reachable action.** #467's escalation
+   says *"mention the bot for an immediate re-review"* — but mentioning the bot is exactly what
+   the bot does to itself. So the one guard that fired (3-cycle cap → `needs-human-review`) was
+   **un-paused by the loop itself** on the very next ack. A safety cap whose reset is reachable
+   by the runaway agent is not a cap.
+
+### Loop B — dev-lead autofix commit storm (the 378 commits)
+
+```
+ dev-lead-fix-reviews / fix-ci pushes a fixup commit (new SHA)
+        │  git push → `synchronize`
+        ▼
+ pr-review-trigger.yml re-reviews (new SHA defeats same-SHA idempotency)
+        │  posts fix-requests / dismiss+re-review
+        ▼
+ dev-lead.yml (on pull_request_review, issue_comment, check_run) → fix again → push
+        └──────────────────────────────► new SHA, forever
+```
+
+`[skip ci-relay]` on fixup commits suppresses the **CI** relay, but a push is still a
+`synchronize` event, so the **review** half was never suppressed. Each fixup is a new SHA, so
+pr-review's same-SHA idempotency (#899) can't stop it. Worse, the autofix engine **re-appended
+function definitions instead of replacing them**, so each cycle *grew and corrupted* the file —
+the loop wasn't even converging on correctness.
+
+### Why every existing guard let it through
+
+| Guard | Scope | Why it didn't stop #860 |
+|---|---|---|
+| `MAX_REVIEW_CYCLES=3` (`lib/review-cycle.sh`, #467) | non-converging review cycles since last approval/escalation | **Fired once**, then was re-armed by the bot's own self-mention (the documented re-engage path). Also resets on *machine* approvals. |
+| `MAX_FAIL_ATTEMPTS=2` (`dev-lead-fix-ci`) | consecutive engine **failures** | Counts failures only; succeeding fixups that push commits increment nothing. |
+| `MAX_ATTEMPTS=3` (`auto-rebase-retry`) | retries of one rebase run | Per-run, not per-PR-lifetime. |
+| `MAX_DISPATCH=20` (sweep) | dispatches **per sweep tick** | Resets every tick. |
+| `concurrency: cancel-in-progress` | collapses concurrent bursts | Bounds parallelism, not sequential iteration count (#916 showed the same). |
+| same-SHA review idempotency (#899) | one review per SHA | Every fixup is a **new** SHA. |
+| `dev-lead-retry.yml` (every 2h) | re-dispatch rate-limited PRs | **Amplifier** — re-ignites a stalled loop. |
+
+**The missing control:** nothing bounds **total automated activity on one PR over its
+lifetime** (acks + commits + review cycles + age), and **no guard's reset requires a human.**
+Each agent is partially bounded alone; the composite — and the bot's conversation with itself —
+is unbounded.
+
+### Contributing factors
+
+- **Stale April base, never squashed** — repeated `merge main` inflated commits and created
+  recurring conflict-resolution work that itself triggered more fix cycles (the #655 stale-base
+  hazard, but *inside* a live PR rather than at merge).
+- **Direction reversal mid-flight** — agents "addressed feedback" pointing in conflicting
+  directions, so the design never converged.
+- **Exhausted advisory bots re-invoked** — Codex/CodeRabbit re-called after rate-limit, adding
+  noise and hitting their own posting ceilings.
+- **Known incident class** — #855/#916 were patched *locally* (dedupe one comment; add one
+  concurrency group). No cross-agent, per-PR, human-reset budget was introduced, so the loop
+  reappeared on a new surface.
+
+---
+
+## 4. Learnings
+
+1. **An agent must never be triggered by its own output.** The single highest-impact bug here
+   is the bot @-mentioning itself in an ack that the mention listener then acts on. Self-authored
+   events (and marker-tagged acks) must be filtered at the trigger.
+2. **A safety cap whose reset is reachable by the runaway is not a cap.** "Mention the bot to
+   re-engage" let the bot un-pause itself. Reset events must require a **human** (human comment,
+   human label removal, human push) — never a bot-reachable command or a machine approval.
+3. **Bound the work item, not just the worker.** Per-script caps (engine failures, rebase
+   retries, sweep dispatches) don't compose into a system bound. The budget must live on the
+   **PR**, shared by every agent that writes to it.
+4. **Success can loop too.** Guards that count only *failures* miss loops made of succeeding
+   actions (1,481 successful acks; 378 successful pushes). Count *actions*.
+5. **A new SHA is not new intent.** SHA-keyed idempotency can't stop a loop whose every
+   iteration makes a new SHA. Loop detection needs a key stable across fixups (PR + churn count).
+6. **Re-trigger crons amplify runaways.** `dev-lead-retry` / sweep must check a stop condition
+   *before* re-dispatching, or they keep dead loops alive.
+7. **No human noticed for four days.** There was no human in the thread and no proactive alert.
+   Detection has to be pushed (a health check), not pulled (someone happening to look).
+8. **Autofix that appends instead of replaces corrupts under iteration.** The function
+   duplication shows the fix engine can make a PR *worse* each cycle — another reason to cap
+   cycles hard rather than trust convergence.
+
+---
+
+## 5. Proposed improvements
+
+Ordered by impact/effort; scoped to existing files so changes mirror established patterns.
+
+### P0 — Stop the self-trigger (the single most important fix)
+
+In `pr-review-mention.yml` (and the org `pr-review-mention-reusable.yml` it calls), **ignore
+mention events authored by the bot itself and any comment carrying the
+`<!-- pr-review-agent mention-ack -->` (or any `<!-- pr-review-agent … -->`) marker.** A
+comment the agent posts about its own work must never re-trigger the agent. Equivalently /
+additionally: the ack comment should **not literally `@`-mention `donpetry-bot`** — use plain
+text so no mention webhook fires. Either change alone kills 93.6% of the volume.
+
+### P0 — Make the cap's reset require a human
+
+In `lib/review-cycle.sh` and the #467 escalation copy: the re-engagement path must be a
+**human** action (a human removing `needs-human-review`, or a human — not the bot — pushing or
+commenting). Remove "mention the bot to re-engage" as an automated escape hatch, and change the
+cycle-counter reset event from "latest approval marker" to "latest approval **by a human**".
+Machine approvals (`repair-pr-approvals`, bot approvals) must not reset the counter.
+
+### P0 — Per-PR automated-churn circuit breaker (shared budget)
+
+Add `lib/pr-automation-budget.sh` with `compute_pr_automation_cycles <pr>` /
+`pr_budget_exhausted <pr>`, counting **agent-authored commits + review cycles + acks since the
+last *human* interaction**. Default ceiling `MAX_PR_AUTOMATION_CYCLES=10` (env-overridable).
+Consulted by `dev-lead-fix-reviews.sh` / `dev-lead-fix-ci.sh` (before `commit_and_push`) and
+`review-one-pr.sh` (before submitting). On exhaustion: stop all automated writes, add
+`needs-human`, **disable auto-merge**, post **one** deduped escalation
+(`<!-- pr-automation-budget exhausted -->`), and re-engage only on human action. This is the
+cross-agent generalization of the #467 cap; unlike it, the reset is human-gated.
+
+### P1 — Retry crons must respect the stop condition
+
+`dev-lead-retry.yml` and `pr-review-sweep.yml` must skip any PR carrying the
+budget-exhausted / `needs-human` marker **before** re-dispatching (reuse the existing
+`has_escalation_marker` check). A scheduler that re-ignites an escalated PR defeats the breaker.
+
+### P1 — Don't re-invoke exhausted advisory engines; dedupe their notices
+
+When an engine (Codex/Gemini/CodeRabbit) returns a rate-limit/usage-limit response, mark it
+exhausted for the run and **post at most one** notice (the #855 fix, applied to every engine in
+the cascade, not just the originally reported one).
+
+### P2 — Surface runaway PRs in health checks (detection net)
+
+Extend `daily-pr-review-health` / `fleet_monitor` to flag any open PR over soft thresholds
+(**> 50 commits**, **> 200 comments**, **> N agent cycles**, or **open > 48h with active agent
+churn**) as a *runaway candidate*. #860 ran four days unseen; a daily push alert catches the
+next one on day one and would have caught #855/#916/#860 alike.
+
+### P2 — Keep agent branches rebased, not merge-stacked
+
+Prefer rebase/squash over repeated `merge main` for agent branches (via the existing auto-rebase
+path), so commit count tracks real change and the stale-base hazard can't accumulate inside a
+long-lived PR. A 378-commit / 18-file PR is itself a lint-able smell.
+
+### Immediate operational mitigation (no code)
+
+Until P0 lands: **close PR #860 and re-open the intended change from a fresh, rebased branch off
+current `main`** (the history is unrecoverable churn and the file is function-duplicated; the
+real change is an 18-file, +524/−982 diff). **Pause** `dev-lead-retry` / sweep dispatch against
+it and ensure the mention listener can't re-arm it, so neither loop can restart.
+
+---
+
+## 6. Acceptance criteria for the fix (P0)
+
+- [ ] A comment authored by the bot, or carrying a `pr-review-agent` marker, **never**
+      re-triggers the mention listener; the ack comment fires no mention webhook.
+- [ ] The cycle cap and the per-PR budget reset **only** on human action; a machine approval
+      or a bot mention does not reset them.
+- [ ] A PR reaching `MAX_PR_AUTOMATION_CYCLES` gets **one** escalation, a `needs-human` label,
+      auto-merge disabled, and **no further automated commits, reviews, or acks**.
+- [ ] `dev-lead-retry.yml` / `pr-review-sweep.yml` skip PRs carrying the exhausted marker.
+- [ ] Regression coverage: an E2E scenario simulating (a) a self-mention ack and (b) a
+      review↔fix ping-pong, asserting both halt at the budget.
+
+---
+
+## 7. References
+
+- This PR: #860 (self-mention comment storm + autofix commit storm)
+- #855 — pr-review comment runaway (~2,493 duplicate "engine unavailable" comments; hit GitHub's 2,500 limit) — *closed*
+- #916 — pr-review trigger storm (100 runs / ~15 min, self-review loop suspected) — *open*
+- #192 — rate-limited runs lost; origin of `dev-lead-retry.yml` — *closed*
+- #467 — `lib/review-cycle.sh` cycle cap (the pattern P0 generalizes and human-gates)
+- #899 — pr-review "already reviewed" / same-SHA idempotency
+- #655 — stale-base / semantic-revert guard (`test-deletion-guard.yml`)
+- Key files: `.github/workflows/pr-review-mention.yml`, `.github/workflows/pr-review-trigger.yml`,
+  `.github/workflows/dev-lead.yml`, `.github/workflows/dev-lead-retry.yml`,
+  `.github/workflows/pr-review-sweep.yml`, `scripts/dev-lead-fix-reviews.sh`,
+  `scripts/dev-lead-fix-ci.sh`, `scripts/review-one-pr.sh`, `scripts/lib/review-cycle.sh`

--- a/docs/postmortems/2026-06-pr-860-runaway.md
+++ b/docs/postmortems/2026-06-pr-860-runaway.md
@@ -207,14 +207,14 @@ Add `lib/pr-automation-budget.sh` with `compute_pr_automation_cycles <pr>` /
 last *human* interaction**. Default ceiling `MAX_PR_AUTOMATION_CYCLES=10` (env-overridable).
 Consulted by `dev-lead-fix-reviews.sh` / `dev-lead-fix-ci.sh` (before `commit_and_push`) and
 `review-one-pr.sh` (before submitting). On exhaustion: stop all automated writes, add
-`needs-human`, **disable auto-merge**, post **one** deduped escalation
+`needs-human-review`, **disable auto-merge**, post **one** deduped escalation
 (`<!-- pr-automation-budget exhausted -->`), and re-engage only on human action. This is the
 cross-agent generalization of the #467 cap; unlike it, the reset is human-gated.
 
 ### P1 — Retry crons must respect the stop condition
 
 `dev-lead-retry.yml` and `pr-review-sweep.yml` must skip any PR carrying the
-budget-exhausted / `needs-human` marker **before** re-dispatching (reuse the existing
+budget-exhausted / `needs-human-review` marker **before** re-dispatching (reuse the existing
 `has_escalation_marker` check). A scheduler that re-ignites an escalated PR defeats the breaker.
 
 ### P1 — Don't re-invoke exhausted advisory engines; dedupe their notices
@@ -251,7 +251,7 @@ it and ensure the mention listener can't re-arm it, so neither loop can restart.
       re-triggers the mention listener; the ack comment fires no mention webhook.
 - [ ] The cycle cap and the per-PR budget reset **only** on human action; a machine approval
       or a bot mention does not reset them.
-- [ ] A PR reaching `MAX_PR_AUTOMATION_CYCLES` gets **one** escalation, a `needs-human` label,
+- [ ] A PR reaching `MAX_PR_AUTOMATION_CYCLES` gets **one** escalation, a `needs-human-review` label,
       auto-merge disabled, and **no further automated commits, reviews, or acks**.
 - [ ] `dev-lead-retry.yml` / `pr-review-sweep.yml` skip PRs carrying the exhausted marker.
 - [ ] Regression coverage: an E2E scenario simulating (a) a self-mention ack and (b) a


### PR DESCRIPTION
## What this is

An investigation, root-cause analysis, and prevention proposal for **runaway PR #860**
(*[Phase 2] Cache the LSP index…*), which accumulated **378 commits** and **1,582 comments**
over four days for a **net 18-file, +524/−982 diff**.

Adds `docs/postmortems/2026-06-pr-860-runaway.md`. No production behavior is changed by this PR.

## Method

Every commit, all **1,582 comments** (16 API pages, none sampled), all 33 reviews, and the
workflow/script wiring were retrieved and parsed.

## Root cause (two interacting agent loops)

1. **Self-mention comment storm (dominant — 93.6% of comments).** The `pr-review` cascade
   posts an ack that **@-mentions the bot itself** (`@donpetry-bot I'm on it…`). That self-mention
   is an `issue_comment` event, so `pr-review-mention.yml` re-triggers the cascade, which posts
   another identical ack — **1,481 byte-identical comments at a ~9s cadence for ~4.5h** on 06-24.
2. **dev-lead autofix commit storm (the 378 commits).** Each `dev-lead-fix-*` push re-fired the
   cascade on `synchronize`; each review re-triggered dev-lead. The autofix engine **re-appended**
   function definitions instead of replacing them — **14 functions defined 2–4×** before a manual
   cleanup. `[skip ci-relay]` suppressed the CI relay but not the review re-trigger.

The #467 **3-cycle cap fired once** — but its documented re-engage path is *"mention the bot for
an immediate re-review,"* which is exactly what the self-mention ack does, so the bot un-paused
itself. There was **no human in the thread** for four days. This is the same class as **#855**
(comment storm) and **#916** (trigger storm) on a new surface.

## Headline learnings

- **An agent must never be triggered by its own output.**
- **A safety cap whose reset is reachable by the runaway is not a cap** — resets must be human-gated.
- **Bound the PR, not just each script**; **count actions, not just failures**; **a new SHA is not new intent**; **retry crons amplify runaways.**

## Proposed fixes (detailed in the doc)

- **P0** — mention listener ignores the bot's own comments / `pr-review-agent` acks (and the ack
  shouldn't `@`-mention the bot); human-gate every cap reset (no machine approvals, no bot mentions);
  a shared **per-PR automated-churn circuit breaker** (`MAX_PR_AUTOMATION_CYCLES`) → `needs-human` +
  auto-merge off.
- **P1** — `dev-lead-retry` / sweep skip the exhausted marker; dedupe exhausted-engine notices.
- **P2** — runaway-PR detection in `daily-pr-review-health` / `fleet_monitor`; rebase agent branches.
- **Immediate (no code):** close #860 and re-open the intended change from a fresh rebased branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV2trztQMwnyGCfoj1rymi)_