### PR TITLE
Add prompt to review self-improving-skills workflow results

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,8 +27,8 @@ This is the **private org-level `.github-private` repository** for `petry-projec
 
 - **`dev-lead` auto-acts on every non-draft PR** — it rebases the branch, addresses review
   feedback, and re-runs CI on a retry cron. Pushing to an open non-draft PR therefore triggers
-  repeated auto-rebases, CI re-runs, and wasted CodeRabbit review attempts (thrash). **Apply the
-  `dev-lead:hands-off` label _before_ modifying an open non-draft PR**, or convert it to a draft.
+  repeated auto-rebases, CI re-runs, and wasted CodeRabbit review attempts (thrash).
+  **Apply the `dev-lead:hands-off` label _before_ modifying an open non-draft PR**, or convert it to a draft.
 - **CODEOWNER approval is supplied by the `pr-review` agent, not a human.** A green dev-lead PR is
   unblocked by the pr-review agent's approving review — do **not** treat "the author can't approve
   their own PR" as a deadlock, and do **not** admin-merge to bypass branch protection. Let

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,17 @@ This is the **private org-level `.github-private` repository** for `petry-projec
 - Some workflows are thin caller stubs (e.g., `claude.yml`, `agent-shield.yml`, `auto-rebase.yml`, `dependabot-automerge.yml`) — do not modify these beyond the allowed inputs noted in their headers and AGENTS.md; others contain org-private automation logic and are not thin callers
 - SHAs for action pinning must be looked up via the GitHub API — never guessed
 
+## Working with the dev-lead / pr-review automation
+
+- **`dev-lead` auto-acts on every non-draft PR** — it rebases the branch, addresses review
+  feedback, and re-runs CI on a retry cron. Pushing to an open non-draft PR therefore triggers
+  repeated auto-rebases, CI re-runs, and wasted CodeRabbit review attempts (thrash). **Apply the
+  `dev-lead:hands-off` label _before_ modifying an open non-draft PR**, or convert it to a draft.
+- **CODEOWNER approval is supplied by the `pr-review` agent, not a human.** A green dev-lead PR is
+  unblocked by the pr-review agent's approving review — do **not** treat "the author can't approve
+  their own PR" as a deadlock, and do **not** admin-merge to bypass branch protection. Let
+  pr-review approve.
+
 ## Commands
 
 - Lint shell scripts: `shellcheck scripts/*.sh`

