### PR TITLE
feat: implement issue #1025 — canary-rollout post-merge: fleet-wide evaluate coverage (P1) + benign-failure allowlist + app-id→client-id

### DIFF
--- a/.github/workflows/canary-rollout.yml
+++ b/.github/workflows/canary-rollout.yml
@@ -8,15 +8,16 @@
 # recording a GitHub Deployment for traceability. It never writes consumer files.
 #
 # Auth: the mover credential is a GitHub App installation token minted at runtime via
-# actions/create-github-app-token from RELEASE_MANAGER_APP_ID (variable) + RELEASE_MANAGER_APP_KEY (secret) (scoped,
+# actions/create-github-app-token from RELEASE_MANAGER_APP_CLIENT_ID (variable) + RELEASE_MANAGER_APP_KEY (secret) (scoped,
 # rotatable, auditable) — NOT a raw PAT and NOT github.token. The App carries
 # Contents:write (tag moves on the host repos), Deployments:write, Actions:read (the
 # gate reads workflow-run history across every tier repo) and Metadata:read. Minting
 # is a HARD requirement: if the token cannot be minted the job fails — it must not
 # silently degrade to github.token, which cannot move protected `.github` tags (#868).
 #
-#   - schedule (every 4h): read-only `evaluate` ONLY — emits the per-version gate
-#     + health report (#502 observability). Never promotes on the timer.
+#   - schedule (every 4h): read-only `evaluate-all` ONLY — evaluates EVERY agent in
+#     canary-rings.json (fleet-wide, #1025 P1) and emits each one's per-version gate +
+#     health report (#502 observability). Never promotes on the timer.
 #   - workflow_dispatch: `evaluate` | `promote` | `rollback`, human-gated.
 # ─────────────────────────────────────────────────────────────────────────────
 name: Canary Rollout
@@ -57,7 +58,9 @@ permissions:
   contents: read
 
 concurrency:
-  group: canary-rollout-${{ github.event.inputs.agent || 'dev-lead' }}
+  # Scheduled runs evaluate the whole fleet (read-only), so they group under 'fleet'
+  # and never serialize behind a per-agent promote/rollback dispatch (#1025 P1).
+  group: canary-rollout-${{ github.event.inputs.agent || 'fleet' }}
   cancel-in-progress: false
 
 jobs:
@@ -73,8 +76,13 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          app-id: ${{ vars.RELEASE_MANAGER_APP_ID }}
+          # client-id (not the deprecated app-id, #1025 P3). This is the App's client ID,
+          # a distinct value from the numeric app id — set vars.RELEASE_MANAGER_APP_CLIENT_ID.
+          client-id: ${{ vars.RELEASE_MANAGER_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_MANAGER_APP_KEY }}
+          # owner:-wide (NOT a fixed repositories: list). The fleet gate reads run history
+          # across every tier repo, including the stable-tier '*' member (all consumers),
+          # which cannot be enumerated — so scoping to a repo list would break the gate (#1025 P3).
           owner: ${{ github.repository_owner }}
 
       - name: Verify App token was minted (hard requirement)
@@ -83,7 +91,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${APP_TOKEN}" ]; then
-            echo "::error::Canary rollout requires a GitHub App token (RELEASE_MANAGER_APP_ID (variable) + RELEASE_MANAGER_APP_KEY (secret)). Refusing to fall back to github.token, which cannot move protected .github channel tags (#868)."
+            echo "::error::Canary rollout requires a GitHub App token (RELEASE_MANAGER_APP_CLIENT_ID (variable) + RELEASE_MANAGER_APP_KEY (secret)). Refusing to fall back to github.token, which cannot move protected .github channel tags (#868)."
             exit 1
           fi
 
@@ -99,8 +107,9 @@ jobs:
       - name: Run canary-rollout
         id: run
         env:
-          # On the 4h timer, force read-only evaluate — never promote on a schedule.
-          CMD: ${{ github.event_name == 'schedule' && 'evaluate' || github.event.inputs.command }}
+          # On the 4h timer, force read-only fleet-wide evaluate-all — never promote on a
+          # schedule, and evaluate EVERY agent in the registry, not just dev-lead (#1025 P1).
+          CMD: ${{ github.event_name == 'schedule' && 'evaluate-all' || github.event.inputs.command }}
           AGENT: ${{ github.event.inputs.agent || 'dev-lead' }}
           OVERRIDE: ${{ github.event.inputs.override }}
           DRY_RUN: ${{ github.event.inputs.dry_run }}
@@ -113,7 +122,8 @@ jobs:
           set -euo pipefail
           args=()
           case "$CMD" in
-            evaluate) args=(evaluate "$AGENT") ;;
+            evaluate)     args=(evaluate "$AGENT") ;;
+            evaluate-all) args=(evaluate-all) ;;   # fleet-wide read-only (the 4h timer, #1025 P1)
             promote)
               args=(promote "$AGENT")
               [ "$OVERRIDE" = "true" ] && args+=(--override)

--- a/.github/workflows/canary-rollout.yml
+++ b/.github/workflows/canary-rollout.yml
@@ -80,7 +80,7 @@ jobs:
           # a distinct value from the numeric app id — set vars.RELEASE_MANAGER_APP_CLIENT_ID.
           client-id: ${{ vars.RELEASE_MANAGER_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_MANAGER_APP_KEY }}
