### PR TITLE
feat: implement issue #1009 — dev-lead emits empty, model-less token records that pollute the "no price" count in the cost report

### DIFF
--- a/scripts/lib/token-metrics.sh
+++ b/scripts/lib/token-metrics.sh
@@ -80,6 +80,20 @@ emit_token_record() {
   local input="${5:-0}" cache="${6:-0}" output="${7:-0}" context="${8:-}"
   local cache_write="${9:-0}"
 
+  # Drop empty, model-less records: no model (empty or "-") AND zero usage across
+  # every token count. These carry no signal — a dev-lead error/fallback branch can
+  # emit one when usage failed to parse and no model was resolved — and they only
+  # inflate the cost report's "no price" count and add a junk `- / -` cost-driver
+  # row (#1009). A real model with an all-zero usage block is a legitimate empty
+  # call and is still emitted. Counts are trusted integers (0-defaulted above).
+  case "$model" in
+    "" | "-")
+      if [ "$(( input + cache + output + cache_write ))" -eq 0 ]; then
+        return 0
+      fi
+      ;;
+  esac
+
   local mult et ts run_id record
   mult=$(model_multiplier_for "$model")
   et=$(calculate_et "$input" "$cache" "$output" "$mult")

--- a/scripts/token_report.sh
+++ b/scripts/token_report.sh
@@ -84,6 +84,17 @@ annotate_records() {
   [ -e "${files[0]}" ] || return 0   # no JSONL files → no rows
   jq -r 'select(type == "object")
     | select((.kind // "token_usage") == "token_usage")
+    # Drop empty, model-less records (no model AND zero usage): they are not priced
+    # calls at all — counting them inflates the "no price" warning and adds a junk
+    # `- / -` cost-driver row (#1009). A real model missing a price still surfaces
+    # (known=0 → warns); a real model with an all-zero usage block is still counted.
+    | select(
+        (((.model // "") | (. == "" or . == "-"))
+         and ((.input_tokens // 0) == 0)
+         and ((.cache_read_tokens // 0) == 0)
+         and ((.cache_creation_tokens // 0) == 0)
+         and ((.output_tokens // 0) == 0)) | not
+      )
     | [
       (.repo // "unknown"), (.workflow // "unknown"), (.tier // "-"), (.model // "-"),
       (.input_tokens // 0), (.cache_read_tokens // 0), (.output_tokens // 0),

--- a/tests/dev-lead/unit/test_token_metrics.bats
+++ b/tests/dev-lead/unit/test_token_metrics.bats
@@ -201,6 +201,44 @@ teardown() {
   [ "$cw" = "0" ]
 }
 
+# ── emit_token_record: empty model-less all-zero suppression (#1009) ───────────
+
+@test "emit_token_record: suppresses an empty model-less all-zero record" {
+  # dev-lead error/fallback path emits (workflow, tier, engine, model="") with 0 usage.
+  # Such a record carries no signal — it only inflates the report's "no price" count
+  # and adds a junk `- / -` cost-driver row, so it must not be written at all.
+  emit_token_record "dev-lead" "" "claude" "" 0 0 0 ""
+  [ ! -s "$TOKEN_LOG_FILE" ]
+}
+
+@test "emit_token_record: suppresses a '-' model all-zero record (incl. cache_write)" {
+  emit_token_record "dev-lead" "" "claude" "-" 0 0 0 "" 0
+  [ ! -s "$TOKEN_LOG_FILE" ]
+}
+
+@test "emit_token_record: still emits a real model with an all-zero usage block" {
+  # A genuine empty call (real model, zero tokens) is legitimate and must survive.
+  emit_token_record "dev-lead" "writer" "claude" "claude-sonnet-4-6" 0 0 0 ""
+  [ -s "$TOKEN_LOG_FILE" ]
+  local model
+  model=$(jq -r '.model' < "$TOKEN_LOG_FILE")
+  [ "$model" = "claude-sonnet-4-6" ]
+}
+
+@test "emit_token_record: still emits a model-less record that carries real usage" {
+  # Only the *all-zero AND model-less* case is junk; non-zero usage is real signal.
+  emit_token_record "dev-lead" "writer" "claude" "" 100 0 50 ""
+  [ -s "$TOKEN_LOG_FILE" ]
+}
+
+@test "emit_token_record: suppresses model-less record whose only tokens are cache_write" {
+  # Guard must consider cache_write (9th arg), not just the first three counts.
+  emit_token_record "dev-lead" "" "claude" "" 0 0 0 "" 0
+  [ ! -s "$TOKEN_LOG_FILE" ]
+  emit_token_record "dev-lead" "" "claude" "" 0 0 0 "" 25
+  [ -s "$TOKEN_LOG_FILE" ]
+}
+
 # ── parse_engine_usage / extract_engine_text ──────────────────────────────────
 
 @test "parse_engine_usage: claude JSON sets input/cache-read/cache-write/output" {

--- a/tests/dev-lead/unit/test_token_metrics.bats
+++ b/tests/dev-lead/unit/test_token_metrics.bats
@@ -231,8 +231,9 @@ teardown() {
   [ -s "$TOKEN_LOG_FILE" ]
 }
 
-@test "emit_token_record: suppresses model-less record whose only tokens are cache_write" {
-  # Guard must consider cache_write (9th arg), not just the first three counts.
+@test "emit_token_record: keeps a model-less record whose only tokens are cache_write (guard considers 9th arg)" {
+  # The guard must consider cache_write (9th arg), not just the first three counts:
+  # an all-zero model-less record is suppressed, but one carrying cache_write is kept.
   emit_token_record "dev-lead" "" "claude" "" 0 0 0 "" 0
   [ ! -s "$TOKEN_LOG_FILE" ]
   emit_token_record "dev-lead" "" "claude" "" 0 0 0 "" 25

--- a/tests/token_report.bats
+++ b/tests/token_report.bats
@@ -80,8 +80,7 @@ setup() {
 @test "annotate_records: excludes empty model-less all-zero records (#1009)" {
   # The dev-lead path emitted model-less, zero-usage junk records that surfaced as a
   # `- / -` row and inflated the "no price" count. They are not priced calls at all,
-  # so annotate_records drops them entirely. A record with an empty model but real
-  # tokens, and a real-model row, are kept.
+  # so annotate_records drops them entirely, keeping only the genuine real-model row.
   tmp="$(mktemp -d)"
   printf '%s\n' \
     '{"ts":"2026-06-01T00:00:00Z","workflow":"dev-lead","tier":"","model":"","input_tokens":0,"cache_read_tokens":0,"cache_creation_tokens":0,"output_tokens":0,"repo":"r","context":""}' \

--- a/tests/token_report.bats
+++ b/tests/token_report.bats
@@ -77,6 +77,52 @@ setup() {
   [ "$result" = "-1.000000 0" ]
 }
 
+@test "annotate_records: excludes empty model-less all-zero records (#1009)" {
+  # The dev-lead path emitted model-less, zero-usage junk records that surfaced as a
+  # `- / -` row and inflated the "no price" count. They are not priced calls at all,
+  # so annotate_records drops them entirely. A record with an empty model but real
+  # tokens, and a real-model row, are kept.
+  tmp="$(mktemp -d)"
+  printf '%s\n' \
+    '{"ts":"2026-06-01T00:00:00Z","workflow":"dev-lead","tier":"","model":"","input_tokens":0,"cache_read_tokens":0,"cache_creation_tokens":0,"output_tokens":0,"repo":"r","context":""}' \
+    '{"ts":"2026-06-01T00:00:01Z","workflow":"dev-lead","tier":"","model":"-","input_tokens":0,"cache_read_tokens":0,"cache_creation_tokens":0,"output_tokens":0,"repo":"r","context":""}' \
+    '{"ts":"2026-06-01T00:00:02Z","workflow":"pr-review","tier":"deep","model":"claude-opus-4-7","input_tokens":100,"output_tokens":50,"repo":"r","context":""}' \
+    > "$tmp/mixed.jsonl"
+  result="$(annotate_records "$tmp" | wc -l)"
+  rm -rf "$tmp"
+  [ "$result" -eq 1 ]
+}
+
+@test "render_token_report: empty model-less junk does not add to the 'no price' count" {
+  # Only a genuine unknown-but-real model should warn. A model-less all-zero record
+  # must not appear as an unpriced call, and its `- / -` row must not render.
+  tmp="$(mktemp -d)"
+  printf '%s\n' \
+    '{"ts":"2026-06-01T00:00:00Z","workflow":"dev-lead","tier":"","model":"","input_tokens":0,"cache_read_tokens":0,"cache_creation_tokens":0,"output_tokens":0,"repo":"r","context":""}' \
+    '{"ts":"2026-06-01T00:00:02Z","workflow":"pr-review","tier":"deep","model":"claude-opus-4-7","input_tokens":100,"output_tokens":50,"repo":"r","context":""}' \
+    > "$tmp/mixed.jsonl"
+  run render_token_report "$tmp" 7 1 1 2026-06-07
+  rm -rf "$tmp"
+  [ "$status" -eq 0 ]
+  # No unpriced warning (the only non-priced record was junk, now excluded).
+  [[ "$output" != *"had no price"* ]]
+  # No junk `- / -` cost-driver row.
+  [[ "$output" != *"| \`dev-lead\` |  | \`-\` |"* ]]
+}
+
+@test "render_token_report: a real unknown-model call still warns (#1009 regression guard)" {
+  # Fix B must NOT silence genuine unpriced-but-real calls.
+  tmp="$(mktemp -d)"
+  printf '%s\n' \
+    '{"ts":"2026-06-01T00:00:00Z","workflow":"dev-lead","tier":"","model":"","input_tokens":0,"cache_read_tokens":0,"cache_creation_tokens":0,"output_tokens":0,"repo":"r","context":""}' \
+    '{"ts":"2026-06-01T00:00:02Z","workflow":"x","tier":"y","model":"mystery-model-v9","input_tokens":100,"output_tokens":50,"repo":"r","context":""}' \
+    > "$tmp/mixed.jsonl"
+  run render_token_report "$tmp" 7 1 1 2026-06-07
+  rm -rf "$tmp"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"had no price"* ]]
+}
+
 # ---------------------------------------------------------------------------
 # render_token_report
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1009

Implemented by dev-lead agent. Please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Filtered out empty token-usage records when no model is present and all token counts are zero, so they no longer appear in token logs or reports.
  * Prevented these placeholder rows from inflating “no price”/junk counts, while still keeping real usage records and legitimate unknown-price cases visible.

* **Tests**
  * Added regression coverage for zero-usage, model-less records and confirmed valid records continue to be reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->