### PR TITLE
docs(initiatives): record review-ready gate now deployed & verified live (#736)

### DIFF
--- a/docs/initiatives/auto-rebase-vs-merge-queue.md
+++ b/docs/initiatives/auto-rebase-vs-merge-queue.md
@@ -1,6 +1,6 @@
 # Initiative: Auto-rebase Fan-out Reduction — Decision Record & Merge Queue Go/No-Go Gate
 
-**Status:** Decision record — free mitigation validated (≥50% metric met); Merge Queue go/no-go **deferred to a human** (epic [#736](https://github.com/petry-projects/.github-private/issues/736) open question)
+**Status:** Decision record — free mitigation validated (≥50% metric met) **and deployed org-wide & verified live 2026-06-26** (see §2 update); Merge Queue go/no-go **deferred to a human** (epic [#736](https://github.com/petry-projects/.github-private/issues/736) open question)
 **Author:** dev-lead / Claude Code
 **Date:** 2026-06-21
 **Scope (confirmed):** Records the measured before/after impact of the **review-ready auto-rebase
@@ -71,6 +71,19 @@ Epic #736's success metric: **auto-rebase-triggered branch-update CI runs drop b
 **✅ MET.** The review-ready restriction cut the behind-PR multiplier by **~57%** (7 eligible → 3),
 clearing the ≥50% bar, with **no plan upgrade** and **without losing** the agentic conflict-resolution
 fallback (the sentinel path is preserved — see §3).
+
+> **Update (2026-06-26) — the gate is now actually deployed in production.** The ~57% figure above was
+> computed from the eligible-PR *multiplier* (a predicate snapshot), and at the time this record was
+> written the restriction was **not yet filtering anything in production**: the central reusable
+> defaulted `tooling_ref` to `v1`, a tag that predates `lib/eligibility.sh` (added in #468), so every
+> auto-rebase run failed to source the predicate — petry-projects/.github's own runs errored outright
+> while consumer repos still ran the **original unrestricted fan-out**. That latent regression was fixed
+> in [petry-projects/.github#528](https://github.com/petry-projects/.github/pull/528) (2026-06-24), which
+> sources the predicate from the reusable's own commit (`github.job_workflow_sha`); the
+> `auto-rebase/stable` channel was then promoted org-wide. The gate is now **verified live** — e.g.
+> `.github-private` PR #744 (no approval, no `auto-rebase:ready` label) went from auto-updated-every-push
+> to **skipped**. Net effect on this record: the free mitigation behind the "defer Merge Queue" decision
+> is now genuinely in effect, so the §4 deferral holds on **stronger** footing, not weaker.
 
 ---
 

--- a/docs/initiatives/auto-rebase-vs-merge-queue.md
+++ b/docs/initiatives/auto-rebase-vs-merge-queue.md
@@ -76,7 +76,7 @@ fallback (the sentinel path is preserved — see §3).
 > computed from the eligible-PR *multiplier* (a predicate snapshot), and at the time this record was
 > written the restriction was **not yet filtering anything in production**: the central reusable
 > defaulted `tooling_ref` to `v1`, a tag that predates `lib/eligibility.sh` (added in #468), so every
-> auto-rebase run failed to source the predicate — petry-projects/.github's own runs errored outright
+> auto-rebase run failed to source the predicate — `petry-projects/.github`'s own runs errored outright
 > while consumer repos still ran the **original unrestricted fan-out**. That latent regression was fixed
 > in [petry-projects/.github#528](https://github.com/petry-projects/.github/pull/528) (2026-06-24), which
 > sources the predicate from the reusable's own commit (`github.job_workflow_sha`); the


### PR DESCRIPTION
## What

Adds a dated **2026-06-26** update note to `docs/initiatives/auto-rebase-vs-merge-queue.md` (§2) plus a Status-line tag, recording that the review-ready auto-rebase gate is now **actually deployed org-wide and verified live**.

## Why

The §2 "≥50% MET" verdict was computed from the eligible-PR *multiplier* (a predicate snapshot). At the time this record was written, the restriction was **not yet filtering anything in production**: the central reusable defaulted `tooling_ref` to `v1`, which predates `lib/eligibility.sh` (added in #468), so every auto-rebase run failed to source the predicate — `petry-projects/.github`'s own runs errored, and consumer repos still ran the **original unrestricted fan-out**.

That latent regression was fixed in [petry-projects/.github#528](https://github.com/petry-projects/.github/pull/528) (2026-06-24, sources the predicate from `github.job_workflow_sha`), after which the `auto-rebase/stable` channel was promoted org-wide. Now verified live — e.g. `.github-private` PR #744 (no approval, no `auto-rebase:ready` label) went from auto-updated-every-push to **skipped**.

## Decision impact

**None to the call** — Merge Queue stays deferred (§4). But the free mitigation that justified deferring is now genuinely in effect, so the deferral holds on **stronger** footing. Docs-only.

Relates to epic #736.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the initiative status to reflect that the free mitigation is now validated, deployed across the organization, and verified live.
  * Clarified that a previously reported metric was based on an eligibility snapshot, and added a note about a rollout issue that was corrected.
  * Kept the Merge Queue decision as an open, human-deferred question.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->