-          # owner:-wide (NOT a fixed repositories: list). The fleet gate reads run history
+          # owner-wide (NOT a fixed repositories: list). The fleet gate reads run history
           # across every tier repo, including the stable-tier '*' member (all consumers),
           # which cannot be enumerated — so scoping to a repo list would break the gate (#1025 P3).
           owner: ${{ github.repository_owner }}

--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -110,13 +110,13 @@ candidate_cut_date() {
   git log -1 --format=%cI "$commit" 2>/dev/null || echo ""
 }
 
-# _run_json <repo> <workflow> <since_z> — gh run-list JSON (conclusion+createdAt) for a
+# _run_json <repo> <workflow> <since_z> — gh run-list JSON (conclusion,createdAt,databaseId,workflowName) for a
 # repo since the given Zulu timestamp. Empty repo/wildcard → []. Never fails the caller.
 _run_json() {
   local repo="$1" wf="$2" since="$3"
   [ -z "$repo" ] || [ "$repo" = '*' ] && { echo '[]'; return 0; }
   gh run list --repo "$repo" --workflow "$wf" ${since:+--created ">=$since"} \
-    -L 1000 --json conclusion,createdAt 2>/dev/null || echo '[]'
+    -L 1000 --json conclusion,createdAt,databaseId,workflowName 2>/dev/null || echo '[]'
 }
 
 # _tier_sample <agent> <since_z> <repo...> — EXECUTED runs (success+failure) on the
