### PR TITLE
feat: implement issue #1005 — Onboard dev-lead into Release_Manager automation (+ resolve ring1 no-signal blocker)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -92,7 +92,8 @@ jobs:
             tests/test_downstream_impact_regression.bats \
             tests/test_engine_unavailable_notice.bats \
             tests/test_batch_skip_reporting.bats \
-            tests/test_review_one_pr_ci_pending.bats
+            tests/test_review_one_pr_ci_pending.bats \
+            tests/test_release_registry.bats
 
   template-drift:
     # Drift guard (#969): fail when a file committed in petry-projects/repo-template

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,7 @@ on:
       - 'tests/**'
       - 'agents/**'
       - 'evals/**'
+      - 'release/**'
       - '.gitleaks.toml'
   workflow_dispatch:
 

--- a/release/registry.yml
+++ b/release/registry.yml
@@ -1,0 +1,31 @@
+# release/registry.yml — fleet registry of first-party reusables consumed by the
+# autonomous soak-and-promote loop (Release_Manager automation, #993/#994/#999).
+# The orchestrator reads this as the source of truth for WHICH reusables to soak
+# and the ring → repos rollout map that its health gate evaluates.
+#
+# Schema
+#   version                schema version.
+#   reusables.<name>:
+#     host          repo that OWNS the reusable — its release/channel tags are cut
+#                   here (a host of petry-projects/.github means the reusable is
+#                   cross-repo and this repo holds only the thin caller stub).
+#     run_workflow  the workflow (file or display name) whose run history feeds the
+#                   health gate for this reusable.
+#     gate          per-reusable gate knobs (soak_window_days, ...).
+#     rings         ordered rollout ladder — a list of { channel, order, repos }.
+#                   A candidate soaks in each ring in `order` and is promoted to the
+#                   next only once the gate confirms the current ring is healthy.
+version: 1
+
+reusables:
+  # First onboarding intake (#1005): dev-lead, validated live 2026-07-01.
+  # next=ring0=v1.5.0 (candidate, mid-roll); ring1=stable=v1.4.0 (rollback target).
+  dev-lead:
+    host: petry-projects/.github-private
+    run_workflow: dev-lead.yml
+    gate: { soak_window_days: 7 }
+    rings:
+      - { channel: next,   order: 0, repos: [petry-projects/.github-private] }
+      - { channel: ring0,  order: 1, repos: [petry-projects/.github] }
+      - { channel: ring1,  order: 2, repos: [petry-projects/TalkTerm, petry-projects/bmad-bgreat-suite] }
+      - { channel: stable, order: 3, repos: [petry-projects/ContentTwin, petry-projects/google-app-scripts, petry-projects/markets, petry-projects/broodly] }

--- a/release/registry.yml
+++ b/release/registry.yml
@@ -20,6 +20,12 @@ version: 1
 reusables:
   # First onboarding intake (#1005): dev-lead, validated live 2026-07-01.
   # next=ring0=v1.5.0 (candidate, mid-roll); ring1=stable=v1.4.0 (rollback target).
+  #
+  # COORDINATION NOTE: ring1 health signal is not yet active. The two ring1 consumer
+  # repos (TalkTerm, bmad-bgreat-suite) currently pin @dev-lead/stable, not
+  # @dev-lead/ring1. The Release_Manager gate cannot soak ring1→stable until
+  # staged repin PRs land in those repos to move them onto the ring1 channel.
+  # This registry entry records the intended ring1 shape; the blocker is external.
   dev-lead:
     host: petry-projects/.github-private
     run_workflow: dev-lead.yml

