### PR TITLE
test(safety-checks): regression guards for xit/xdescribe (mawk) + cross-file rem-leak (#305)

### DIFF
--- a/tests/test_safety_checks.bats
+++ b/tests/test_safety_checks.bats
@@ -149,13 +149,15 @@ setup() {
   local diff='diff --git a/foo.test.js b/foo.test.js
 --- a/foo.test.js
 +++ b/foo.test.js
-@@ -1,2 +1,3 @@
+@@ -1,2 +1,4 @@
  test("keep", ()=>{})
 +xit("skipme", ()=>{})
++xdescribe("group", ()=>{})
  more'
   run sc_ci_weakening "$diff"
   [ "$status" -eq 0 ]
-  echo "$output" | grep -qi "skip/disable marker"
+  grep -qi "skip/disable marker" <<< "$output"
+  grep -q "foo.test.js" <<< "$output"
 }
 
 # Regression (issue #305 review): the awk `rem[]` threshold map must be reset per
@@ -179,7 +181,7 @@ diff --git a/b/unrelated.txt b/b/unrelated.txt
   [ "$status" -eq 0 ]
   # Exactly the real threshold drop in file A is reported; file B must NOT
   # produce a "lowered threshold" finding from a leaked rem[] value.
-  [ "$(echo "$output" | grep -ci "lowered numeric threshold")" -eq 1 ]
+  [ "$(grep -ci "lowered numeric threshold" <<< "$output" || true)" -eq 1 ]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/test_safety_checks.bats
+++ b/tests/test_safety_checks.bats
@@ -141,6 +141,47 @@ setup() {
   [ -z "$output" ]
 }
 
+# Regression (issue #305 review): the xit/xdescribe markers must be matched with
+# POSIX-portable boundaries, NOT GNU awk's `\b` — the CI `bats` job runs on
+# Ubuntu where `awk` is mawk, which does not support `\b`. Before the fix this
+# path silently never matched on the runner.
+@test "ci-weakening: detects xit/xdescribe skip markers (POSIX boundary, must pass on mawk)" {
+  local diff='diff --git a/foo.test.js b/foo.test.js
+--- a/foo.test.js
++++ b/foo.test.js
+@@ -1,2 +1,3 @@
+ test("keep", ()=>{})
++xit("skipme", ()=>{})
+ more'
+  run sc_ci_weakening "$diff"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qi "skip/disable marker"
+}
+
+# Regression (issue #305 review): the awk `rem[]` threshold map must be reset per
+# file (`delete rem`). Without it, a removed threshold in file A leaks into the
+# comparison for file B, producing a false "lowered threshold" finding there.
+@test "ci-weakening: removed threshold in file A does not leak into file B (rem state reset)" {
+  local diff='diff --git a/a/codecov.yml b/a/codecov.yml
+--- a/a/codecov.yml
++++ b/a/codecov.yml
+@@ -1,2 +1,2 @@
+-coverage: 90
++coverage: 80
+ x: y
+diff --git a/b/unrelated.txt b/b/unrelated.txt
+--- a/b/unrelated.txt
++++ b/b/unrelated.txt
+@@ -1,1 +1,2 @@
+ hello
++coverage note: 5 lines added'
+  run sc_ci_weakening "$diff"
+  [ "$status" -eq 0 ]
+  # Exactly the real threshold drop in file A is reported; file B must NOT
+  # produce a "lowered threshold" finding from a leaked rem[] value.
+  [ "$(echo "$output" | grep -ci "lowered numeric threshold")" -eq 1 ]
+}
+
 # ---------------------------------------------------------------------------
 # Check 2 — Prompt injection in workflows (deterministic, hard-stop)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds two regression tests to `tests/test_safety_checks.bats`, following up on #1012 (issue #305).

## Why

#1012 auto-merged the deterministic safety-checks feature — including the gemini-review correctness fixes to `scripts/lib/safety-checks.sh` (POSIX word boundaries replacing GNU `\b`, and `delete rem` per file) — **before** regression coverage for those exact paths was added. This PR locks in both fixes:

1. **`xit`/`xdescribe` detection (mawk).** The CI `bats` job runs on Ubuntu where `awk` is **mawk**, which does not support `\b`. The pre-fix `\bxit\b` pattern silently never matched on the runner. This test asserts `xit(` is detected as CI-weakening — it would have failed on the runner before the POSIX-boundary fix.
2. **Cross-file `rem[]` state leak.** Without `delete rem` per file, a removed threshold in file A leaked into file B's comparison, producing a false "lowered threshold" finding. This test uses a two-file diff and asserts exactly one finding.

## Verification

Both tests were verified to **fail against the pre-fix lib** (old code: `xit` undetected; leak-count = 2, not 1) and **pass on the merged fix**. Full suite: 39/39 green on mawk.

## Risk

Test-only. No production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added two new regression tests for safety checks covering disabled test markers in JavaScript diffs, ensuring consistent, POSIX-portable detection across environments.
  * Added coverage to confirm per-file state resets in multi-file diffs, preventing threshold changes in one file from triggering incorrect findings in another.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->