### PR TITLE
fix(seed-repo-template): correct dependabot path/default + close test gap (#966)

### DIFF
--- a/scripts/seed-repo-template.sh
+++ b/scripts/seed-repo-template.sh
@@ -45,14 +45,15 @@ set -euo pipefail
 #   STANDARDS_REPO   repo holding the canonical standards/ (default petry-projects/.github).
 #   STANDARDS_DIR    optional local checkout of STANDARDS_REPO; when set, files are
 #                    read from disk instead of the GitHub API (regeneration seam).
-#   DEPENDABOT_STACK standards/dependabot/<stack> to ship as .github/dependabot.yml
-#                    (default node).
+#   DEPENDABOT_STACK standards/dependabot/<stack>.yml to ship as .github/dependabot.yml
+#                    (default frontend; one of: frontend, backend-go, backend-python,
+#                    backend-rust, fullstack, infra-terraform).
 #   GH_TOKEN         PAT with repo scope (create a branch + PR on TEMPLATE_REPO).
 
 DRY_RUN="${DRY_RUN:-false}"
 TEMPLATE_REPO="${TEMPLATE_REPO:-petry-projects/repo-template}"
 STANDARDS_REPO="${STANDARDS_REPO:-petry-projects/.github}"
-DEPENDABOT_STACK="${DEPENDABOT_STACK:-node}"
+DEPENDABOT_STACK="${DEPENDABOT_STACK:-frontend}"
 
 _is_dry() { [ "$DRY_RUN" = "true" ]; }
 
@@ -249,10 +250,11 @@ after you create your repo from the template:
 
 ## 1. Pick your Dependabot stack
 
-`.github/dependabot.yml` ships with a default stack. Replace it with the stack
-that matches your project (the canonical stacks live in
-`petry-projects/.github` under `standards/dependabot/<stack>/`). For example, a
-Node project uses the `node` stack; a Go project uses the `go` stack.
+`.github/dependabot.yml` ships with the `frontend` (npm) stack by default.
+Replace it with the stack that matches your project — the canonical stacks live
+in `petry-projects/.github` under `standards/dependabot/<stack>.yml`. Available
+stacks: `frontend` (npm), `backend-go`, `backend-python`, `backend-rust`,
+`fullstack` (npm + Go + Terraform), and `infra-terraform`.
 
 ## 2. Customize `ci.yml` for your stack
 
@@ -311,9 +313,9 @@ _emit_baseline() {
     _gen_baseline "$path"
   else
     local content
-    content="$(_fetch_standard "standards/dependabot/${DEPENDABOT_STACK}/dependabot.yml")" || true
+    content="$(_fetch_standard "standards/dependabot/${DEPENDABOT_STACK}.yml")" || true
     if [ -z "$content" ]; then
-      echo "::error::could not fetch standards/dependabot/${DEPENDABOT_STACK}/dependabot.yml" >&2
+      echo "::error::could not fetch standards/dependabot/${DEPENDABOT_STACK}.yml from ${STANDARDS_REPO}" >&2
       return 1
     fi
     printf '%s\n' "$content"

--- a/tests/test_seed_repo_template.bats
+++ b/tests/test_seed_repo_template.bats
@@ -27,7 +27,7 @@ setup() {
   export PATH="$STUB_BIN:$PATH"
   CALLS="$STUB_BIN/calls.log"; export CALLS
   STANDARDS_DIR="$(mktemp -d)" || { echo "Failed to create STANDARDS_DIR" >&2; exit 1; }
-  mkdir -p "$STANDARDS_DIR/standards/workflows" "$STANDARDS_DIR/standards/dependabot/node"
+  mkdir -p "$STANDARDS_DIR/standards/workflows" "$STANDARDS_DIR/standards/dependabot"
   export STANDARDS_DIR
 }
 teardown() {
@@ -55,6 +55,15 @@ EOF
 # Drop a fake standards/workflows/<name> fixture used by --emit-workflow / seeding.
 _fixture_workflow() { # <name> <heredoc-content-on-stdin>
   cat > "$STANDARDS_DIR/standards/workflows/$1"
+}
+
+# gh stub that returns NOTHING for every call. Used by the fail-loud tests so a
+# fixture absent from STANDARDS_DIR cannot fall through to a real network fetch
+# (which would succeed for files that exist in the live standards repo and make
+# the test pass/fail on network state instead of the seeder's behavior).
+_stub_gh_empty() {
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB_BIN/gh"
+  chmod +x "$STUB_BIN/gh"
 }
 
 # ── manifest: workflow set (AC #1, #5) ────────────────────────────────────────
@@ -144,6 +153,39 @@ _fixture_workflow() { # <name> <heredoc-content-on-stdin>
   [[ "$output" != *"./.github/workflows/dependency-audit-reusable.yml"* ]]
 }
 
+@test "emit-workflow: sonarcloud inline stub ships byte-identically (no repin)" {
+  # sonarcloud is kind=inline: it carries no reusable ref and must pass through
+  # verbatim, exactly like ci.yml. Covers the second inline workflow (#966 follow-up).
+  printf 'name: SonarCloud Analysis\non: [push]\njobs:\n  sonarcloud:\n    name: SonarCloud\n    runs-on: ubuntu-latest\n' \
+    | _fixture_workflow sonarcloud.yml
+  run bash "$SEED" --emit-workflow sonarcloud.yml
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(cat "$STANDARDS_DIR/standards/workflows/sonarcloud.yml")" ]
+}
+
+@test "emit-workflow: FAILS LOUD when an inline workflow's standard file is absent" {
+  # Regression guard for the original #966 defect: ci/sonarcloud are declared
+  # kind=inline but were MISSING from standards/workflows/. The emit path must
+  # exit non-zero with a clear error, never silently ship an empty workflow.
+  # No fixture for sonarcloud.yml is written → the fetch must fail.
+  _stub_gh_empty
+  run bash "$SEED" --emit-workflow sonarcloud.yml
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"could not fetch standards/workflows/sonarcloud.yml"* ]]
+}
+
+@test "emit-workflow: every inline manifest stub fails loud when its standard is absent" {
+  # Guards the whole inline set, so a future manifest addition can't silently
+  # 404 at seed time the way ci.yml did.
+  _stub_gh_empty
+  for name in "${INLINE_STUBS[@]}"; do
+    run bash "$SEED" --emit-workflow "${name}.yml"
+    [ "$status" -ne 0 ] || { echo "$name did not fail loud on a missing standard" >&2; false; }
+    [[ "$output" == *"could not fetch standards/workflows/${name}.yml"* ]] \
+      || { echo "$name missing the fail-loud error message" >&2; false; }
+  done
+}
+
 # ── baseline content (AC #3, #4) ──────────────────────────────────────────────
 @test "baseline: CODEOWNERS is the org default rule" {
   run bash "$SEED" --emit-baseline .github/CODEOWNERS
@@ -192,10 +234,36 @@ _fixture_workflow() { # <name> <heredoc-content-on-stdin>
 # ── dependabot baseline is sourced from the chosen standards/ stack template ───
 @test "baseline: dependabot.yml comes from the chosen standards/dependabot stack" {
   printf 'version: 2\nupdates:\n  - package-ecosystem: npm\n' \
-    > "$STANDARDS_DIR/standards/dependabot/node/dependabot.yml"
-  run env DEPENDABOT_STACK=node bash "$SEED" --emit-baseline .github/dependabot.yml
+    > "$STANDARDS_DIR/standards/dependabot/frontend.yml"
+  run env DEPENDABOT_STACK=frontend bash "$SEED" --emit-baseline .github/dependabot.yml
   [ "$status" -eq 0 ]
   [[ "$output" == *"package-ecosystem: npm"* ]]
+}
+
+@test "baseline: dependabot.yml stack is a flat standards/dependabot/<stack>.yml file (not a subdir)" {
+  # Regression guard (#966 follow-up): the canonical layout is flat files
+  # (standards/dependabot/frontend.yml), NOT standards/dependabot/<stack>/dependabot.yml.
+  printf 'version: 2\nupdates:\n  - package-ecosystem: gomod\n' \
+    > "$STANDARDS_DIR/standards/dependabot/backend-go.yml"
+  run env DEPENDABOT_STACK=backend-go bash "$SEED" --emit-baseline .github/dependabot.yml
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"package-ecosystem: gomod"* ]]
+}
+
+@test "baseline: default DEPENDABOT_STACK is a real flat stack file (frontend)" {
+  printf 'version: 2\nupdates:\n  - package-ecosystem: npm\n' \
+    > "$STANDARDS_DIR/standards/dependabot/frontend.yml"
+  run bash "$SEED" --emit-baseline .github/dependabot.yml
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"package-ecosystem: npm"* ]]
+}
+
+@test "baseline: FAILS LOUD when the chosen dependabot stack file is absent" {
+  # No fixture written → the fetch must fail non-zero, never ship an empty file.
+  _stub_gh_empty
+  run env DEPENDABOT_STACK=frontend bash "$SEED" --emit-baseline .github/dependabot.yml
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"could not fetch standards/dependabot/frontend.yml"* ]]
 }
 
 # ── seeding orchestration: DRY_RUN ────────────────────────────────────────────
