### PR TITLE
feat(pr-limits): wire the admission gate into dev-lead-fix-issue.sh (#1003)

### DIFF
--- a/scripts/dev-lead-fix-issue.sh
+++ b/scripts/dev-lead-fix-issue.sh
@@ -23,6 +23,14 @@ MAX_ATTEMPTS="${MAX_ATTEMPTS:-3}"
 # skips issues carrying it.
 NEEDS_HUMAN_LABEL="${NEEDS_HUMAN_LABEL:-dev-lead:needs-human}"
 
+# PR-limit admission gate (epic petry-projects/.github#505 Phase 3) config.
+# The shared guard + limits config live in the PUBLIC standards repo so every
+# automation caller enforces the same org-wide cap. PLG_STANDARDS_DIR lets tests
+# and offline runs source a local checkout instead of hitting the API.
+PLG_SOURCE_REPO="${PLG_SOURCE_REPO:-petry-projects/.github}"
+PLG_SOURCE_REF="${PLG_SOURCE_REF:-main}"
+PLG_DEFER_MARKER="<!-- dev-lead-issue-deferred -->"
+
 check_existing_pr() {
   local existing
   existing=$(gh api "repos/${REPO}/pulls?state=open" \
@@ -168,6 +176,99 @@ ${snippet}" 2>/dev/null || true
   exit 1
 }
 
+# _plg_fetch <repo-relative-path> <dest>: populate <dest> with the file at
+# <repo-relative-path>. Prefer a local checkout (PLG_STANDARDS_DIR, used by
+# tests/offline runs); otherwise fetch from the PUBLIC PLG_SOURCE_REPO via the
+# contents API. Returns non-zero on any failure or empty result so callers can
+# fail-open.
+_plg_fetch() {
+  local path="$1" dest="$2"
+  if [ -n "${PLG_STANDARDS_DIR:-}" ]; then
+    local src="${PLG_STANDARDS_DIR}/${path}"
+    [ -f "$src" ] || return 1
+    cp "$src" "$dest" 2>/dev/null || return 1
+  else
+    gh api "repos/${PLG_SOURCE_REPO}/contents/${path}?ref=${PLG_SOURCE_REF}" \
+      --jq '.content' 2>/dev/null | base64 -d > "$dest" 2>/dev/null || return 1
+  fi
+  [ -s "$dest" ]
+}
+
+# admission_gate_allows: returns 0 (allow) / 1 (defer). Fetches the shared guard
+# + limits config from the public standards repo and asks plg_admission_gate
+# whether a new "dev-lead" automation PR may be opened. FAIL-OPEN: any fetch,
+# sourcing, or unexpected-rc problem allows PR creation so a guard defect never
+# blocks the pipeline. rc==1 from the guard is the only real "defer".
+admission_gate_allows() {
+  local tmp guard config
+  tmp="$(mktemp -d)"
+  guard="${tmp}/pr-limit-gate.sh"
+  config="${tmp}/pr-limits.json"
+
+  if ! _plg_fetch "scripts/lib/pr-limit-gate.sh" "$guard"; then
+    echo "::warning::PR-limit gate: could not fetch guard (scripts/lib/pr-limit-gate.sh) from ${PLG_SOURCE_REPO}@${PLG_SOURCE_REF} — failing open (allowing PR)"
+    rm -rf "$tmp"
+    return 0
+  fi
+  if ! _plg_fetch "standards/pr-limits.json" "$config"; then
+    echo "::warning::PR-limit gate: could not fetch config (standards/pr-limits.json) from ${PLG_SOURCE_REPO}@${PLG_SOURCE_REF} — failing open (allowing PR)"
+    rm -rf "$tmp"
+    return 0
+  fi
+
+  # Source the guard defensively: an `if ! source` guard keeps a non-zero return
+  # from the sourced file from tripping set -e, and declare -F confirms the entry
+  # point actually exists before we call it.
+  # shellcheck source=/dev/null
+  if ! source "$guard" || ! declare -F plg_admission_gate >/dev/null; then
+    echo "::warning::PR-limit gate: guard did not source or define plg_admission_gate — failing open (allowing PR)"
+    rm -rf "$tmp"
+    return 0
+  fi
+
+  local rc=0
+  PR_LIMITS_CONFIG="$config" plg_admission_gate "dev-lead" >/dev/null || rc=$?
+  rm -rf "$tmp"
+
+  case "$rc" in
+    0) return 0 ;;  # under cap — allow PR creation
+    1) return 1 ;;  # at/over cap — real defer
+    *) echo "::warning::PR-limit gate: unexpected exit code ${rc} from plg_admission_gate — failing open (allowing PR)"
+       return 0 ;;
+  esac
+}
+
+# deferral_comment_exists: 0 when a deferral comment (body starting with
+# PLG_DEFER_MARKER) already exists on the issue. Robust to gh failure or a
+# non-numeric result — both treated as "not exists" so a transient API error
+# never suppresses a needed comment.
+deferral_comment_exists() {
+  local count
+  count=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" \
+    --jq "[.[] | select(.body | startswith(\"${PLG_DEFER_MARKER}\"))] | length" 2>/dev/null || echo 0)
+  [[ "$count" =~ ^[0-9]+$ ]] || count=0
+  [ "$count" -gt 0 ]
+}
+
+# post_deferral_comment: idempotently post a single deferral comment. No-op if a
+# deferral comment already exists, so repeated runs never spam the issue. The
+# body starts with PLG_DEFER_MARKER on its own line. gh errors are swallowed —
+# a failed comment must not turn a benign defer into a hard failure.
+post_deferral_comment() {
+  if deferral_comment_exists; then
+    return 0
+  fi
+  gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "${PLG_DEFER_MARKER}
+## Dev-Lead: implementation deferred — automation PR queue is full
+
+**No pull request was opened** for issue #${ISSUE_NUMBER}. The org-wide
+open-automation-PR queue is currently at its signed-off cap (see
+\`standards/pr-limits.json\` in \`${PLG_SOURCE_REPO}\`).
+
+This issue stays labeled \`dev-lead\` and will be re-attempted automatically once
+the queue drains — no action is required." 2>/dev/null || true
+}
+
 main() {
   if [ -z "$ISSUE_NUMBER" ]; then
     echo "::error::ISSUE_NUMBER is required"
@@ -207,6 +308,18 @@ main() {
 
   if [ "$DEV_LEAD_DRY_RUN" = "true" ]; then
     echo "[dry-run] fix-issue: would implement issue #${ISSUE_NUMBER} using prompt: $prompt_file"
+    rm -f "$prompt_file"
+    exit 0
+  fi
+
+  # PR-limit admission gate — epic petry-projects/.github#505 Phase 3.
+  # Before opening a new automation PR, defer if the org-wide open-automation-PR
+  # queue is at the signed-off cap (standards/pr-limits.json in petry-projects/.github).
+  # Placed AFTER the dry-run early-exit so a dry-run never defers; FAIL-OPEN so a
+  # guard problem never blocks PR creation.
+  if ! admission_gate_allows; then
+    echo "::notice::PR-limit gate: deferring issue #${ISSUE_NUMBER} — org-wide automation PR cap reached; left labeled dev-lead for retry"
+    post_deferral_comment
     rm -f "$prompt_file"
     exit 0
   fi

--- a/scripts/dev-lead-fix-issue.sh
+++ b/scripts/dev-lead-fix-issue.sh
@@ -182,6 +182,7 @@ ${snippet}" 2>/dev/null || true
 # contents API. Returns non-zero on any failure or empty result so callers can
 # fail-open.
 _plg_fetch() {
+  [ "$#" -lt 2 ] && return 1
   local path="$1" dest="$2"
   if [ -n "${PLG_STANDARDS_DIR:-}" ]; then
     local src="${PLG_STANDARDS_DIR}/${path}"
@@ -201,7 +202,7 @@ _plg_fetch() {
 # blocks the pipeline. rc==1 from the guard is the only real "defer".
 admission_gate_allows() {
   local tmp guard config
-  tmp="$(mktemp -d)"
+  tmp="$(mktemp -d)" || { echo "::warning::PR-limit gate: mktemp failed — failing open (allowing PR)"; return 0; }
   guard="${tmp}/pr-limit-gate.sh"
   config="${tmp}/pr-limits.json"
 
@@ -239,13 +240,17 @@ admission_gate_allows() {
 }
 
 # deferral_comment_exists: 0 when a deferral comment (body starting with
-# PLG_DEFER_MARKER) already exists on the issue. Robust to gh failure or a
-# non-numeric result — both treated as "not exists" so a transient API error
-# never suppresses a needed comment.
+# PLG_DEFER_MARKER) already exists on the issue. Paginates so a marker on a later
+# comment page is not missed (which would cause a duplicate defer comment), and
+# null-safe on bodyless comments. Robust to gh failure or a non-numeric result —
+# both treated as "not exists" so a transient API error never suppresses a
+# needed comment. gh --paginate applies --jq per page (one number per page);
+# jq -s 'add // 0' sums the per-page counts.
 deferral_comment_exists() {
   local count
-  count=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" \
-    --jq "[.[] | select(.body | startswith(\"${PLG_DEFER_MARKER}\"))] | length" 2>/dev/null || echo 0)
+  count=$(gh api --paginate "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" \
+    --jq "[.[] | select((.body // \"\") | startswith(\"${PLG_DEFER_MARKER}\"))] | length" 2>/dev/null \
+    | jq -s 'add // 0' 2>/dev/null || echo 0)
   [[ "$count" =~ ^[0-9]+$ ]] || count=0
   [ "$count" -gt 0 ]
 }

--- a/tests/dev-lead/unit/test_fix_issue_pr_limit_gate.bats
+++ b/tests/dev-lead/unit/test_fix_issue_pr_limit_gate.bats
@@ -1,0 +1,214 @@
+#!/usr/bin/env bats
+# Unit tests for the PR-limit admission gate wired into dev-lead-fix-issue.sh.
+# Epic petry-projects/.github#505 Phase 3. Mirrors the stub pattern in
+# test_fix_issue.bats: engine stubs on PATH, a gh stub, a git stub for the
+# non-dry-run commit/push path, and a per-test PLG_STANDARDS_DIR fixture holding
+# a FAKE guard + minimal limits config so allow/defer is driven by FAKE_GATE
+# without the real guard or any network access.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+FIX_ISSUE_SCRIPT="$SCRIPT_DIR/scripts/dev-lead-fix-issue.sh"
+STUB_ENGINES_DIR="$SCRIPT_DIR/tests/dev-lead/fixtures/engines"
+
+setup() {
+  export GITHUB_ENV="$(mktemp)"
+  export GITHUB_OUTPUT="$(mktemp)"
+
+  STUB_BIN_DIR="$(mktemp -d)"
+  cp "$STUB_ENGINES_DIR/stub-claude" "$STUB_BIN_DIR/claude"
+  cp "$STUB_ENGINES_DIR/stub-gemini" "$STUB_BIN_DIR/gemini"
+  chmod +x "$STUB_BIN_DIR/claude" "$STUB_BIN_DIR/gemini"
+  export PATH="$STUB_BIN_DIR:$PATH"
+  export STUB_BIN_DIR
+
+  # Flag files the gh stub touches so tests can assert what happened.
+  PR_CREATED_FLAG="$(mktemp -u)"; export PR_CREATED_FLAG
+  COMMENT_FILE="$(mktemp)"; export COMMENT_FILE
+  # Prior issue comments the gh stub serves for the comments-list query. Default
+  # empty so no deferral comment pre-exists.
+  : "${PRIOR_COMMENTS_JSON:=[]}"; export PRIOR_COMMENTS_JSON
+
+  # gh stub: no existing PRs; serves issue title/body; records `pr create` via a
+  # flag file; records every posted comment body; serves prior comments for the
+  # idempotency check. Dispatch on the subcommand ($1) so the prompt body's
+  # literal "gh api" examples cannot mask the real branches. The comments query
+  # applies the real --jq expression (so the length/startswith idempotency check
+  # behaves like real gh). Reads PR_CREATED_FLAG / COMMENT_FILE / the (possibly
+  # per-test) PRIOR_COMMENTS_JSON from the exported environment at runtime.
+  cat > "$STUB_BIN_DIR/gh" <<'GHEOF'
+#!/usr/bin/env bash
+cmd="$1"; shift || true
+# Extract a --jq expression if present.
+jqexpr=""
+args=("$@")
+for ((i=0; i<${#args[@]}; i++)); do
+  [ "${args[$i]}" = "--jq" ] && jqexpr="${args[$((i+1))]}"
+done
+case "$cmd" in
+  api)
+    case "$*" in
+      *"pulls?state=open"*) echo "[]" ;;
+      *comments*)
+        if [ -n "$jqexpr" ]; then
+          printf '%s' "${PRIOR_COMMENTS_JSON:-[]}" | jq -r "$jqexpr"
+        else
+          printf '%s' "${PRIOR_COMMENTS_JSON:-[]}"
+        fi ;;
+      *"users/"*)  echo '{"id":12345}' ;;
+      *"issues/"*) echo '{"title":"Test Issue","body":"Test issue body"}' ;;
+      *)           echo "{}" ;;
+    esac ;;
+  pr)
+    case "$*" in
+      create*) touch "$PR_CREATED_FLAG"; echo "https://github.com/x/y/pull/1"; exit 0 ;;
+      *)       echo "{}" ;;
+    esac ;;
+  issue)
+    sub="$1"; shift || true
+    case "$sub" in
+      comment)
+        body=""
+        while [ $# -gt 0 ]; do
+          if [ "$1" = "--body" ]; then body="$2"; shift 2; continue; fi
+          shift
+        done
+        printf '%s\n----8<----\n' "$body" >> "$COMMENT_FILE"
+        exit 0 ;;
+      *) echo "{}" ;;
+    esac ;;
+  label) exit 0 ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN_DIR/gh"
+
+  # git stub for the non-dry-run commit/push path. status --porcelain reports a
+  # change so the script reaches lint → commit → push → gh pr create.
+  cat > "$STUB_BIN_DIR/git" <<'GITEOF'
+#!/usr/bin/env bash
+case "$*" in
+  "config"*)            exit 0 ;;
+  "checkout -b"*)       exit 0 ;;
+  "rev-parse HEAD")     echo "abc123deadbeef" ;;
+  "status --porcelain") echo "M scripts/foo.sh" ;;
+  "add -A")             exit 0 ;;
+  "commit"*)            exit 0 ;;
+  "push"*)              exit 0 ;;
+  *)                    exit 0 ;;
+esac
+GITEOF
+  chmod +x "$STUB_BIN_DIR/git"
+
+  # Lint stub that always passes so the commit path is not blocked by real lint.
+  cat > "$STUB_BIN_DIR/dev-lead-lint.sh" <<'LINTEOF'
+#!/usr/bin/env bash
+echo "  [lint] all checks passed (stub)"
+exit 0
+LINTEOF
+  chmod +x "$STUB_BIN_DIR/dev-lead-lint.sh"
+
+  # Per-test standards fixture: a FAKE guard (allow/defer driven by FAKE_GATE)
+  # plus a minimal limits config. PLG_STANDARDS_DIR routes _plg_fetch here.
+  PLG_STANDARDS_DIR="$(mktemp -d)"; export PLG_STANDARDS_DIR
+  mkdir -p "$PLG_STANDARDS_DIR/scripts/lib" "$PLG_STANDARDS_DIR/standards"
+  cat > "$PLG_STANDARDS_DIR/scripts/lib/pr-limit-gate.sh" <<'GUARDEOF'
+#!/usr/bin/env bash
+# FAKE guard for tests: defer only when FAKE_GATE=defer.
+plg_admission_gate() { [ "${FAKE_GATE:-allow}" = "defer" ] && return 1 || return 0; }
+GUARDEOF
+  cat > "$PLG_STANDARDS_DIR/standards/pr-limits.json" <<'CFGEOF'
+{"org_wide":{"automation_open_pr_cap":50},"per_source_caps":{},"exempt_actors":[],"exempt_labels":[]}
+CFGEOF
+
+  export ISSUE_NUMBER="100"
+  export REPO="petry-projects/.github-private"
+  export REVIEW_ENGINE="claude"
+  export GITHUB_REPOSITORY="petry-projects/.github-private"
+  export LINT_SCRIPT="$STUB_BIN_DIR/dev-lead-lint.sh"
+
+  cd "$SCRIPT_DIR"
+}
+
+teardown() {
+  rm -f "$GITHUB_ENV" "$GITHUB_OUTPUT" "$PR_CREATED_FLAG" "$COMMENT_FILE"
+  rm -rf "$STUB_BIN_DIR" "$PLG_STANDARDS_DIR"
+}
+
+@test "pr-limit gate: under cap → opens PR (gh pr create called)" {
+  export DEV_LEAD_DRY_RUN="false"
+  export FAKE_GATE="allow"
+
+  run bash "$FIX_ISSUE_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ -f "$PR_CREATED_FLAG" ]
+}
+
+@test "pr-limit gate: at/over cap → defers (gh pr create NOT called)" {
+  export DEV_LEAD_DRY_RUN="false"
+  export FAKE_GATE="defer"
+
+  run bash "$FIX_ISSUE_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ ! -f "$PR_CREATED_FLAG" ]
+  [[ "$output" == *"PR-limit gate: deferring issue #100"* ]]
+}
+
+@test "pr-limit gate: defer → posts one deferral comment with the marker" {
+  export DEV_LEAD_DRY_RUN="false"
+  export FAKE_GATE="defer"
+
+  run bash "$FIX_ISSUE_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  local posted; posted=$(cat "$COMMENT_FILE")
+  [[ "$posted" == *"<!-- dev-lead-issue-deferred -->"* ]]
+  # Exactly one deferral comment posted.
+  local marker_count
+  marker_count=$(grep -c -- "<!-- dev-lead-issue-deferred -->" "$COMMENT_FILE")
+  [ "$marker_count" -eq 1 ]
+}
+
+@test "pr-limit gate: defer idempotent → no new comment when a marker already exists" {
+  export DEV_LEAD_DRY_RUN="false"
+  export FAKE_GATE="defer"
+  # gh stub serves an existing deferral comment for the comments-list query, so
+  # deferral_comment_exists returns true and post_deferral_comment is a no-op.
+  export PRIOR_COMMENTS_JSON='[{"body":"<!-- dev-lead-issue-deferred -->\nprior deferral"}]'
+
+  run bash "$FIX_ISSUE_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ ! -f "$PR_CREATED_FLAG" ]
+  # No new deferral comment was posted (COMMENT_FILE stays empty).
+  [ ! -s "$COMMENT_FILE" ]
+}
+
+@test "pr-limit gate: dry-run over cap → exits via [dry-run], gate not consulted" {
+  export DEV_LEAD_DRY_RUN="true"
+  export FAKE_GATE="defer"
+
+  run bash "$FIX_ISSUE_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[dry-run]"* ]]
+  # Gate never ran → no defer notice, no deferral comment, no PR.
+  [[ "$output" != *"PR-limit gate: deferring"* ]]
+  [ ! -f "$PR_CREATED_FLAG" ]
+  [ ! -s "$COMMENT_FILE" ]
+}
+
+@test "pr-limit gate: fetch failure → fails open, opens PR, warns" {
+  export DEV_LEAD_DRY_RUN="false"
+  export FAKE_GATE="defer"
+  # Point PLG_STANDARDS_DIR at an EMPTY dir so _plg_fetch cannot find the guard.
+  PLG_STANDARDS_DIR="$(mktemp -d)"; export PLG_STANDARDS_DIR
+
+  run bash "$FIX_ISSUE_SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [ -f "$PR_CREATED_FLAG" ]
+  [[ "$output" == *"::warning::"* ]]
+  [[ "$output" == *"failing open"* ]]
+}

--- a/tests/dev-lead/unit/test_fix_issue_pr_limit_gate.bats
+++ b/tests/dev-lead/unit/test_fix_issue_pr_limit_gate.bats
@@ -24,9 +24,10 @@ setup() {
   # Flag files the gh stub touches so tests can assert what happened.
   PR_CREATED_FLAG="$(mktemp -u)"; export PR_CREATED_FLAG
   COMMENT_FILE="$(mktemp)"; export COMMENT_FILE
-  # Prior issue comments the gh stub serves for the comments-list query. Default
-  # empty so no deferral comment pre-exists.
-  : "${PRIOR_COMMENTS_JSON:=[]}"; export PRIOR_COMMENTS_JSON
+  # Prior issue comments the gh stub serves for the comments-list query.
+  # Unconditionally reset to empty so no deferral comment pre-exists; individual
+  # tests (e.g. the idempotency test) override it after setup.
+  PRIOR_COMMENTS_JSON="[]"; export PRIOR_COMMENTS_JSON
 
   # gh stub: no existing PRs; serves issue title/body; records `pr create` via a
   # flag file; records every posted comment body; serves prior comments for the
@@ -49,8 +50,10 @@ case "$cmd" in
     case "$*" in
       *"pulls?state=open"*) echo "[]" ;;
       *comments*)
+        # Emit a single page so the script's `jq -s 'add // 0'` sums correctly.
+        # Tolerates a leading --paginate flag (extracted via the --jq loop above).
         if [ -n "$jqexpr" ]; then
-          printf '%s' "${PRIOR_COMMENTS_JSON:-[]}" | jq -r "$jqexpr"
+          jq -r "$jqexpr" <<< "${PRIOR_COMMENTS_JSON:-[]}"
         else
           printf '%s' "${PRIOR_COMMENTS_JSON:-[]}"
         fi ;;
@@ -113,8 +116,17 @@ LINTEOF
   mkdir -p "$PLG_STANDARDS_DIR/scripts/lib" "$PLG_STANDARDS_DIR/standards"
   cat > "$PLG_STANDARDS_DIR/scripts/lib/pr-limit-gate.sh" <<'GUARDEOF'
 #!/usr/bin/env bash
-# FAKE guard for tests: defer only when FAKE_GATE=defer.
-plg_admission_gate() { [ "${FAKE_GATE:-allow}" = "defer" ] && return 1 || return 0; }
+# FAKE guard for tests. Asserts the production contract so a regression cannot
+# pass silently via the script's fail-open: the source arg must be "dev-lead"
+# and PR_LIMITS_CONFIG must point at a readable config. A contract violation
+# returns 2 (an unexpected code the script treats as fail-open) AND logs to
+# stderr, which breaks the allow/defer assertions in tests 1 and 2. Otherwise
+# defer only when FAKE_GATE=defer.
+plg_admission_gate() {
+  [ "$1" = "dev-lead" ] || { echo "FAKE-GUARD: expected source 'dev-lead', got '$1'" >&2; return 2; }
+  [ -r "${PR_LIMITS_CONFIG:-}" ] || { echo "FAKE-GUARD: PR_LIMITS_CONFIG not readable: '${PR_LIMITS_CONFIG:-}'" >&2; return 2; }
+  [ "${FAKE_GATE:-allow}" = "defer" ] && return 1 || return 0
+}
 GUARDEOF
   cat > "$PLG_STANDARDS_DIR/standards/pr-limits.json" <<'CFGEOF'
 {"org_wide":{"automation_open_pr_cap":50},"per_source_caps":{},"exempt_actors":[],"exempt_labels":[]}
@@ -166,7 +178,7 @@ teardown() {
   [[ "$posted" == *"<!-- dev-lead-issue-deferred -->"* ]]
   # Exactly one deferral comment posted.
   local marker_count
-  marker_count=$(grep -c -- "<!-- dev-lead-issue-deferred -->" "$COMMENT_FILE")
+  marker_count=$(grep -c -- "<!-- dev-lead-issue-deferred -->" "$COMMENT_FILE" || true)
   [ "$marker_count" -eq 1 ]
 }
 


### PR DESCRIPTION
Phase 3 of the PR-limits initiative (epic petry-projects/.github#505): enforce the org-wide open-automation-PR cap **at the source**.

## What
Before opening a new automation PR, `dev-lead-fix-issue.sh` now asks the shared admission gate whether the standing queue of open non-draft automation PRs is at the signed-off cap, and **defers** if so.

- **`_plg_fetch`** — pulls the guard (`scripts/lib/pr-limit-gate.sh`) + config (`standards/pr-limits.json`) from the **public** `petry-projects/.github@main` at runtime → single source of truth, **not vendored**. `PLG_STANDARDS_DIR` routes to a local checkout for tests/offline.
- **`admission_gate_allows`** — sources the guard, calls `plg_admission_gate "dev-lead"`. **FAIL-OPEN** on any fetch/source/unexpected-rc problem so a guard defect never wedges PR creation; `rc==1` is the only real defer.
- **idempotent defer** — one comment (marker `<!-- dev-lead-issue-deferred -->`); drain-retries never spam.
- **Call site** sits AFTER the `DEV_LEAD_DRY_RUN` early-exit (a dry-run never defers) and BEFORE branch creation; on defer it opens nothing, leaves the issue labeled `dev-lead`, posts the note, exits 0.

## Behavior today
Config is authoritative in `petry-projects/.github` — cap **signed off at 50**, a single org-wide soft ceiling. Baseline is ~44 open automation PRs, so **nothing is refused today**; this only bounds runaway growth.

## Tests
New `tests/dev-lead/unit/test_fix_issue_pr_limit_gate.bats` (6 cases: under-cap opens PR, at/over-cap defers, single deferral comment, idempotent, dry-run-not-consulted, fetch-failure fail-open) — **6/6 pass**; `test_fix_issue.bats` **16/16** (no regression); shellcheck clean; `dev-lead-lint` passes.

## Note
Hand-authored after the dev-lead engine's own run implemented + validated the identical design but hit the **1800s CI timeout** before it could push (see #1003). Closes #1003.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic PR admission checks before creating new implementation PRs.
  * When the queue is full, the script now defers work and posts a clear, one-time comment explaining the delay.

* **Bug Fixes**
  * Dry-run executions no longer trigger deferrals.
  * Deferral comments are now idempotent, avoiding duplicate updates.
  * If shared standards data can’t be fetched, the process fails open and continues with a warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->