--- a/tests/test_release_registry.bats
+++ b/tests/test_release_registry.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+# Validates release/registry.yml — the fleet registry the Release_Manager
+# soak-and-promote automation (#993/#994/#999) reads to gate + promote each
+# first-party reusable. This guards the shape of the dev-lead onboarding intake
+# (#1005): host, the health-gate workflow, gate knobs, and the ordered
+# next→ring0→ring1→stable rollout ladder with its validated repo lists.
+#
+# Run with: bats tests/test_release_registry.bats
+
+REGISTRY="$(dirname "$BATS_TEST_FILENAME")/../release/registry.yml"
+
+setup() {
+  command -v yq >/dev/null 2>&1 || skip "yq not installed"
+  command -v jq >/dev/null 2>&1 || skip "jq not installed"
+}
+
+@test "registry.yml: is valid YAML with a schema version" {
+  run yq -e '.version' "$REGISTRY"
+  [ "$status" -eq 0 ]
+}
+
+@test "registry.yml: has a non-empty reusables map" {
+  run yq -e '.reusables | length > 0' "$REGISTRY"
+  [ "$status" -eq 0 ]
+}
+
+@test "registry.yml: dev-lead entry is present" {
+  run yq -e '.reusables | has("dev-lead")' "$REGISTRY"
+  [ "$status" -eq 0 ]
+}
+
+@test "registry.yml: dev-lead is hosted in .github-private" {
+  run yq -e '.reusables."dev-lead".host == "petry-projects/.github-private"' "$REGISTRY"
+  [ "$status" -eq 0 ]
+}
+
+@test "registry.yml: dev-lead declares a run_workflow for the health gate" {
+  run bash -c "yq -e '.reusables.\"dev-lead\".run_workflow' '$REGISTRY' | grep -q ."
+  [ "$status" -eq 0 ]
+}
+
+@test "registry.yml: dev-lead gate soak_window_days is 7" {
+  run yq -e '.reusables."dev-lead".gate.soak_window_days == 7' "$REGISTRY"
+  [ "$status" -eq 0 ]
+}
+
+@test "registry.yml: dev-lead has four rings" {
+  run yq -e '.reusables."dev-lead".rings | length == 4' "$REGISTRY"
+  [ "$status" -eq 0 ]
+}
+
+@test "registry.yml: dev-lead ring channels are next/ring0/ring1/stable in order" {
+  run bash -c "yq -o=json '$REGISTRY' | jq -er '[.reusables.\"dev-lead\".rings[].channel] == [\"next\",\"ring0\",\"ring1\",\"stable\"]'"
+  [ "$status" -eq 0 ]
+}
+
+@test "registry.yml: dev-lead ring order values are 0..3 ascending" {
+  run bash -c "yq -o=json '$REGISTRY' | jq -er '[.reusables.\"dev-lead\".rings[].order] == [0,1,2,3]'"
+  [ "$status" -eq 0 ]
+}
+
+@test "registry.yml: dev-lead next ring is the self-host repo" {
+  run bash -c "yq -o=json '$REGISTRY' | jq -er '(.reusables.\"dev-lead\".rings[] | select(.channel==\"next\").repos) == [\"petry-projects/.github-private\"]'"
+  [ "$status" -eq 0 ]
+}
+
+@test "registry.yml: dev-lead ring0 is the other org-infra repo" {
+  run bash -c "yq -o=json '$REGISTRY' | jq -er '(.reusables.\"dev-lead\".rings[] | select(.channel==\"ring0\").repos) == [\"petry-projects/.github\"]'"
+  [ "$status" -eq 0 ]
+}
+
+@test "registry.yml: dev-lead ring1 carries the two low-traffic consumers" {
+  run bash -c "yq -o=json '$REGISTRY' | jq -er '(.reusables.\"dev-lead\".rings[] | select(.channel==\"ring1\").repos) == [\"petry-projects/TalkTerm\",\"petry-projects/bmad-bgreat-suite\"]'"
+  [ "$status" -eq 0 ]
+}
+
+@test "registry.yml: dev-lead stable carries the remaining four consumers" {
+  run bash -c "yq -o=json '$REGISTRY' | jq -er '(.reusables.\"dev-lead\".rings[] | select(.channel==\"stable\").repos) == [\"petry-projects/ContentTwin\",\"petry-projects/google-app-scripts\",\"petry-projects/markets\",\"petry-projects/broodly\"]'"
+  [ "$status" -eq 0 ]
+}

--- a/tests/test_release_registry.bats
+++ b/tests/test_release_registry.bats
@@ -35,7 +35,7 @@ setup() {
 }
 
 @test "registry.yml: dev-lead declares a run_workflow for the health gate" {
-  run bash -c "yq -e '.reusables.\"dev-lead\".run_workflow' '$REGISTRY' | grep -q ."
+  run yq -e '.reusables."dev-lead".run_workflow' "$REGISTRY"
   [ "$status" -eq 0 ]
 }
 

--- a/tests/test_release_registry.bats
+++ b/tests/test_release_registry.bats
@@ -10,8 +10,8 @@
 REGISTRY="$(dirname "$BATS_TEST_FILENAME")/../release/registry.yml"
 
 setup() {
-  command -v yq >/dev/null 2>&1 || skip "yq not installed"
-  command -v jq >/dev/null 2>&1 || skip "jq not installed"
+  command -v yq >/dev/null 2>&1 || { echo "ERROR: yq is required but not installed" >&2; return 1; }
+  command -v jq >/dev/null 2>&1 || { echo "ERROR: jq is required but not installed" >&2; return 1; }
 }
 
 @test "registry.yml: is valid YAML with a schema version" {


### PR DESCRIPTION
Closes #1005

Implemented by dev-lead agent. Please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new staged release rollout registry configuration supporting soak timing, health signaling, and promotion across multiple rings.
* **Tests**
  * Expanded automated Bats coverage to validate the release registry’s required fields, soak window, ring ordering, and expected repository lists.
* **Chores / CI**
  * Updated the lint workflow to run for pull requests affecting release-area changes and included the new registry test in the Bats suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->