### PR TITLE
feat: implement issue #934 — feature-ideation enhancement backfill + dry-run + marker continuity (restore idea-enhancer parity before deprecation)

### DIFF
--- a/.github/workflows/feature-ideation.yml
+++ b/.github/workflows/feature-ideation.yml
@@ -64,6 +64,11 @@ on:
         required: false
         default: false
         type: boolean
+      enhance_backlog:
+        description: 'Backfill: sweep this repo''s open, human-authored, not-yet-enhanced Ideas and post exactly one structured enhancement comment each (idempotent via the enhancement marker). Operator-triggered; pair with dry_run=true to preview without posting.'
+        required: false
+        default: false
+        type: boolean
   # Auto-enhance a freshly-created idea: when a new Discussion is opened in the
   # Ideas category, the analyst researches and refines it in single-idea mode.
   discussion:
@@ -146,5 +151,9 @@ jobs:
       focus_area: ${{ inputs.focus_area || '' }}
       research_depth: ${{ inputs.research_depth || 'standard' }}
       dry_run: ${{ inputs.dry_run || false }}
+      # Operator-triggered backlog sweep (#934). Empty on schedule/discussion
+      # triggers → false → normal scan/single-idea enhancement. Pair with
+      # dry_run=true to preview the intended comments without posting.
+      enhance_backlog: ${{ inputs.enhance_backlog || false }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/feature-ideation.yml
+++ b/.github/workflows/feature-ideation.yml
@@ -65,7 +65,11 @@ on:
         default: false
         type: boolean
       enhance_backlog:
-        description: 'Backfill: sweep this repo''s open, human-authored, not-yet-enhanced Ideas and post exactly one structured enhancement comment each (idempotent via the enhancement marker). Operator-triggered; pair with dry_run=true to preview without posting.'
+        description: >-
+          Backfill: sweep this repo's open, human-authored, not-yet-enhanced Ideas and
+          post exactly one structured enhancement comment each (idempotent via the
+          enhancement marker). Operator-triggered; pair with dry_run=true to preview
+          without posting.
         required: false
         default: false
         type: boolean

--- a/docs/initiatives/idea-to-initiative-pipeline.md
+++ b/docs/initiatives/idea-to-initiative-pipeline.md
@@ -69,6 +69,52 @@ unit-tested.
   and the human gates.
 - Tooling: `scripts/idea-enhancer/{gather-candidates,post-enhancement}.sh`.
 
+### Enhancement is folding into `feature-ideation` (#872) — backfill + dry-run
+
+The standalone `idea-enhancer` capability is being **consolidated** into the
+`feature-ideation` reusable workflow (epic #872) and the standalone enhancer is
+slated for deprecation (#876) **once** the folded path is validated. The two
+enhancement modes `idea-enhancer` provided — the existing-backlog **sweep** and
+the enhancement **dry-run** — are restored on the folded path (#934, planned
+from discussion #933). The enhancement logic lives in the **central** reusable
+`petry-projects/.github` (`feature-ideation-reusable.yml`); `.github-private`
+ships only the thin `feature-ideation.yml` caller stub (pinned to the
+`@feature-ideation/next` dogfood ring), which exposes these modes as
+`workflow_dispatch` inputs.
+
+- **Backfill sweep** — dispatch `feature-ideation` with `enhance_backlog: true`.
+  It sweeps the target repo's open, human-authored, not-yet-enhanced **Ideas**
+  Discussions and posts **exactly one** structured enhancement comment each.
+  Bot-authored and already-enhanced ideas are skipped. This is the safety-net
+  backfill that catches human ideas added before the folded enhancer went live.
+- **Dry-run** — dispatch with `dry_run: true` **and** `enhance_backlog: true`.
+  Every intended per-Discussion enhancement comment is logged to the JSONL
+  artifact and **nothing** is posted (one artifact entry per candidate
+  Discussion). The dry-run is free of model spend beyond candidate gathering.
+- **Marker continuity (cutover-safe).** The idempotency check honors **both**
+  the legacy `<!-- idea-enhancer:enhanced -->` marker and the canonical
+  `<!-- feature-ideation:enhanced -->` marker; new enhancement comments emit the
+  single canonical marker. So **no** idea enhanced by the old `idea-enhancer` is
+  re-enhanced after the cutover, and a repeated backfill is a no-op.
+- **Cost.** Operator-triggered (`workflow_dispatch`), **no new cron** — the
+  backfill reuses `feature-ideation`'s existing model budget and 20-minute
+  timeout, so it is cost-neutral-to-reducing.
+
+#### Operator runbook — backfilling the `.github-private` backlog
+
+1. **Dry-run first.** Run the **Feature Research & Ideation** workflow via
+   *Run workflow* with `enhance_backlog: true` **and** `dry_run: true`. Download
+   the dry-run JSONL artifact and confirm its entry count equals an independent
+   count of open, human-authored, not-yet-enhanced Ideas (the candidate set).
+   Nothing is posted.
+2. **Go live.** Re-dispatch with `enhance_backlog: true` and `dry_run: false`.
+   After one live run, every open, human-authored, not-yet-enhanced Idea carries
+   exactly one structured enhancement comment — the un-enhanced backlog drops to
+   **0**.
+3. **Verify idempotency.** A second live backfill run posts **0** new comments
+   (no idea is double-enhanced, including ideas already carrying the legacy
+   marker). Only then is `idea-enhancer` safe to deprecate (#876).
+
 ### `idea-triage.yml` — weekly ripeness shortlist
 - Scans every open **Ideas** Discussion, scores each **Ripe / Soon / Not yet**
   on evidence, prerequisites, alignment, coverage, and freshness.

--- a/tests/test_feature_ideation.bats
+++ b/tests/test_feature_ideation.bats
@@ -48,5 +48,5 @@ setup() {
 }
 
 @test "feature-ideation.yml forwards enhance_backlog to the reusable workflow" {
-  grep -qF 'enhance_backlog: ${{ inputs.enhance_backlog || false }}' "$FEATURE_IDEATION_YML"
+  grep -qE 'enhance_backlog:[[:space:]]*"?\$\{\{[[:space:]]*inputs\.enhance_backlog[[:space:]]*\|\|[[:space:]]*false[[:space:]]*\}\}"?' "$FEATURE_IDEATION_YML"
 }

--- a/tests/test_feature_ideation.bats
+++ b/tests/test_feature_ideation.bats
@@ -34,3 +34,19 @@ setup() {
   grep -F "uses: ${REUSABLE}@" "$FEATURE_IDEATION_YML"
   grep -qF "uses: ${REUSABLE}@${CHANNEL}" "$FEATURE_IDEATION_YML"
 }
+
+# ── #934: operator-triggered enhancement backfill ────────────────────────────
+# The folded feature-ideation reusable gains a backlog-sweep mode (porting the
+# idea-enhancer sweep). The stub exposes it as a boolean workflow_dispatch input
+# and forwards it, matching the canonical stub template so the sync is drift-free.
+
+@test "feature-ideation.yml exposes the enhance_backlog backfill-sweep input" {
+  # Declared as a workflow_dispatch input AND forwarded in with: → two occurrences.
+  run grep -c "enhance_backlog:" "$FEATURE_IDEATION_YML"
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 2 ]
+}
+
+@test "feature-ideation.yml forwards enhance_backlog to the reusable workflow" {
+  grep -qF 'enhance_backlog: ${{ inputs.enhance_backlog || false }}' "$FEATURE_IDEATION_YML"
+}


### PR DESCRIPTION
Closes #934

Implemented by dev-lead agent. Please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional workflow input to support backlog enhancement runs and dry-run previewing.
  * The workflow now passes this option through for operator-triggered backlog sweeps.

* **Documentation**
  * Expanded the idea-to-initiative pipeline guide with backfill modes, idempotency behavior, and a step-by-step runbook.

* **Tests**
  * Added regression checks to confirm the new workflow input is declared and forwarded correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->