### PR TITLE
feat(seed): seed .gitleaks.toml into repo template from standards/gitleaks.toml (#575)

### DIFF
--- a/scripts/seed-repo-template.sh
+++ b/scripts/seed-repo-template.sh
@@ -314,27 +314,27 @@ _emit_baseline() {
   local content std_path
   if [ "$source" = "gen" ]; then
     _gen_baseline "$path"
-  elif [ "$source" = "fetch" ]; then
-    # Dependabot special case: the standards path is DEPENDABOT_STACK-derived.
-    std_path="standards/dependabot/${DEPENDABOT_STACK}.yml"
-    content="$(_fetch_standard "$std_path")" || true
-    if [ -z "$content" ]; then
-      echo "::error::could not fetch ${std_path} from ${STANDARDS_REPO}" >&2
-      return 1
-    fi
-    printf '%s\n' "$content"
-  elif [ "${source#fetch:}" != "$source" ]; then
-    # General verbatim fetch: source=fetch:<standards-path> (e.g. .gitleaks.toml).
-    std_path="${source#fetch:}"
-    content="$(_fetch_standard "$std_path")" || true
-    if [ -z "$content" ]; then
-      echo "::error::could not fetch ${std_path} from ${STANDARDS_REPO}" >&2
-      return 1
-    fi
-    printf '%s\n' "$content"
   else
-    echo "::error::unknown baseline source '${source}' for ${path}" >&2
-    return 2
+    if [ "$source" = "fetch" ]; then
+      # Dependabot special case: the standards path is DEPENDABOT_STACK-derived.
+      std_path="standards/dependabot/${DEPENDABOT_STACK}.yml"
+    elif [ "${source#fetch:}" != "$source" ]; then
+      # General verbatim fetch: source=fetch:<standards-path> (e.g. .gitleaks.toml).
+      std_path="${source#fetch:}"
+      if [ -z "$std_path" ]; then
+        echo "::error::empty standards path in source '${source}' for ${path}" >&2
+        return 2
+      fi
+    else
+      echo "::error::unknown baseline source '${source}' for ${path}" >&2
+      return 2
+    fi
+    content="$(_fetch_standard "$std_path")" || true
+    if [ -z "$content" ]; then
+      echo "::error::could not fetch ${std_path} from ${STANDARDS_REPO}" >&2
+      return 1
+    fi
+    printf '%s\n' "$content"
   fi
 }
 

--- a/scripts/seed-repo-template.sh
+++ b/scripts/seed-repo-template.sh
@@ -77,12 +77,14 @@ readonly -a WORKFLOW_MANIFEST=(
 
 # Baseline files (AC #3). One row per file: "path|source".
 #   source=gen → generated inline by _gen_baseline.
-#   source=fetch:<standards-path> → fetched verbatim from STANDARDS_REPO.
+#   source=fetch:<standards-path> → fetched verbatim from STANDARDS_REPO at that path.
+#   source=fetch (bare) → the Dependabot stack special case (path is DEPENDABOT_STACK-derived).
 readonly -a BASELINE_MANIFEST=(
   "AGENTS.md|gen"
   "CLAUDE.md|gen"
   ".github/CODEOWNERS|gen"
   ".github/dependabot.yml|fetch"
+  ".gitleaks.toml|fetch:standards/gitleaks.toml"
   "sonar-project.properties|gen"
   ".gitignore|gen"
   "LICENSE|gen"
@@ -309,16 +311,30 @@ _emit_baseline() {
     echo "::error::unknown baseline file: $path" >&2
     return 2
   fi
+  local content std_path
   if [ "$source" = "gen" ]; then
     _gen_baseline "$path"
-  else
-    local content
-    content="$(_fetch_standard "standards/dependabot/${DEPENDABOT_STACK}.yml")" || true
+  elif [ "$source" = "fetch" ]; then
+    # Dependabot special case: the standards path is DEPENDABOT_STACK-derived.
+    std_path="standards/dependabot/${DEPENDABOT_STACK}.yml"
+    content="$(_fetch_standard "$std_path")" || true
     if [ -z "$content" ]; then
-      echo "::error::could not fetch standards/dependabot/${DEPENDABOT_STACK}.yml from ${STANDARDS_REPO}" >&2
+      echo "::error::could not fetch ${std_path} from ${STANDARDS_REPO}" >&2
       return 1
     fi
     printf '%s\n' "$content"
+  elif [ "${source#fetch:}" != "$source" ]; then
+    # General verbatim fetch: source=fetch:<standards-path> (e.g. .gitleaks.toml).
+    std_path="${source#fetch:}"
+    content="$(_fetch_standard "$std_path")" || true
+    if [ -z "$content" ]; then
+      echo "::error::could not fetch ${std_path} from ${STANDARDS_REPO}" >&2
+      return 1
+    fi
+    printf '%s\n' "$content"
+  else
+    echo "::error::unknown baseline source '${source}' for ${path}" >&2
+    return 2
   fi
 }
 

--- a/scripts/template_stub_drift.sh
+++ b/scripts/template_stub_drift.sh
@@ -52,6 +52,7 @@ readonly -a TEMPLATE_DRIFT_FILES=(
   ".github/dependabot.yml|--emit-baseline|.github/dependabot.yml"
   ".github/CODEOWNERS|--emit-baseline|.github/CODEOWNERS"
   "CLAUDE.md|--emit-baseline|CLAUDE.md"
+  ".gitleaks.toml|--emit-baseline|.gitleaks.toml"
 )
 
 # ── Documented allowlist (AC #2) ──────────────────────────────────────────────

--- a/tests/template_stub_drift.bats
+++ b/tests/template_stub_drift.bats
@@ -58,6 +58,7 @@ setup() {
   [[ "$output" == *".github/dependabot.yml"* ]]
   [[ "$output" == *".github/CODEOWNERS"* ]]
   [[ "$output" == *"CLAUDE.md"* ]]
+  [[ "$output" == *".gitleaks.toml"* ]]
 }
 
 @test "covered set: excludes the allowlisted ci.yml (per-stack customizable)" {

--- a/tests/test_seed_repo_template.bats
+++ b/tests/test_seed_repo_template.bats
@@ -97,8 +97,8 @@ _stub_gh_empty() {
   run bash "$SEED" --list-baseline
   [ "$status" -eq 0 ]
   for f in AGENTS.md CLAUDE.md .github/CODEOWNERS .github/dependabot.yml \
-           sonar-project.properties .gitignore LICENSE SECURITY.md \
-           README.md BOOTSTRAP.md; do
+           .gitleaks.toml sonar-project.properties .gitignore LICENSE \
+           SECURITY.md README.md BOOTSTRAP.md; do
     [[ "$output" == *"$f"* ]] || { echo "missing baseline: $f" >&2; false; }
   done
 }
@@ -237,6 +237,27 @@ EOF
   [[ "$output" == *"auto-trigger"* ]]
 }
 
+# ── .gitleaks.toml baseline is fetched verbatim from standards/gitleaks.toml ───
+# Seeds the secret-scan job's required config (push-protection.md); without it the
+# template ci.yml's `gitleaks detect --config .gitleaks.toml` fails file-not-found.
+@test "baseline: .gitleaks.toml is fetched verbatim from standards/gitleaks.toml (#575)" {
+  printf 'title = "gitleaks config"\n[allowlist]\npaths = [ %s ]\n' "'''_bmad/'''" \
+    > "$STANDARDS_DIR/standards/gitleaks.toml"
+  run bash "$SEED" --emit-baseline .gitleaks.toml
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'title = "gitleaks config"'* ]]
+  [[ "$output" == *"_bmad/"* ]]
+}
+
+@test "baseline: .gitleaks.toml FAILS LOUD when standards/gitleaks.toml is absent" {
+  # No fixture written; empty gh stub blocks the network fallback so the general
+  # fetch:<path> source must fail loud, not emit empty (it exists in the live repo).
+  _stub_gh_empty
+  run bash "$SEED" --emit-baseline .gitleaks.toml
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"standards/gitleaks.toml"* ]]
+}
+
 # ── dependabot baseline is sourced from the chosen standards/ stack template ───
 @test "baseline: dependabot.yml comes from the chosen standards/dependabot stack" {
   printf 'version: 2\nupdates:\n  - package-ecosystem: npm\n' \
@@ -295,11 +316,13 @@ EOF
     fi
   done
   printf 'version: 2\n' > "$STANDARDS_DIR/standards/dependabot/frontend.yml"
+  printf 'title = "gitleaks config"\n' > "$STANDARDS_DIR/standards/gitleaks.toml"
   run env DEPENDABOT_STACK=frontend bash "$SEED" --repo petry-projects/repo-template
   [ "$status" -eq 0 ]
   [ -f "$CALLS" ]
   grep -q "contents/.github/workflows/auto-rebase.yml" "$CALLS"
   grep -q "contents/.github/CODEOWNERS" "$CALLS"
+  grep -q "contents/.gitleaks.toml" "$CALLS"
   grep -q "pr create" "$CALLS"
 }
 
