### PR TITLE
feat: wire cut-release.sh cross-repo publish via gh api (#872)

### DIFF
--- a/docs/release/runbook.md
+++ b/docs/release/runbook.md
@@ -13,10 +13,9 @@ caller) pin the moving channel tag `@<agent>/stable` and thread
 `agent_ref: <agent>/stable`. The cross-repo reusables (`feature-ideation` + the
 six above) live in `petry-projects/.github`, so their release/channel tags are cut
 against **that** repo, not this repo's `origin` (see "Cross-repo reusables" in
-[`versioning.md`](./versioning.md)). `cut-release.sh` recognizes them and previews
-their tags via `--dry-run`, but **live cross-repo pushes are not wired yet** — the
-push target is an open question, so non-dry-run cuts for any cross-repo agent are
-refused for now.
+[`versioning.md`](./versioning.md)). `cut-release.sh` resolves and publishes their
+tags against **`petry-projects/.github`** via `gh api` (#872, wired); a live
+`--push` for a cross-repo agent needs `GH_TOKEN` with `contents:write` on that repo.
 
 **Two tag kinds per agent:**
 
@@ -59,11 +58,10 @@ scripts/cut-release.sh pr-review 1.6.0 --ref origin/main --dry-run
 scripts/cut-release.sh pr-review 1.6.0 --ref origin/main --push
 
 # Cross-repo agents (feature-ideation + the six #482 reusables, reusables in
-# petry-projects/.github): dry-run previews the tag names, but live --push is
-# refused until the cross-repo target is decided (see "Cross-repo reusables" in
-# versioning.md):
-scripts/cut-release.sh feature-ideation 1.4.0 --channel ring0 --dry-run
+# petry-projects/.github): tags are cut against that repo via gh api (#872).
+# Preview with --dry-run; publish with --push (needs contents:write on .github):
 scripts/cut-release.sh agent-shield 2.1.0 --channel next --dry-run
+scripts/cut-release.sh agent-shield 2.1.0 --channel next --push
 ```
 
 - Pick the version per semver (see `versioning.md#semantic-versioning`): bugfix →

--- a/docs/release/versioning.md
+++ b/docs/release/versioning.md
@@ -143,22 +143,23 @@ reusables (`agent-shield`, `auto-rebase`, `dependency-audit`, `dependabot-autome
   repo carries only the thin caller stubs `.github/workflows/<name>.yml`.
 - Therefore a release is a commit on **`petry-projects/.github`**, and the `<name>/vX.Y.Z` immutable +
   `<name>/<channel>` tags must be cut **against that repo**, not this repo's `origin`.
-- `scripts/cut-release.sh` recognizes each of these agents (`valid_agent`) and formats its tag names,
-  and its `--dry-run` prints the intended immutable + channel tags. **Live cross-repo pushes are not
-  wired yet** — the push target mechanism (a `--repo`/remote argument vs. dispatching against the public
-  repo) is an open question reserved for a human decision, so the script refuses a non-dry-run cut for
-  any cross-repo agent (the `cross_repo_agent` guard / `TODO(#872)` in `cut-release.sh`). Use
-  `--dry-run` to preview tag names until the target is decided.
+- `scripts/cut-release.sh` recognizes each of these agents (`valid_agent`) and, for a cross-repo agent,
+  **resolves the ref and creates/moves the tags against `petry-projects/.github` via `gh api`** (#872,
+  wired). `--dry-run` previews the immutable + channel tag names; a live `--push` creates the annotated
+  `<name>/vX.Y.Z` release object and force-moves the `<name>/<channel>` tag on `.github`, and needs
+  `GH_TOKEN` with `contents:write` on that repo. (`origin/main` in `--ref` means `.github`'s `main` — the
+  `origin/` prefix is stripped for the cross-repo API lookup.)
 - Because these channel tags live on `petry-projects/.github`, the protective ruleset that bounds them
   (the mutable-ref exception) is created **there**, not on this repo — see
   [`AGENTS.md`](../../AGENTS.md) "Release channel tags & the mutable-ref exception".
 
 > **Why not `standards/canary-rings.json` yet?** The machine-readable ring source of truth consumed by
-> the promotion automation (`scripts/canary-rollout.sh`, #501) carries only the in-repo agents whose
-> channel tags it can actually move. Cross-repo agents (`feature-ideation` and the six above) are
-> documented here and supported by `cut-release.sh` (dry-run), but are deliberately **absent** from
-> `canary-rings.json` until the cross-repo tag-move path is wired (`TODO #872`) — adding them sooner
-> would advertise a promotion the automation cannot perform.
+> the promotion automation (`scripts/canary-rollout.sh`, #501) carries only the agents whose channel
+> tags that automation can move. `cut-release.sh` now publishes cross-repo tags via `gh api` (#872), but
+> `canary-rollout.sh` does not yet use that cross-repo path, so `feature-ideation` and the six above stay
+> **absent** from `canary-rings.json` until the rollout automation is taught the same `gh api` move —
+> adding them sooner would advertise a promotion the automation cannot perform. (Manual/scripted cuts via
+> `cut-release.sh` work today.)
 
 ### The six #482 reusables (ring assignment)
 
@@ -169,7 +170,7 @@ them under the full `{next, ring0, ring1, stable}` model with the explicit, org-
 host-relative**: `next` is `.github-private` even though the reusables are hosted in `.github` (which
 sits in `ring0`). Re-cutting their releases on a sane incremental-semver basis (reconciling the manual
 `<name>/v2.0.0` tags) and cutting the `next`/`ring0`/`ring1` channels is an operational step done via
-`cut-release.sh` once the cross-repo push target (`TODO #872`) is wired.
+`cut-release.sh`, whose cross-repo publish path is now wired (#872).
 
 ## Cutting / moving tags
 
@@ -185,9 +186,10 @@ scripts/cut-release.sh pr-review 1.1.0 --channel stable --push
 # Preview without touching anything:
 scripts/cut-release.sh pr-review 1.1.0 --channel stable --dry-run
 
-# feature-ideation: dry-run only for now (cross-repo target unresolved — see above).
-# Prints feature-ideation/v1.4.0 and feature-ideation/ring0 without mutating anything:
+# Cross-repo agent (reusable in petry-projects/.github): cut against that repo via
+# gh api (#872). --dry-run previews; --push publishes (needs contents:write on .github):
 scripts/cut-release.sh feature-ideation 1.4.0 --channel ring0 --dry-run
+scripts/cut-release.sh feature-ideation 1.4.0 --channel ring0 --push
 ```
 
 The promote/rollback **runbook** (when to move `stable`, how to roll back, verify, gotchas) lives in

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -14,21 +14,37 @@
 #                  agent-shield | auto-rebase | dependency-audit |
 #                  dependabot-automerge | dependabot-rebase | pr-review-mention
 #   <version>    semantic version without the leading v, e.g. 1.2.0
-#   --ref        commit/ref to tag (default: origin/main)
+#   --ref        commit/ref to tag (default: main). For this-repo agents it is
+#                resolved against local git (e.g. origin/main); for cross-repo
+#                agents it is resolved against petry-projects/.github via the API
+#                (an `origin/` prefix is stripped — `origin/main` means its `main`).
 #   --channel    also move <agent>/<name> (e.g. stable) to the new release
-#   --push       push the created/moved tags to origin (default: local only)
+#   --push       publish the created/moved tags (default: print only). For
+#                this-repo agents this pushes to origin; for cross-repo agents it
+#                creates/moves the tags on petry-projects/.github via the API.
 #   --dry-run    print what would happen; touch nothing
 #
 # Examples:
 #   cut-release.sh pr-review 1.1.0 --push
 #   cut-release.sh pr-review 1.1.0 --channel stable --push
 #   cut-release.sh dev-lead  2.0.0 --channel stable --dry-run
+#   cut-release.sh agent-shield 2.1.0 --channel next --push   # cross-repo → .github
+#
+# Cross-repo agents (#872): feature-ideation + the six #482 reusables are hosted in
+# petry-projects/.github (this repo holds only the thin caller stubs), so their
+# tags are cut against THAT repo. Resolution + publish go through `gh api`
+# (requires GH_TOKEN with contents:write on petry-projects/.github). See
+# docs/release/versioning.md "Cross-repo reusables".
 #
 # The pure helpers (valid_agent, cross_repo_agent, validate_version, release_ref,
-# channel_ref) are defined at the top level so tests can `source` this file without
-# executing it (see the source-guard at the bottom and tests/test_cut_release.bats).
+# channel_ref, strip_origin) are defined at the top level so tests can `source`
+# this file without executing it (see the source-guard at the bottom and
+# tests/test_cut_release.bats).
 #
 set -euo pipefail
+
+# The repo whose git refs hold cross-repo agents' release/channel tags.
+CROSS_REPO_TARGET="petry-projects/.github"
 
 # ── pure helpers (sourced by tests; no side effects) ─────────────────────────
 
@@ -45,10 +61,9 @@ valid_agent() {
 
 # cross_repo_agent <agent> — return 0 iff the agent's reusable workflow lives in
 # petry-projects/.github (this repo holds only the thin caller stub). For these,
-# a "release" is a commit on that public repo, so its release/channel tags must be
-# cut against THAT repo — not this repo's `origin`. The cross-repo push target is
-# an open question (TODO #872), so live cuts are refused and only --dry-run is
-# supported. See docs/release/versioning.md "Cross-repo reusables".
+# a "release" is a commit on that public repo, so its release/channel tags are
+# resolved and cut against THAT repo (CROSS_REPO_TARGET) via `gh api`, not this
+# repo's `origin` (#872, wired). See docs/release/versioning.md "Cross-repo reusables".
 cross_repo_agent() {
   case "$1" in
     feature-ideation) return 0 ;;
@@ -68,6 +83,41 @@ release_ref() { printf '%s/v%s\n' "$1" "$2"; }
 
 # channel_ref <agent> <channel> — echo the channel tag name.
 channel_ref() { printf '%s/%s\n' "$1" "$2"; }
+
+# strip_origin <ref> — normalize a local-style ref to a remote-repo ref name for
+# the cross-repo API path: `origin/main` → `main`, a bare ref/SHA passes through.
+# (`git rev-parse` understands `origin/main`; the GitHub API does not.)
+strip_origin() { printf '%s\n' "${1#origin/}"; }
+
+# ── cross-repo tag operations (gh api; require GH_TOKEN with contents:write) ───
+# Thin wrappers kept separate from the pure helpers so the network surface is
+# explicit. Each targets an arbitrary <repo> so tests can mock `gh`.
+
+# gh_resolve_sha <repo> <ref> — echo the commit SHA <ref> resolves to on <repo>.
+gh_resolve_sha() { gh api "repos/$1/commits/$2" --jq '.sha'; }
+
+# gh_tag_exists <repo> <tag> — return 0 iff refs/tags/<tag> exists on <repo>.
+gh_tag_exists() { gh api "repos/$1/git/ref/tags/$2" >/dev/null 2>&1; }
+
+# gh_create_annotated_tag <repo> <tag> <sha> <message> — create an annotated tag
+# object and the ref pointing at it (mirrors `git tag -a`). Fails if the ref
+# exists (the API refuses to create a duplicate ref — immutability is enforced).
+gh_create_annotated_tag() {
+  local obj
+  obj=$(gh api -X POST "repos/$1/git/tags" \
+        -f "tag=$2" -f "message=$4" -f "object=$3" -f "type=commit" --jq '.sha')
+  gh api -X POST "repos/$1/git/refs" -f "ref=refs/tags/$2" -f "sha=$obj" >/dev/null
+}
+
+# gh_move_tag <repo> <tag> <sha> — point refs/tags/<tag> at <sha> (force-move if
+# it exists, create if not). Lightweight ref, matching `git tag -f` for channels.
+gh_move_tag() {
+  if gh_tag_exists "$1" "$2"; then
+    gh api -X PATCH "repos/$1/git/refs/tags/$2" -f "sha=$3" -F "force=true" >/dev/null
+  else
+    gh api -X POST "repos/$1/git/refs" -f "ref=refs/tags/$2" -f "sha=$3" >/dev/null
+  fi
+}
 
 # ── main ─────────────────────────────────────────────────────────────────────
 
@@ -104,48 +154,67 @@ main() {
     return 2
   fi
 
-  local rel chan sha
+  local rel chan sha pushrefs
   rel="$(release_ref "$agent" "$version")"
-  if ! sha="$(git rev-parse --verify "$ref^{commit}")"; then
-    echo "::error::ref '$ref' could not be resolved — verify the ref exists and the remote has been fetched" >&2
-    return 1
+  pushrefs=("$rel")
+  if [ -n "$channel" ]; then chan="$(channel_ref "$agent" "$channel")"; pushrefs+=("$chan"); fi
+
+  # Resolve the target SHA. This-repo agents resolve against local git; cross-repo
+  # agents (#872) resolve against petry-projects/.github via the API.
+  if cross_repo_agent "$agent"; then
+    local rref; rref="$(strip_origin "$ref")"
+    if ! sha="$(gh_resolve_sha "$CROSS_REPO_TARGET" "$rref")" || [ -z "$sha" ]; then
+      echo "::error::ref '$rref' could not be resolved on $CROSS_REPO_TARGET (check the ref exists and GH_TOKEN has access)" >&2
+      return 1
+    fi
+  else
+    if ! sha="$(git rev-parse --verify "$ref^{commit}")"; then
+      echo "::error::ref '$ref' could not be resolved — verify the ref exists and the remote has been fetched" >&2
+      return 1
+    fi
   fi
 
-  echo "agent=$agent version=$version ref=$ref ($sha)"
+  local target="origin (this repo)"
+  cross_repo_agent "$agent" && target="$CROSS_REPO_TARGET (cross-repo)"
+  echo "agent=$agent version=$version ref=$ref ($sha) target=$target"
   echo "release tag: $rel"
-  [ -n "$channel" ] && { chan="$(channel_ref "$agent" "$channel")"; echo "channel tag: $chan -> $rel"; }
+  [ -n "$channel" ] && echo "channel tag: $chan -> $rel"
 
   if [ "$dry" = true ]; then
-    if cross_repo_agent "$agent"; then
-      echo "::warning::cross-repo placeholder: the SHA above ($sha) was resolved from petry-projects/.github-private. ${agent}'s canonical commits and tags live in petry-projects/.github — this SHA is a local placeholder only."
-    fi
     echo "(dry-run) no tags created or pushed."
     return 0
   fi
 
-  # TODO(#872): the cross-repo agents' reusables live in petry-projects/.github, so
-  # their release/channel tags must be cut against THAT repo — but main() pushes to
-  # this repo's `origin`. The cross-repo push target (a --repo/remote arg vs.
-  # dispatching against the public repo) is an open question reserved for a human
-  # decision. Until it is wired, only --dry-run is supported for these agents; refuse
-  # live cuts so tags are never written to the wrong remote.
+  # ── cross-repo agents: create/move tags on petry-projects/.github via the API ──
   if cross_repo_agent "$agent"; then
-    echo "::error::live cut/push for '$agent' is not wired yet — its tags belong on petry-projects/.github (cross-repo target is an open question; see TODO). Use --dry-run for now." >&2
-    return 1
+    if gh_tag_exists "$CROSS_REPO_TARGET" "$rel"; then
+      echo "::error::release tag '$rel' already exists on $CROSS_REPO_TARGET — immutable tags are never overwritten." >&2
+      return 1
+    fi
+    if [ "$do_push" != true ]; then
+      echo "print only — re-run with --push to publish to $CROSS_REPO_TARGET: ${pushrefs[*]}"
+      return 0
+    fi
+    gh_create_annotated_tag "$CROSS_REPO_TARGET" "$rel" "$sha" "$agent release v$version"
+    echo "created $rel on $CROSS_REPO_TARGET"
+    if [ -n "$channel" ]; then
+      gh_move_tag "$CROSS_REPO_TARGET" "$chan" "$sha"
+      echo "moved $chan -> $sha on $CROSS_REPO_TARGET"
+    fi
+    echo "published to $CROSS_REPO_TARGET: ${pushrefs[*]}"
+    return 0
   fi
 
+  # ── this-repo agents: local annotated tag + force-moved channel, pushed to origin ──
   if git rev-parse -q --verify "refs/tags/$rel" >/dev/null; then
     echo "::error::release tag '$rel' already exists — immutable tags are never overwritten." >&2
     return 1
   fi
   git tag -a "$rel" "$sha" -m "$agent release v$version"
   echo "created $rel"
-
-  local pushrefs=("$rel")
   if [ -n "$channel" ]; then
     git tag -f "$chan" "$sha"
     echo "moved $chan -> $sha"
-    pushrefs+=("$chan")
   fi
 
   if [ "$do_push" = true ]; then

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -162,6 +162,10 @@ main() {
   # Resolve the target SHA. This-repo agents resolve against local git; cross-repo
   # agents (#872) resolve against petry-projects/.github via the API.
   if cross_repo_agent "$agent"; then
+    if ! command -v gh >/dev/null 2>&1; then
+      echo "::error::'gh' CLI is required for cross-repo agents but was not found in PATH" >&2
+      return 1
+    fi
     local rref; rref="$(strip_origin "$ref")"
     if ! sha="$(gh_resolve_sha "$CROSS_REPO_TARGET" "$rref")" || [ -z "$sha" ]; then
       echo "::error::ref '$rref' could not be resolved on $CROSS_REPO_TARGET (check the ref exists and GH_TOKEN has access)" >&2

--- a/tests/test_cut_release.bats
+++ b/tests/test_cut_release.bats
@@ -213,3 +213,27 @@ setup() {
   run channel_ref "auto-rebase" "stable"
   [ "$output" = "auto-rebase/stable" ]
 }
+
+# ---------------------------------------------------------------------------
+# strip_origin — normalize a local-style ref to a remote-repo ref name (#872)
+# ---------------------------------------------------------------------------
+
+@test "strip_origin: origin/main becomes main" {
+  run strip_origin "origin/main"
+  [ "$output" = "main" ]
+}
+
+@test "strip_origin: a bare ref passes through" {
+  run strip_origin "main"
+  [ "$output" = "main" ]
+}
+
+@test "strip_origin: a SHA passes through" {
+  run strip_origin "376a4fcb1117444595e3e702fa450873d0e54310"
+  [ "$output" = "376a4fcb1117444595e3e702fa450873d0e54310" ]
+}
+
+@test "strip_origin: only the leading origin/ is stripped" {
+  run strip_origin "origin/release/origin/x"
+  [ "$output" = "release/origin/x" ]
+}

--- a/tests/test_cut_release_cross_repo.bats
+++ b/tests/test_cut_release_cross_repo.bats
@@ -7,7 +7,7 @@
 # Run with: bats tests/test_cut_release_cross_repo.bats
 
 setup() {
-  TT_TMP="$(mktemp -d)"
+  TT_TMP="$(mktemp -d)" || { echo "Failed to create temp directory" >&2; exit 1; }
   SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/cut-release.sh"
   GH_CALLS="${TT_TMP}/gh-calls.log"; export GH_CALLS
   : > "$GH_CALLS"

--- a/tests/test_cut_release_cross_repo.bats
+++ b/tests/test_cut_release_cross_repo.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+# Integration tests for the cross-repo publish path in cut-release.sh (#872):
+# feature-ideation + the six #482 reusables are hosted in petry-projects/.github,
+# so their release/channel tags are cut against THAT repo via `gh api`. These
+# tests run main() end-to-end with a fake `gh` so no network/tags are touched.
+#
+# Run with: bats tests/test_cut_release_cross_repo.bats
+
+setup() {
+  TT_TMP="$(mktemp -d)"
+  SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/cut-release.sh"
+  GH_CALLS="${TT_TMP}/gh-calls.log"; export GH_CALLS
+  : > "$GH_CALLS"
+  install_gh_stub
+}
+
+teardown() { rm -rf "$TT_TMP"; }
+
+# Fake gh: logs every call, resolves a fixed SHA, and answers the ref-exists probe
+# from GH_TAG_EXISTS (default 0 = absent). POSTs to git/tags return a tag-object SHA.
+install_gh_stub() {
+  local bin="${TT_TMP}/bin"; mkdir -p "$bin"
+  cat > "$bin/gh" <<'STUB'
+#!/usr/bin/env bash
+{ printf 'gh'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'; } >> "$GH_CALLS"
+[ "${1:-}" = "api" ] || exit 0
+case "$*" in
+  *"commits/"*)        echo "feedfacefeedfacefeedfacefeedfacefeedface"; exit 0 ;;
+  *"git/ref/tags/"*)   [ "${GH_TAG_EXISTS:-0}" = "1" ] && exit 0 || exit 1 ;;  # exists probe
+  *"git/tags"*)        echo "0babebabe0babebabe0babebabe0babebabe0bab"; exit 0 ;;  # annotated tag object
+  *"git/refs"*)        exit 0 ;;  # create/patch ref
+esac
+exit 0
+STUB
+  chmod +x "$bin/gh"
+  PATH="${bin}:${PATH}"; export PATH
+}
+
+@test "cross-repo --dry-run resolves the SHA against .github and touches nothing" {
+  run env GH_TOKEN=x bash "$SCRIPT" agent-shield 2.1.0 --channel next --dry-run
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'target=petry-projects/.github'
+  echo "$output" | grep -q '(dry-run) no tags created'
+  # resolved a SHA, but no tag object / ref was created
+  grep -q 'commits/main' "$GH_CALLS"
+  ! grep -qE 'POST .*git/(tags|refs)' "$GH_CALLS"
+  ! grep -qE 'PATCH ' "$GH_CALLS"
+}
+
+@test "cross-repo without --push is print-only (no mutation)" {
+  run env GH_TOKEN=x bash "$SCRIPT" agent-shield 2.1.0 --channel next
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'print only — re-run with --push'
+  ! grep -qE 'POST .*git/(tags|refs)' "$GH_CALLS"
+  ! grep -qE 'PATCH ' "$GH_CALLS"
+}
+
+@test "cross-repo --push creates the release tag and moves the channel on .github" {
+  run env GH_TOKEN=x bash "$SCRIPT" agent-shield 2.1.0 --channel next --push
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'created agent-shield/v2.1.0 on petry-projects/.github'
+  echo "$output" | grep -q 'moved agent-shield/next'
+  echo "$output" | grep -q 'published to petry-projects/.github'
+  # annotated tag object + ref creation both went to petry-projects/.github
+  grep -qE 'POST repos/petry-projects/\.github/git/tags' "$GH_CALLS"
+  grep -qE 'POST repos/petry-projects/\.github/git/refs .*refs/tags/agent-shield/v2.1.0' "$GH_CALLS"
+}
+
+@test "cross-repo --push refuses to overwrite an existing release tag" {
+  GH_TAG_EXISTS=1 run env GH_TOKEN=x GH_TAG_EXISTS=1 bash "$SCRIPT" agent-shield 2.1.0 --channel next --push
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q 'already exists on petry-projects/.github'
+  ! grep -qE 'POST .*git/tags' "$GH_CALLS"
+}
+
+@test "a this-repo agent still uses the local-git path (no gh api), dry-run" {
+  run env GH_TOKEN=x bash "$SCRIPT" pr-review 9.9.9 --dry-run
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'target=origin (this repo)'
+  ! grep -q 'commits/' "$GH_CALLS"
+}


### PR DESCRIPTION
## Summary

Unblocks promotion of the #870 reusables. The six #482 reusables + `feature-ideation` are hosted in `petry-projects/.github`, so their release/channel tags belong on **that** repo — but `cut-release.sh` resolved refs against local git and **refused** live cross-repo cuts (the push target was flagged an open question, `TODO(#872)`). This wires the cross-repo path.

## What changed
- **Cross-repo resolve + publish via `gh api`** — for a `cross_repo_agent`, the ref resolves against `petry-projects/.github` (`commits/<ref>`; an `origin/` prefix is stripped so `origin/main` → its `main`), and `--push` creates the annotated `<name>/vX.Y.Z` release object + force-moves the `<name>/<channel>` tag (`git/tags` + `git/refs`).
- **This-repo agents unchanged** — `pr-review`/`dev-lead` keep the local-git tag+push path verbatim.
- **Immutability preserved cross-repo** — an existing `<name>/vX.Y.Z` is never overwritten.
- `--push` for a cross-repo agent requires `GH_TOKEN` with `contents:write` on `petry-projects/.github`.

## Tests
- `strip_origin` pure helper (+4 cases).
- New gh-mocked integration suite `tests/test_cut_release_cross_repo.bats`: dry-run resolves + touches nothing; print-only (no `--push`); `--push` creates release + moves channel on `.github`; `--push` refuses an existing release tag; this-repo agent still uses local git.
- **46 pass**, `shellcheck --severity=warning` clean.

## Docs
`versioning.md` + `runbook.md` updated — cross-repo cut is now wired (was "dry-run only"). Note: `canary-rollout.sh` (the automated promotion driver) does **not** yet use this cross-repo path, so the six stay out of `canary-rings.json` until that's taught the same move — manual/scripted `cut-release.sh` cuts work today.

Refs #872, #870.

🤖 Generated with [Claude Code](https://claude.com/claude-code)