@@ -220,8 +288,8 @@ _fixture_workflow() { # <name> <heredoc-content-on-stdin>
         | _fixture_workflow "$n.yml"
     fi
   done
-  printf 'version: 2\n' > "$STANDARDS_DIR/standards/dependabot/node/dependabot.yml"
-  run env DEPENDABOT_STACK=node bash "$SEED" --repo petry-projects/repo-template
+  printf 'version: 2\n' > "$STANDARDS_DIR/standards/dependabot/frontend.yml"
+  run env DEPENDABOT_STACK=frontend bash "$SEED" --repo petry-projects/repo-template
   [ "$status" -eq 0 ]
   [ -f "$CALLS" ]
   grep -q "contents/.github/workflows/auto-rebase.yml" "$CALLS"
@@ -248,8 +316,8 @@ EOF
         | _fixture_workflow "$n.yml"
     fi
   done
-  printf 'version: 2\n' > "$STANDARDS_DIR/standards/dependabot/node/dependabot.yml"
-  run env DEPENDABOT_STACK=node bash "$SEED" --repo petry-projects/repo-template
+  printf 'version: 2\n' > "$STANDARDS_DIR/standards/dependabot/frontend.yml"
+  run env DEPENDABOT_STACK=frontend bash "$SEED" --repo petry-projects/repo-template
   [ "$status" -eq 0 ]
   [[ "$output" == *"PR #42 already open"* ]]
   [ ! -f "$CALLS" ] || ! grep -q "pr create" "$CALLS"

--- a/tests/test_seed_repo_template.bats
+++ b/tests/test_seed_repo_template.bats
@@ -156,8 +156,14 @@ _stub_gh_empty() {
 @test "emit-workflow: sonarcloud inline stub ships byte-identically (no repin)" {
   # sonarcloud is kind=inline: it carries no reusable ref and must pass through
   # verbatim, exactly like ci.yml. Covers the second inline workflow (#966 follow-up).
-  printf 'name: SonarCloud Analysis\non: [push]\njobs:\n  sonarcloud:\n    name: SonarCloud\n    runs-on: ubuntu-latest\n' \
-    | _fixture_workflow sonarcloud.yml
+  _fixture_workflow sonarcloud.yml <<'EOF'
+name: SonarCloud Analysis
+on: [push]
+jobs:
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+EOF
   run bash "$SEED" --emit-workflow sonarcloud.yml
   [ "$status" -eq 0 ]
   [ "$output" = "$(cat "$STANDARDS_DIR/standards/workflows/sonarcloud.yml")" ]


### PR DESCRIPTION
## What

Makes `scripts/seed-repo-template.sh` (epic #964, story #966) actually runnable. It currently **cannot populate `repo-template`** — a live run 404s and aborts. Two path defects, both hidden because the bats tests mock the standards fetch (false green):

1. **Inline workflows missing upstream** — `ci`/`sonarcloud` are `kind=inline`, fetched from `standards/workflows/`, but those canonical files never existed there. Added in the companion **petry-projects/.github#564**.
2. **Wrong Dependabot path + default (fixed here)** — the seeder fetched `standards/dependabot/<stack>/dependabot.yml` (a non-existent subdirectory layout) with default stack `node` (not a real stack). The real layout is flat: `standards/dependabot/<stack>.yml`.

## Changes

- Dependabot fetch path → `standards/dependabot/<stack>.yml`; error message includes the repo.
- Default `DEPENDABOT_STACK` `node` → `frontend`; fix the env doc and the generated `BOOTSTRAP.md` (which named non-existent `node`/`go` stacks and a `<stack>/` subdir) to list the real stacks.
- **Tests** — move fixtures to the flat layout; add fail-loud regression guards (a missing inline workflow standard *or* a missing dependabot stack file must exit non-zero, never ship an empty file); add `sonarcloud` inline-emit coverage; add a network-free `gh` stub so fail-loud tests don't pass/fail on live repo state.

No seeder *logic* change for `kind=inline` was needed — `_emit_workflow` already ships inline workflows verbatim (no repin); the defect was purely the missing files + wrong dependabot path.

## Validation

End-to-end against a mirror of the live `standards/` + the two new files (from #564):
- all 10 workflow stubs + 10 baseline files emit with **zero fetch errors**;
- inline `ci`/`sonarcloud` ship **byte-identically**; caller stubs repin to `@<name>/stable` (S7637 NOSONAR markers preserved);
- `shellcheck` clean; **26/26 bats** pass.

Merge order: #564 (canonical files) should land first so a live seed succeeds; this PR is independently green (tests use fixtures).

Refs #966, epic #964.