@@ -323,6 +346,7 @@ EOF
     fi
   done
   printf 'version: 2\n' > "$STANDARDS_DIR/standards/dependabot/frontend.yml"
+  printf 'title = "gitleaks config"\n' > "$STANDARDS_DIR/standards/gitleaks.toml"
   run env DEPENDABOT_STACK=frontend bash "$SEED" --repo petry-projects/repo-template
   [ "$status" -eq 0 ]
   [[ "$output" == *"PR #42 already open"* ]]


### PR DESCRIPTION
## Summary

Seeds a `.gitleaks.toml` at the root of every repo created from `repo-template`, sourced verbatim from `petry-projects/.github` `standards/gitleaks.toml`. **Companion to petry-projects/.github#578** — that PR adds the `secret-scan` job to the template `ci.yml`, which runs `gitleaks detect --config .gitleaks.toml` and **fails file-not-found without this config**. Land them together.

## Changes

- **`BASELINE_MANIFEST`** — add `.gitleaks.toml|fetch:standards/gitleaks.toml`.
- **`_emit_baseline`** — generalize the fetch source: bare `fetch` stays the Dependabot stack special case; new **`fetch:<standards-path>`** fetches that path verbatim (the form the manifest header already documented but wasn't implemented). Unknown sources now fail loud.
- **Tests** — verbatim-fetch + fail-loud (empty-gh stub blocks the network fallback) for `.gitleaks.toml`; added to the baseline-set list; fixture provisioned + cross-repo write asserted in the seeding e2e. **28/28 seed bats pass**, `shellcheck --severity=warning -x` clean.

## Verified
Real emit against the live `standards/gitleaks.toml` is **byte-identical**:
```
$ STANDARDS_DIR=…/.github seed-repo-template.sh --emit-baseline .gitleaks.toml
title = "gitleaks config"
…
[allowlist]
paths = [ '''_bmad/''' ]
→ VERBATIM (byte-identical)
```

Part of #575 (folded-in from closed #1001). Epic #964.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for seeding and verifying a `.gitleaks.toml` baseline file from the standard template source.
  * Expanded baseline fetching to support general standard-path imports.

* **Bug Fixes**
  * Improved validation and error messages when a standard file path is missing or cannot be fetched.
  * Included `.gitleaks.toml` in template drift checks to surface template differences consistently.

* **Tests**
  * Updated baseline listing, fetching, missing-file failure handling, and seeding flow assertions to cover `.gitleaks.toml`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->