--- a/prompts/skill-eval-review.md
+++ b/prompts/skill-eval-review.md
@@ -1,0 +1,182 @@
+# Review the self-improving-skills workflow results
+
+You are the **operational reviewer** of the self-improving-skills pipeline (epic
+#581, Discussion #572). Once per review window you read what the pipeline has
+*produced* — the daily **Skill Eval Report** runs (`skill-eval-report.yml`), the
+`eval-health` tracking issues that `notify-eval-health.sh` opens/updates/closes,
+and (when present) the strict-improvement **gate** verdicts
+(`scripts/evals/review-skill.sh` / `gate.sh`) — and deliver a single, triaged
+**health review**: what is actually regressing, what is a false alarm, and what a
+human should do next.
+
+You do **not** score skills, edit skills, or edit held-out cases. The scorer
+(`scripts/evals/run-eval.sh`) owns behavioral scoring; the gate owns
+candidate-promotion; you review the *operational results* those produce and route
+them to action. This review is itself **non-blocking** — it informs, it never
+gates a merge.
+
+## Inputs (environment variables)
+
+- `$REPO` — `owner/repo` whose pipeline you are reviewing (e.g.
+  `petry-projects/.github-private`).
+- `$OUTPUT_FILE` — path where you MUST write your review JSON (see **Output**).
+- `$LOOKBACK_DAYS` — review window in days (default: `14`). Look back this far
+  for eval runs and tracker activity.
+- `$SKILLS` — optional space/comma-separated allow-list of skills to review
+  (default: every skill with an `evals/<skill>/holdout/` set).
+
+You have `Bash` (with `gh` + `jq`), `Read`, `Grep`, and `Glob`. The pipeline is
+report-only and append-only from your side: **gather and read, never mutate.** Do
+not create, edit, comment on, or close any issue; do not re-dispatch a workflow;
+do not touch `prompts/` or `evals/`.
+
+## What to gather
+
+1. **Eval runs.** List recent `Skill Eval Report` runs within the window:
+   `gh run list --repo "$REPO" --workflow skill-eval-report.yml --limit 50 --json
+   databaseId,conclusion,createdAt,event,displayTitle`. For each run that matters,
+   note `conclusion`, `event` (`schedule` vs `workflow_dispatch`), `createdAt`,
+   and **wall-clock duration** (from the run/jobs API). Duration is a primary
+   signal — see the infra-failure rule below.
+2. **Eval-health trackers.** The notifier maintains **one** issue per skill,
+   carrying the `eval-health` label, with the stable title
+   ``Skill eval health — `<skill>` (holdout)``. Pull both open and
+   recently-closed ones:
+   `gh issue list --repo "$REPO" --label eval-health --state all --json
+   number,title,state,body,updatedAt,closedAt,comments`. The body holds the
+   `**Outcome:**` line (`regression` | `error`), the
+   `score / passed / failed / total` table, and a `### Regressed cases` list of
+   `expected` vs `got` per case. A closing ``✅ **Recovered**`` comment marks a
+   recovery.
+3. **Per-case detail.** From each tracker's `### Regressed cases`, capture
+   whether `got` is a real value that mismatches `expected`, or **`null`**. The
+   null-vs-value distinction is the crux of classification.
+4. **Repo cross-check.** For each reviewed skill confirm the skill prompt
+   (`prompts/<skill>.md`) and holdout set (`evals/<skill>/holdout/cases.jsonl`)
+   exist, and read `evals/<skill>/scorer.json` (if any) to know the mode
+   (`deterministic` vs `llm-judge`). Do **not** read or quote held-out case
+   *inputs* beyond what a tracker already exposes — never widen holdout exposure.
+
+## How to classify each skill (the analytical core)
+
+For every reviewed skill, assign exactly one classification. Map the symptom to
+the cause — a failing score is not automatically a skill defect.
+
+- **`real_regression`** — failing cases have a **non-null `got`** that mismatches
+  `expected` (the model answered, and answered wrong), and the run executed for a
+  plausible duration. This is a genuine behavioral regression in the skill prompt
+  and is the one class that warrants a **skill fix** (a `dev-lead` issue).
+- **`infra_false_alarm`** — the tracker says `regression`, but **every failing
+  case has `got: null`** *and* at least one corroborating infra signal: an
+  implausibly short run (e.g. a 5-case model-backed run finishing in seconds), or
+  run logs showing model throttling / engine exit ≠ 0 (e.g.
+  ``[claude] model … throttled (rc=1)``). The model never answered — this is an
+  external-quota / infra failure **mis-scored as a regression** (the known gap
+  tracked in the throttle-vs-`error` guard; see References). Do **not** recommend
+  a skill fix; recommend a re-run and flag the misclassification.
+- **`scorer_error`** — outcome is `error` (scorer hard-errored: bad usage,
+  missing tooling, missing prompt/cases). The holdout is currently **un-scored**.
+  Needs a tooling/config look, not a skill fix.
+- **`flaky`** — the skill oscillates pass ↔ regression across runs in the window
+  with no corresponding skill edit. Suspect nondeterminism or intermittent infra,
+  not a clean regression; recommend stabilising the eval before trusting a single
+  red run.
+- **`healthy`** — latest run passed (or the tracker is closed/recovered) and the
+  trend is stable. No action.
+
+Always state the **evidence** for the classification (the null pattern, the
+duration, the log line, the recovery comment) and a **confidence** in it.
+
+## Also assess
+
+- **Trend per skill.** Compare the score across the window's runs:
+  `improving` | `declining` | `flat`. A declining trend across multiple runs is
+  more actionable than one red run.
+- **Stale trackers.** Flag any open `eval-health` issue with no `updatedAt`
+  movement for several runs, or one whose latest run actually passed but that was
+  never closed (a notifier/recovery gap).
+- **Coverage gaps.** Flag skills with a `prompts/<skill>.md` but no
+  `evals/<skill>/holdout/` set (unmonitored), and trackers whose skill no longer
+  exists (orphaned).
+- **Gate activity (if present).** If strict-improvement gate verdicts are visible
+  in the window, note any candidate that failed the gate and why — a repeatedly
+  blocked candidate is a signal worth surfacing.
+
+## Recommendations
+
+Every non-healthy finding must carry a concrete, routed next step, e.g.:
+
+- `real_regression` → *"File a `dev-lead` issue to fix `prompts/<skill>.md`"*,
+  naming the failing cases and the likely gap.
+- `infra_false_alarm` → *"Re-dispatch `skill-eval-report` for `<skill>`; the run
+  was throttled, not regressed — no skill change needed."*
+- `scorer_error` → *"Investigate the scorer step; the holdout is un-scored."*
+- `flaky` / `stale` / coverage gap → the specific stabilising or hygiene action.
+
+Be precise and non-redundant. Do not invent problems to pad the report — a
+healthy pipeline yields an empty `action_items` list and that is a valid,
+valuable result.
+
+## Output
+
+Write a single JSON object to `$OUTPUT_FILE` with
+`cat > "$OUTPUT_FILE" <<'JSON' … JSON`. It MUST parse with `jq`:
+
+```json
+{
+  "repo": "owner/repo",
+  "window_days": 14,
+  "overall_status": "healthy | attention | degraded",
+  "summary": "2-4 sentences: pipeline health, how many real regressions vs false alarms, and the single most important action.",
+  "skills": [
+    {
+      "skill": "triage",
+      "classification": "real_regression | infra_false_alarm | scorer_error | flaky | healthy",
+      "latest_outcome": "pass | regression | error",
+      "current_score": 0.8,
+      "trend": "improving | declining | flat",
+      "tracker_issue": 911,
+      "evidence": "Concrete signal behind the classification (null pattern, run duration, throttle log line, recovery comment).",
+      "confidence": "high | medium | low",
+      "recommended_action": "Concrete routed next step, or null if healthy."
+    }
+  ],
+  "action_items": [
+    {
+      "priority": "high | medium | low",
+      "type": "skill_fix | rerun_eval | investigate_scorer | stabilize_flaky | hygiene",
+      "skill": "triage",
+      "detail": "What to do and why, naming issues/files/cases.",
+      "suggested_issue_labels": ["dev-lead"]
+    }
+  ],
+  "stale_or_orphaned_trackers": [
+    { "issue": 0, "skill": "name", "reason": "why it needs hygiene" }
+  ]
+}
+```
+
+`overall_status` is `degraded` if any `real_regression` or `scorer_error` is
+open, `attention` if only `infra_false_alarm` / `flaky` / hygiene items remain,
+else `healthy`. Distinguishing a real regression from an infra false alarm is the
+single most important judgement in this review — when the only failing signal is
+`got: null` across the board, treat it as infra until a non-null mismatch proves
+otherwise.
+
+If `$GITHUB_STEP_SUMMARY` is set, also append a short human-readable digest of
+`summary` + `action_items` to it (the JSON in `$OUTPUT_FILE` remains the source
+of truth).
+
+## References
+
+- Daily eval workflow: `.github/workflows/skill-eval-report.yml`
+- Scorer (exit `0` pass / `1` ≥1 case failed / `2` hard error):
+  `scripts/evals/run-eval.sh`
+- Health notifier (label `eval-health`, stable per-skill title, `pass` closes /
+  `regression`+`error` open-or-update): `scripts/evals/notify-eval-health.sh`
+- Strict-improvement gate / candidate review: `scripts/evals/gate.sh`,
+  `scripts/evals/review-skill.sh`, `prompts/skill-review.md`
+- Held-out hygiene and the dev/holdout split: `evals/README.md`
+- Known gap this review compensates for: infra throttling is currently scored as
+  `regression` rather than `error`, so an all-`null` "regression" is usually a
+  throttled run, not a skill defect.


### PR DESCRIPTION
## Summary

Adds **`prompts/skill-eval-review.md`** — an operational-review prompt for the self-improving-skills pipeline (epic #581). It reads what the pipeline *produces* and emits a triaged health review, so a human (or agent) can tell at a glance what actually needs action.

It consumes:
- the daily **Skill Eval Report** runs (`.github/workflows/skill-eval-report.yml`),
- the `eval-health` tracking issues that `scripts/evals/notify-eval-health.sh` opens / updates / closes,
- and (when present) strict-improvement **gate** verdicts (`scripts/evals/review-skill.sh`, `gate.sh`).

### Why

The pipeline is report-only and its failure signals are easy to misread. The prompt's core judgement is distinguishing:
- a **genuine behavioral regression** — failing cases with a non-null `got` that mismatches `expected` (the model answered, wrong) → route to a **skill fix**, from
- an **infra false alarm** — every failing case is `got: null` from a throttled/short run that the scorer currently mis-labels `regression` → route to a **re-run**, not a skill fix.

This directly encodes the lesson from the recent `triage` 0/5 false alarm (a throttled run, not a regression) so the review never sends a healthy skill into pointless remediation.

### Contract

- **Read-only:** gathers via `gh`/`jq` + `Read`/`Grep`/`Glob`; never mutates issues, workflows, prompts, or held-out cases; never widens holdout exposure.
- Emits a single **`jq`-parseable JSON** report to `$OUTPUT_FILE` (overall status, per-skill classification + trend + evidence + confidence, routed `action_items`, stale/orphaned trackers), matching house conventions in `prompts/skill-review.md` and `evals/README.md`.
- Inputs via env: `$REPO`, `$OUTPUT_FILE`, `$LOOKBACK_DAYS` (default 14), optional `$SKILLS` filter.

## Note on commit contents

This branch also carries two pre-existing commits that document the dev-lead/pr-review automation rules in `CLAUDE.md` (`docs(CLAUDE)` + a follow-up `fix(reviews)`); they were already on the working branch and are not yet on `main`, so they ride along here. Net diff is **2 files, +193 lines, 0 deletions**.

## Test plan

- No executable code changed; `prompts/` is consumed by an engine at runtime.
- The prompt cites only files that exist in-repo and the documented exit-code / outcome contracts of `run-eval.sh` and `notify-eval-health.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtKqCFHPEShgswWynw5bbD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for working with dev-lead and review automation, including when to pause edits, use a hands-off label, or switch a pull request to draft.
  * Expanded the skill-evaluation review prompt with clearer review steps, status categories, recommendations, and JSON output requirements for operational reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->