@@ -138,7 +138,7 @@ _tier_sample() {
 # (#1025 P2) as TSV "<workflow_regex>\t<step_regex>", one entry per line. Empty if none.
 _benign_patterns() {
   _jq -r --arg a "$1" \
-    '.agents[$a].gate.benign_failure_classes // [] | .[] | [(.workflow // ""), (.step // "")] | @tsv'
+    '.agents[$a].gate?.benign_failure_classes // [] | .[] | [(.workflow // ""), (.step // "")] | @tsv'
 }
 
 # _run_signature <repo> <run_id> — the failed step names of a run, joined by newlines
@@ -185,7 +185,7 @@ _cumulative_health() {
       else
         fail=$(( fail + 1 ))
       fi
-    done < <(jq -r '.[]?|select(.conclusion=="failure")|[(.databaseId|tostring),(.workflowName // "")]|@tsv' 2>/dev/null <<< "$json")
+    done < <(jq -r '.[]?|select(.conclusion=="failure")|[(.databaseId // "" | tostring),(.workflowName // "")]|@tsv' 2>/dev/null <<< "$json")
   done
   echo "$fail $startup $benign"
 }
@@ -277,7 +277,7 @@ _frontier_state() {
   local prior differs apply_benign=1
   prior="$(channel_commit "$agent" "$frontier")"
   differs="$(_reusable_differs "$agent" "$cand" "$prior")"
-  [ "$differs" = "1" ] && apply_benign=0
+  if [ "$differs" = "1" ]; then apply_benign=0; fi
 
   # Cumulative health across EVERY concrete tier repo since the candidate's own cut.
   local all_repos=() ch3
@@ -389,7 +389,7 @@ cmd_promote() {
   # allow_pre: advance a BLOCKED frontier ONLY when triage=PRE_EXISTING (never REGRESSION).
   # Sourced from the per-reusable control block or the --allow-pre-existing flag (#1025 P2).
   local allow_pre
-  allow_pre="$(_jq -r --arg a "$agent" '.agents[$a].gate.control.allow_pre_existing // false')"
+  allow_pre="$(_jq -r --arg a "$agent" '.agents[$a].gate?.control?.allow_pre_existing // false')"
   [ "$allow_pre_flag" = true ] && allow_pre=true
   if [ "$state" = "BLOCKED" ] && [ "$triage" = "REGRESSION" ] && [ "$override" != true ]; then
     echo "::error::gate=BLOCKED (triage=REGRESSION) for '$frontier' [$transition] — candidate regression suspected; not promoting. Investigate + rollback, do not --override blindly."

--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -141,15 +141,27 @@ _benign_patterns() {
     '.agents[$a].gate?.benign_failure_classes // [] | .[] | [(.workflow // ""), (.step // "")] | @tsv'
 }
 
+# Memoization cache for _run_signature: keyed by "repo:run_id".
+# Avoids duplicate gh run view calls for the same (repo, run_id) across agents
+# in evaluate-all (where multiple agents can share repos).
+declare -A _RUN_SIG_CACHE=()
+
 # _run_signature <repo> <run_id> — the failed step names of a run, joined by newlines
 # (the "step/error signature" the allowlist matches against). Empty repo/wildcard/id or
 # any gh error → "" (fail-closed: an unknown signature is never treated as benign).
 _run_signature() {
-  local repo="$1" id="$2" json
+  local repo="$1" id="$2" cache_key sig json
   { [ -z "$repo" ] || [ "$repo" = '*' ] || [ -z "$id" ]; } && { echo ""; return 0; }
+  cache_key="${repo}:${id}"
+  if [[ -v _RUN_SIG_CACHE["$cache_key"] ]]; then
+    echo "${_RUN_SIG_CACHE[$cache_key]}"
+    return 0
+  fi
   json="$(gh run view "$id" --repo "$repo" --json jobs 2>/dev/null || echo '{}')"
-  jq -r '[.jobs[]?|.steps[]?|select(.conclusion=="failure")|.name] | join("\n")' \
-    2>/dev/null <<< "$json" || echo ""
+  sig="$(jq -r '[.jobs[]?|.steps[]?|select(.conclusion=="failure")|.name] | join("\n")' \
+    2>/dev/null <<< "$json" || echo "")"
+  _RUN_SIG_CACHE["$cache_key"]="$sig"
+  echo "$sig"
 }
 
 # _failure_benign <repo> <run_id> <workflow_name> <patterns_tsv> — return 0 if this
@@ -178,14 +190,19 @@ _cumulative_health() {
   for repo in "$@"; do
     json="$(_run_json "$repo" "$wf" "$since")"
     startup=$(( startup + $(jq '[.[]?|select(.conclusion=="startup_failure")]|length' 2>/dev/null <<< "$json" || echo 0) ))
-    while IFS=$'\t' read -r rid rwf; do
-      [ -z "$rid" ] && continue
-      if [ -n "$patterns" ] && _failure_benign "$repo" "$rid" "$rwf" "$patterns"; then
-        benign=$(( benign + 1 ))
-      else
-        fail=$(( fail + 1 ))
-      fi
-    done < <(jq -r '.[]?|select(.conclusion=="failure")|[(.databaseId // "" | tostring),(.workflowName // "")]|@tsv' 2>/dev/null <<< "$json")
+    if [ -z "$patterns" ]; then
+      # No benign patterns to match — count all failures with one jq pass,
+      # avoiding a gh run view call per failure.
+      fail=$(( fail + $(jq '[.[]?|select(.conclusion=="failure")]|length' 2>/dev/null <<< "$json" || echo 0) ))
+    else
+      while IFS=$'\t' read -r rid rwf; do
+        if _failure_benign "$repo" "$rid" "$rwf" "$patterns"; then
+          benign=$(( benign + 1 ))
+        else
+          fail=$(( fail + 1 ))
+        fi
+      done < <(jq -r '.[]?|select(.conclusion=="failure")|[(.databaseId // "" | tostring),(.workflowName // "")]|@tsv' 2>/dev/null <<< "$json")
+    fi
   done
   echo "$fail $startup $benign"
 }

--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -12,8 +12,9 @@ set -euo pipefail
 # channel tag resolves; there is no separate state store.
 #
 # Usage:
-#   canary-rollout.sh evaluate <agent>                 # read-only gate + health report (also the #502 report)
-#   canary-rollout.sh promote  <agent> [--override] [--dry-run]
+#   canary-rollout.sh evaluate     <agent>             # read-only gate + health report (also the #502 report)
+#   canary-rollout.sh evaluate-all                     # read-only evaluate for EVERY registry agent (fleet-wide; the 4h timer)
+#   canary-rollout.sh promote  <agent> [--override] [--allow-pre-existing] [--dry-run]
 #   canary-rollout.sh rollback <agent> <ring> --to <vX.Y.Z> [--dry-run]
 #   canary-rollout.sh resolve  <agent> <channel>       # debug: print resolved member repos
 #
@@ -133,18 +134,60 @@ _tier_sample() {
   echo "$executed ${earliest:--}"
 }
 
-# _cumulative_health <agent> <since_z> <repo...> — failures + startup_failures across
-# EVERY given tier repo since the candidate cut. Prints "<failures> <startup_failures>".
+# _benign_patterns <agent> — emit the per-reusable known-benign failure-class allowlist
+# (#1025 P2) as TSV "<workflow_regex>\t<step_regex>", one entry per line. Empty if none.
+_benign_patterns() {
+  _jq -r --arg a "$1" \
+    '.agents[$a].gate.benign_failure_classes // [] | .[] | [(.workflow // ""), (.step // "")] | @tsv'
+}
+
+# _run_signature <repo> <run_id> — the failed step names of a run, joined by newlines
+# (the "step/error signature" the allowlist matches against). Empty repo/wildcard/id or
+# any gh error → "" (fail-closed: an unknown signature is never treated as benign).
+_run_signature() {
+  local repo="$1" id="$2" json
+  { [ -z "$repo" ] || [ "$repo" = '*' ] || [ -z "$id" ]; } && { echo ""; return 0; }
+  json="$(gh run view "$id" --repo "$repo" --json jobs 2>/dev/null || echo '{}')"
+  jq -r '[.jobs[]?|.steps[]?|select(.conclusion=="failure")|.name] | join("\n")' \
+    2>/dev/null <<< "$json" || echo ""
+}
+
+# _failure_benign <repo> <run_id> <workflow_name> <patterns_tsv> — return 0 if this
+# in-window failure matches any allowlist entry, else 1. Fail-closed on an empty signature.
+_failure_benign() {
+  local repo="$1" rid="$2" rwf="$3" patterns="$4" sig wf_re step_re
+  sig="$(_run_signature "$repo" "$rid")"
+  [ -z "$sig" ] && return 1
+  while IFS=$'\t' read -r wf_re step_re; do
+    [ -z "$step_re" ] && continue
+    if [ "$(benign_match "$rwf" "$sig" "$wf_re" "$step_re")" = "yes" ]; then return 0; fi
+  done <<< "$patterns"
+  return 1
+}
+
+# _cumulative_health <agent> <since_z> <apply_benign 0|1> <repo...> — failures +
+# startup_failures across EVERY given tier repo since the candidate cut. When
+# apply_benign=1, failures matching the per-reusable known-benign allowlist (#1025 P2)
+# are counted separately and excluded from the blocking total. Prints
+# "<failures> <startup_failures> <benign_excluded>".
 _cumulative_health() {
-  local agent="$1" since="$2"; shift 2
-  local wf repo json fail=0 startup=0
+  local agent="$1" since="$2" apply_benign="$3"; shift 3
+  local wf repo json fail=0 startup=0 benign=0 patterns="" rid rwf
   wf="$(_agent_field "$agent" run_workflow)"
+  [ "$apply_benign" = "1" ] && patterns="$(_benign_patterns "$agent")"
   for repo in "$@"; do
     json="$(_run_json "$repo" "$wf" "$since")"
-    fail=$(( fail + $(jq '[.[]?|select(.conclusion=="failure")]|length' 2>/dev/null <<< "$json" || echo 0) ))
     startup=$(( startup + $(jq '[.[]?|select(.conclusion=="startup_failure")]|length' 2>/dev/null <<< "$json" || echo 0) ))
+    while IFS=$'\t' read -r rid rwf; do
+      [ -z "$rid" ] && continue
+      if [ -n "$patterns" ] && _failure_benign "$repo" "$rid" "$rwf" "$patterns"; then
+        benign=$(( benign + 1 ))
+      else
+        fail=$(( fail + 1 ))
+      fi
+    done < <(jq -r '.[]?|select(.conclusion=="failure")|[(.databaseId|tostring),(.workflowName // "")]|@tsv' 2>/dev/null <<< "$json")
   done
-  echo "$fail $startup"
+  echo "$fail $startup $benign"
 }
 
 # _baseline_daily <agent> <window_days> <repo...> — per-day EXECUTED counts on the
@@ -199,7 +242,7 @@ _frontier_state() {
     if [ "$ch" = "next" ] || [ "$c" = "$cand" ]; then :; else frontier="$ch"; break; fi
   done
   if [ -z "$frontier" ]; then
-    echo "$cand - - COMPLETE 0 0 0 0 0 0 -"; return 0
+    echo "$cand - - COMPLETE 0 0 0 0 0 0 0 -"; return 0
   fi
 
   local transition source cut_z now_epoch
@@ -208,7 +251,7 @@ _frontier_state() {
   cut_z="$(candidate_cut_date "$agent" "$cand")"
   if [ -z "$cut_z" ]; then
     # Cannot determine the per-candidate window start — fail closed to prevent unbounded history queries.
-    echo "$cand $frontier $transition BLOCKED 0 0 0 0 0 0 -"; return 0
+    echo "$cand $frontier $transition BLOCKED 0 0 0 0 0 0 0 -"; return 0
   fi
   now_epoch="$(date -u +%s)"
 
@@ -228,14 +271,22 @@ _frontier_state() {
   fi
   [ "$dwell_h" -lt 0 ] && dwell_h=0
 
+  # Whether the candidate changed the agent's reusable vs the prior channel on the frontier.
+  # The known-benign allowlist is applied ONLY when the reusable is byte-identical (differs=0),
+  # so it can never mask a candidate-introduced regression (#1025 P2).
+  local prior differs apply_benign=1
+  prior="$(channel_commit "$agent" "$frontier")"
+  differs="$(_reusable_differs "$agent" "$cand" "$prior")"
+  [ "$differs" = "1" ] && apply_benign=0
+
   # Cumulative health across EVERY concrete tier repo since the candidate's own cut.
   local all_repos=() ch3
   for ch3 in "${chan_array[@]}"; do
     while IFS= read -r r; do [ -n "$r" ] && [ "$r" != '*' ] && all_repos+=("$r"); done \
       < <(resolve_members "$agent" "$ch3")
   done
-  local cum_fail cum_startup
-  read -r cum_fail cum_startup < <(_cumulative_health "$agent" "$cut_z" "${all_repos[@]}")
+  local cum_fail cum_startup cum_benign
+  read -r cum_fail cum_startup cum_benign < <(_cumulative_health "$agent" "$cut_z" "$apply_benign" "${all_repos[@]}")
 
   # Per-transition knobs (registry-configurable; #548 defaults live in the ring SoT).
   local dwell_floor waived="false" target=0
@@ -265,13 +316,10 @@ _frontier_state() {
 
   local triage="-"
   if [ "$state" = "BLOCKED" ]; then
-    local prior differs
-    prior="$(channel_commit "$agent" "$frontier")"
-    differs="$(_reusable_differs "$agent" "$cand" "$prior")"
     triage="$(classify_failure "$differs" "${CANARY_FAILURE_CATEGORY:-unknown}")"
   fi
 
-  echo "$cand $frontier $transition $state $dwell_h $dwell_floor $sample $target $cum_fail $cum_startup $triage"
+  echo "$cand $frontier $transition $state $dwell_h $dwell_floor $sample $target $cum_fail $cum_startup $cum_benign $triage"
 }
 
 cmd_evaluate() {
@@ -287,12 +335,12 @@ cmd_evaluate() {
     local mark="  "; [ -n "$cand" ] && [ "$c" = "$cand" ] && mark="* "
     printf '  %s%-7s -> %s\n' "$mark" "$ch" "${c:0:12}"
   done
-  read -r _cand frontier transition state dwell floor sample target cum_fail cum_startup triage < <(_frontier_state "$agent")
+  read -r _cand frontier transition state dwell floor sample target cum_fail cum_startup cum_benign triage < <(_frontier_state "$agent")
   echo "----"
   if [ "$frontier" = "-" ]; then
     echo "frontier: none — fully rolled out (all rings on candidate)."
   else
-    gate_summary_line "$transition" "$state" "$dwell" "$floor" "$sample" "$target" "$cum_fail" "$cum_startup"
+    gate_summary_line "$transition" "$state" "$dwell" "$floor" "$sample" "$target" "$cum_fail" "$cum_startup" "$cum_benign"
     echo "decision for next ring '$frontier' [$transition]: $state"
     if [ "$state" = "BLOCKED" ]; then
       if [ "$triage" = "REGRESSION" ]; then
@@ -304,29 +352,58 @@ cmd_evaluate() {
   fi
 }
 
+# cmd_evaluate_all — read-only evaluate for EVERY agent in the ring registry (#1025 P1).
+# The 4h schedule runs this so the whole fleet is evaluated on the timer, not just one
+# agent. Iterates the registry keys, so newly-registered reusables are picked up with no
+# workflow change. Never mutates (evaluate is read-only).
+cmd_evaluate_all() {
+  local agents rc=0 agent
+  agents="$(_jq -r '.agents | keys[]' 2>/dev/null || true)"
+  if [ -z "$agents" ]; then
+    echo "no agents registered in $CANARY_RINGS — nothing to evaluate."; return 0
+  fi
+  echo "== canary-rollout evaluate-all: fleet-wide (gate standard: .github#548) =="
+  while IFS= read -r agent; do
+    [ -z "$agent" ] && continue
+    echo "──────── agent: $agent ────────"
+    cmd_evaluate "$agent" || rc=$?
+  done <<< "$agents"
+  return "$rc"
+}
+
 cmd_promote() {
   local agent="$1"; shift
-  local override=false dry=false
+  local override=false dry=false allow_pre_flag=false
   while [ $# -gt 0 ]; do
     case "$1" in
       --override) override=true ;;
       --dry-run)  dry=true ;;
+      --allow-pre-existing) allow_pre_flag=true ;;
       *) echo "::error::unknown promote flag: $1" >&2; return 2 ;;
     esac; shift
   done
-  read -r cand frontier transition state _dwell _floor _sample _target cum_fail _cum_startup triage < <(_frontier_state "$agent")
+  read -r cand frontier transition state _dwell _floor _sample _target cum_fail _cum_startup _cum_benign triage < <(_frontier_state "$agent")
   if [ "$frontier" = "-" ]; then
     echo "nothing to promote — $agent is fully rolled out."; return 0
   fi
+  # allow_pre: advance a BLOCKED frontier ONLY when triage=PRE_EXISTING (never REGRESSION).
+  # Sourced from the per-reusable control block or the --allow-pre-existing flag (#1025 P2).
+  local allow_pre
+  allow_pre="$(_jq -r --arg a "$agent" '.agents[$a].gate.control.allow_pre_existing // false')"
+  [ "$allow_pre_flag" = true ] && allow_pre=true
   if [ "$state" = "BLOCKED" ] && [ "$triage" = "REGRESSION" ] && [ "$override" != true ]; then
     echo "::error::gate=BLOCKED (triage=REGRESSION) for '$frontier' [$transition] — candidate regression suspected; not promoting. Investigate + rollback, do not --override blindly."
     return 0
   fi
-  if [ "$state" != "PROMOTE" ] && [ "$override" != true ]; then
-    echo "gate=$state for ring '$frontier' [$transition] (cum_fail=$cum_fail, triage=$triage) — not promoting. (use --override to force after investigating)"
+  local advance=false
+  [ "$state" = "PROMOTE" ] && advance=true
+  [ "$override" = true ] && advance=true
+  [ "$state" = "BLOCKED" ] && [ "$triage" = "PRE_EXISTING" ] && [ "$allow_pre" = true ] && advance=true
+  if [ "$advance" != true ]; then
+    echo "gate=$state for ring '$frontier' [$transition] (cum_fail=$cum_fail, triage=$triage) — not promoting. (use --override, or --allow-pre-existing for a PRE_EXISTING triage, after investigating)"
     return 0
   fi
-  [ "$override" = true ] && [ "$state" != "PROMOTE" ] && echo "::warning::overriding gate state '$state' for $agent/$frontier"
+  [ "$state" != "PROMOTE" ] && echo "::warning::advancing $agent/$frontier despite gate state '$state' (triage=$triage)"
   echo "advancing $agent/$frontier -> ${cand:0:12}"
   if [ "$dry" = true ]; then
     echo "[DRY-RUN] would: git tag -f $agent/$frontier $cand && git push --force origin $agent/$frontier"
@@ -381,11 +458,12 @@ main() {
   fi
   local sub="${1:-}"; shift || true
   case "$sub" in
-    evaluate) [ $# -ge 1 ] || { echo "usage: evaluate <agent>" >&2; return 2; }; cmd_evaluate "$@" ;;
-    promote)  [ $# -ge 1 ] || { echo "usage: promote <agent> [--override] [--dry-run]" >&2; return 2; }; cmd_promote "$@" ;;
-    rollback) [ $# -ge 2 ] || { echo "usage: rollback <agent> <ring> --to <vX.Y.Z>" >&2; return 2; }; cmd_rollback "$@" ;;
-    resolve)  [ $# -ge 2 ] || { echo "usage: resolve <agent> <channel>" >&2; return 2; }; resolve_members "$@" ;;
-    *) echo "::error::usage: canary-rollout.sh {evaluate|promote|rollback|resolve} <agent> ..." >&2; return 2 ;;
+    evaluate)     [ $# -ge 1 ] || { echo "usage: evaluate <agent>" >&2; return 2; }; cmd_evaluate "$@" ;;
+    evaluate-all) cmd_evaluate_all ;;
+    promote)      [ $# -ge 1 ] || { echo "usage: promote <agent> [--override] [--allow-pre-existing] [--dry-run]" >&2; return 2; }; cmd_promote "$@" ;;
+    rollback)     [ $# -ge 2 ] || { echo "usage: rollback <agent> <ring> --to <vX.Y.Z>" >&2; return 2; }; cmd_rollback "$@" ;;
+    resolve)      [ $# -ge 2 ] || { echo "usage: resolve <agent> <channel>" >&2; return 2; }; resolve_members "$@" ;;
+    *) echo "::error::usage: canary-rollout.sh {evaluate|evaluate-all|promote|rollback|resolve} <agent> ..." >&2; return 2 ;;
   esac
 }
 

--- a/scripts/lib/canary-rollout.sh
+++ b/scripts/lib/canary-rollout.sh
@@ -134,6 +134,20 @@ classify_failure() {
   if [ "$differs" = "1" ]; then echo "REGRESSION"; else echo "PRE_EXISTING"; fi
 }
 
+# benign_match <workflow_name> <failure_signature> <workflow_regex> <step_regex>
+# Decide whether ONE in-window failure matches ONE known-benign failure-class allowlist
+# entry (#1025 P2). A match requires a non-empty <step_regex> (guards against a match-all
+# entry) that matches the failure signature (the failed step/error names), AND — when
+# <workflow_regex> is non-empty — the run's workflow name. Echoes "yes" or "no".
+# Pure: bash ERE only, no I/O. (Author regexes with explicit char classes, e.g. [Pp]ush,
+# since ERE has no inline case-insensitivity flag.)
+benign_match() {
+  local wf="$1" sig="$2" wf_re="$3" step_re="$4"
+  [ -z "$step_re" ] && { echo "no"; return 0; }
+  if [ -n "$wf_re" ] && ! [[ "$wf" =~ $wf_re ]]; then echo "no"; return 0; fi
+  if [[ "$sig" =~ $step_re ]]; then echo "yes"; else echo "no"; fi
+}
+
 # next_channel_in_order <current_channel> <ordered_channels_csv>
 # Given the frontier channel and the ordered channel list (e.g. "next,ring0,ring1,stable"),
 # echo the channel that a PROMOTE advances next, or empty if already at the last ring.
@@ -165,9 +179,10 @@ transition_key() {
   echo ""
 }
 
-# gate_summary_line <transition> <state> <dwell_h> <dwell_floor> <sample> <sample_target> <cum_fail> <cum_startup>
+# gate_summary_line <transition> <state> <dwell_h> <dwell_floor> <sample> <sample_target> <cum_fail> <cum_startup> [cum_benign]
 # One-line human/observability row (used by `evaluate`, doubling as the #502 report).
+# cum_benign (allowlisted failures excluded from cum_fail) is shown when provided.
 gate_summary_line() {
-  printf '%-14s %-9s dwell=%sh/%sh  sample=%s/%s  cum_fail=%s startup=%s\n' \
-    "$1" "$2" "$3" "$4" "$5" "$6" "$7" "$8"
+  printf '%-14s %-9s dwell=%sh/%sh  sample=%s/%s  cum_fail=%s startup=%s benign=%s\n' \
+    "$1" "$2" "$3" "$4" "$5" "$6" "$7" "$8" "${9:-0}"
 }

--- a/standards/canary-rings.json
+++ b/standards/canary-rings.json
@@ -22,6 +22,24 @@
         "_standard": "petry-projects/.github#548 — graduated dwell/sample gate over a per-candidate cumulative window. These are registry-configurable per-transition knobs; the values below are the #548 defaults.",
         "baseline_window_days": 14,
         "baseline_spike_cap_multiple": 3,
+        "benign_failure_classes": [
+          {
+            "id": "dependabot-context-dispatch",
+            "workflow": "Dev-Lead Agent",
+            "step": "[Dd]ependabot",
+            "reason": "#864 — a Dev-Lead run dispatched in a Dependabot context cannot read repo secrets; version-independent benign failure, not a candidate regression."
+          },
+          {
+            "id": "fix-review-git-push-permission",
+            "workflow": "Dev-Lead Agent",
+            "step": "[Pp]ush",
+            "reason": "fix-review git push denied by branch protection / missing write scope; version-independent benign failure, not a candidate regression."
+          }
+        ],
+        "control": {
+          "allow_pre_existing": false
+        },
+        "_benign_note": "benign_failure_classes (#1025 P2): per-reusable allowlist matched against a failed run's workflow name (`workflow` ERE) + failed-step signature (`step` ERE, matched via `gh run view`). Matches are excluded from cum_fail — but ONLY when the candidate's reusable is byte-identical to the prior channel (differs=0), so the allowlist can never mask a candidate-introduced regression. `control.allow_pre_existing`, or `promote --allow-pre-existing`, advances a BLOCKED+PRE_EXISTING frontier (never REGRESSION).",
         "transitions": {
           "next->ring0": {
             "dwell_hours": 4,

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -377,7 +377,7 @@ GHEOF
 # step so the orchestrator can build a signature and test it against the allowlist.
 _benign_stub() {
   local cut_days="$1" run_days_ago="$2" step="$3" reusable_diff="$4"
-  STUB_BIN="$(mktemp -d)"; export PATH="$STUB_BIN:$PATH"
+  STUB_BIN="$(mktemp -d "$BATS_TEST_TMPDIR/stub.XXXXXX")"; export PATH="$STUB_BIN:$PATH"
   local cut_iso run_iso
   cut_iso="$(date -u -d "-${cut_days} days" +%Y-%m-%dT%H:%M:%SZ)"
   run_iso="$(date -u -d "-${run_days_ago} days" +%Y-%m-%dT%H:%M:%SZ)"

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -321,3 +321,137 @@ _graduated_stub() {
   [[ "$output" == *"BLOCKED"* ]]
   [[ "$output" == *"PRE_EXISTING"* ]]
 }
+
+# ── benign_match (per-reusable known-benign failure-class matcher, #1025 P2) ────
+# args: <workflow_name> <failure_signature> <workflow_regex> <step_regex>
+@test "benign_match: workflow + step signature both match → yes" {
+  [ "$(benign_match 'Dev-Lead Agent' 'Push fix-review branch' 'Dev-Lead' '[Pp]ush')" = "yes" ]
+}
+@test "benign_match: workflow regex mismatch → no" {
+  [ "$(benign_match 'Other Workflow' 'Push branch' 'Dev-Lead' '[Pp]ush')" = "no" ]
+}
+@test "benign_match: signature does not match step regex → no" {
+  [ "$(benign_match 'Dev-Lead Agent' 'Compile sources' 'Dev-Lead' '[Pp]ush')" = "no" ]
+}
+@test "benign_match: empty step regex never matches (guards against a match-all entry)" {
+  [ "$(benign_match 'Dev-Lead Agent' 'anything at all' 'Dev-Lead' '')" = "no" ]
+}
+@test "benign_match: empty workflow regex matches any workflow" {
+  [ "$(benign_match 'Whatever' 'Resolve Dependabot dispatch context' '' '[Dd]ependabot')" = "yes" ]
+}
+
+# ── canary-rings.json: benign allowlist + control block shape (#1025 P2) ────────
+@test "canary-rings.json: dev-lead gate carries a benign_failure_classes allowlist + control block" {
+  run jq -e '.agents["dev-lead"].gate.benign_failure_classes | type == "array" and length >= 1' "$RINGS"
+  [ "$status" -eq 0 ]
+  run jq -e '.agents["dev-lead"].gate.benign_failure_classes | all(has("id") and has("reason") and has("step"))' "$RINGS"
+  [ "$status" -eq 0 ]
+  run jq -e '.agents["dev-lead"].gate.control | has("allow_pre_existing")' "$RINGS"
+  [ "$status" -eq 0 ]
+}
+
+# ── orchestrator: evaluate-all iterates the whole registry (#1025 P1) ──────────
+@test "orchestrator: evaluate-all iterates every agent in the registry (fleet-wide)" {
+  _make_stub_bin
+  cat > "$STUB_BIN/gh" <<'GHEOF'
+#!/usr/bin/env bash
+case "$*" in
+  *"run list"*) echo "[]" ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN/gh"
+  # A registry with a second (cloned) agent proves fleet iteration over the registry
+  # keys rather than a dev-lead hardcode.
+  local multi="$BATS_TEST_TMPDIR/rings.json"
+  jq '.agents["fleet-canary-test"] = .agents["dev-lead"]' "$RINGS" > "$multi"
+  run env CANARY_RINGS="$multi" bash "$ORCH" evaluate-all
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"dev-lead"* ]]
+  [[ "$output" == *"fleet-canary-test"* ]]
+}
+
+# ── orchestrator: benign-failure allowlist excludes known-benign from cum_fail ──
+# Lay out next = candidate (cccc); ring0/ring1/stable = prior (bbbb). Every tier repo
+# returns `failure` runs whose only failed step is <step>; `gh run view` yields that
+# step so the orchestrator can build a signature and test it against the allowlist.
+_benign_stub() {
+  local cut_days="$1" run_days_ago="$2" step="$3" reusable_diff="$4"
+  STUB_BIN="$(mktemp -d)"; export PATH="$STUB_BIN:$PATH"
+  local cut_iso run_iso
+  cut_iso="$(date -u -d "-${cut_days} days" +%Y-%m-%dT%H:%M:%SZ)"
+  run_iso="$(date -u -d "-${run_days_ago} days" +%Y-%m-%dT%H:%M:%SZ)"
+  {
+    echo '#!/usr/bin/env bash'
+    echo 'case "$*" in'
+    printf '  *"run list"*) jq -nc --arg d "%s" '"'"'[range(3)|{conclusion:"failure",createdAt:$d,databaseId:(1000+.),workflowName:"Dev-Lead Agent"}]'"'"' ;;\n' "$run_iso"
+    printf '  *"run view"*) jq -nc --arg s "%s" '"'"'{jobs:[{steps:[{name:$s,conclusion:"failure"}]}]}'"'"' ;;\n' "$step"
+    echo '  *) echo "{}" ;;'
+    echo 'esac'
+  } > "$STUB_BIN/gh"
+  chmod +x "$STUB_BIN/gh"
+  local cand_blob="reuseAAAA" prior_blob="reuseAAAA"
+  [ "$reusable_diff" = "1" ] && prior_blob="reuseBBBB"
+  {
+    echo '#!/usr/bin/env bash'
+    echo 'case "$*" in'
+    printf '  *"for-each-ref"*) echo "cccccccccccccccccccccccccccccccccccccccc||%s" ;;\n' "$cut_iso"
+    printf '  *"rev-parse"*"cccccccccccccccccccccccccccccccccccccccc:"*) echo "%s" ;;\n' "$cand_blob"
+    printf '  *"rev-parse"*"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:"*) echo "%s" ;;\n' "$prior_blob"
+    echo '  *"rev-parse"*"dev-lead/next"*)   echo "cccccccccccccccccccccccccccccccccccccccc" ;;'
+    echo '  *"rev-parse"*"dev-lead/ring0"*)  echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" ;;'
+    echo '  *"rev-parse"*"dev-lead/ring1"*)  echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" ;;'
+    echo '  *"rev-parse"*"dev-lead/stable"*) echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" ;;'
+    echo '  *"rev-parse"*) echo "cccccccccccccccccccccccccccccccccccccccc" ;;'
+    echo '  *) : ;;'
+    echo 'esac'
+  } > "$STUB_BIN/git"
+  chmod +x "$STUB_BIN/git"
+}
+
+@test "orchestrator: allowlisted benign failure (reusable unchanged) is excluded from cum_fail → not BLOCKED" {
+  # A git-push-permission failure since cut, but the reusable is byte-identical to the
+  # prior channel → matches the [Pp]ush benign class → excluded → gate is not BLOCKED.
+  _benign_stub 3 2 "Push fix-review branch" 0
+  run env CANARY_RINGS="$RINGS" bash "$ORCH" evaluate dev-lead
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"BLOCKED"* ]]
+  [[ "$output" == *"benign"* ]]
+}
+
+@test "orchestrator: benign allowlist is DISABLED when the candidate changed the reusable → BLOCKED+REGRESSION" {
+  # Same push failure + matching class, but the candidate changed the reusable → the
+  # allowlist must NOT mask a possible candidate regression.
+  _benign_stub 3 2 "Push fix-review branch" 1
+  run env CANARY_RINGS="$RINGS" bash "$ORCH" evaluate dev-lead
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"BLOCKED"* ]]
+  [[ "$output" == *"REGRESSION"* ]]
+}
+
+@test "orchestrator: a non-allowlisted failure (reusable unchanged) still BLOCKS as PRE_EXISTING" {
+  # Failed step matches no benign class → counted → BLOCKED, triaged PRE_EXISTING.
+  _benign_stub 3 2 "Compile TypeScript" 0
+  run env CANARY_RINGS="$RINGS" bash "$ORCH" evaluate dev-lead
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"BLOCKED"* ]]
+  [[ "$output" == *"PRE_EXISTING"* ]]
+}
+
+# ── orchestrator: promote --allow-pre-existing (control override, #1025 P2) ─────
+@test "orchestrator: promote --allow-pre-existing advances a BLOCKED+PRE_EXISTING frontier (dry-run)" {
+  _graduated_stub 3 2 failure 0
+  run env CANARY_RINGS="$RINGS" bash "$ORCH" promote dev-lead --allow-pre-existing --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY-RUN"* ]]
+  [[ "$output" == *"PRE_EXISTING"* ]]
+  [[ "$output" != *"not promoting"* ]]
+}
+
+@test "orchestrator: promote --allow-pre-existing REFUSES a BLOCKED+REGRESSION frontier" {
+  _graduated_stub 3 2 failure 1
+  run env CANARY_RINGS="$RINGS" bash "$ORCH" promote dev-lead --allow-pre-existing --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"DRY-RUN"* ]]
+  [[ "$output" == *"REGRESSION"* ]]
+}

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -384,7 +384,9 @@ _benign_stub() {
   {
     echo '#!/usr/bin/env bash'
     echo 'case "$*" in'
-    printf '  *"run list"*) jq -nc --arg d "%s" '"'"'[range(3)|{conclusion:"failure",createdAt:$d,databaseId:(1000+.),workflowName:"Dev-Lead Agent"}]'"'"' ;;\n' "$run_iso"
+    echo '  *"run list"*)'
+    printf '    if [[ "$*" == *"databaseId"* ]]; then jq -nc --arg d "%s" '"'"'[range(3)|{conclusion:"failure",createdAt:$d,databaseId:(1000+.),workflowName:"Dev-Lead Agent"}]'"'"'; else jq -nc --arg d "%s" '"'"'[range(3)|{conclusion:"failure",createdAt:$d}]'"'"'; fi\n' "$run_iso" "$run_iso"
+    echo '    ;;'
     printf '  *"run view"*) jq -nc --arg s "%s" '"'"'{jobs:[{steps:[{name:$s,conclusion:"failure"}]}]}'"'"' ;;\n' "$step"
     echo '  *) echo "{}" ;;'
     echo 'esac'


### PR DESCRIPTION
Closes #1025

Implemented by dev-lead agent. Please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fleet-wide canary evaluation option (read-only) for scheduled runs.
  * Introduced a “known benign” failure allowlist to prevent certain repeat failures from impacting health outcomes.
  * Added a promotion override flag to allow promoting a blocked state when it’s determined to pre-exist.
* **Bug Fixes**
  * Improved rollout summaries to include benign failure handling and updated triage messaging.
  * Scheduled evaluations now avoid unnecessary serialization behind per-agent promotion/rollback activity.
* **Tests**
  * Added coverage for benign failure matching and the promotion override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->