### PR TITLE
feat: implement issue #1028 — [dev-lead timeout follow-up 1/3] Don't retry exit-124 at the engine level (in-run same-budget retry)

### DIFF
--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -66,9 +66,11 @@ ACTION_TIMEOUT_SEC="${ACTION_TIMEOUT_SEC:-2100}"
 DUCK_TIMEOUT_SEC="${DUCK_TIMEOUT_SEC:-300}"
 
 # Retry config for transient errors. We treat exit codes that look like
-# network/process flakiness (124=GNU timeout, 137/143=signal kills, plus a
-# couple of generic transient codes) as retryable. Rate-limit (engine-level)
-# is NOT retryable here — the workflow's engine-fallback handles that.
+# network/process flakiness (137/143=signal kills) as retryable. A per-tier
+# stage timeout (124=GNU timeout) is NOT retried (#1028): re-running at the same
+# budget just times out again, so it propagates and escalates instead. Rate-limit
+# (engine-level) is NOT retryable here either — the workflow's engine-fallback
+# handles that.
 RETRY_MAX_ATTEMPTS="${RETRY_MAX_ATTEMPTS:-2}"   # total attempts including first
 RETRY_BASE_DELAY_SEC="${RETRY_BASE_DELAY_SEC:-5}"
 
@@ -453,13 +455,17 @@ _emit_mcp_failure_warning() {
 
 # is_transient_failure <exit_code>
 # Returns 0 (true) for exit codes suggesting a flaky network/process state:
-# 124 (GNU timeout) and 137/143 (signal kills). JSON parse failures and
-# generic exit-1s are NOT retried — those are deterministic problems.
+# 137/143 (signal kills). JSON parse failures and generic exit-1s are NOT
+# retried — those are deterministic problems. Exit 124 (GNU `timeout`) is
+# likewise NOT retried (#1028): a per-tier stage timeout means the model used
+# its whole budget, so a same-budget in-run retry would just time out again —
+# wasted runner-minutes + tokens. A 124 propagates immediately; the writer path
+# then classifies it as reason=timeout and escalates (see run_writer_with_fallback).
 is_transient_failure() {
   local rc="$1"
   case "$rc" in
-    124|137|143) return 0 ;;
-    *)           return 1 ;;
+    137|143) return 0 ;;
+    *)       return 1 ;;
   esac
 }
 

--- a/tests/dev-lead/unit/test_engine_fallback.bats
+++ b/tests/dev-lead/unit/test_engine_fallback.bats
@@ -160,7 +160,7 @@ GHEOF
   # and a recording stub shows that claude was tried after gemini failed.
   _make_stub "gemini" 2
   local record_file
-  record_file="$(mktemp)"
+  record_file="$(mktemp "$BATS_TEST_TMPDIR/rec.XXXXXX")"
   _make_recording_stub "claude" 127 "$record_file"
   # Provide token + gh stub so copilot path is deterministic (returns rate-limit)
   export COPILOT_GITHUB_TOKEN="stub-token"
@@ -190,7 +190,7 @@ GHEOF
   # Primary = gemini (exits 2), then fallback order should try claude first
   _make_stub "gemini" 2
   local record_file
-  record_file="$(mktemp)"
+  record_file="$(mktemp "$BATS_TEST_TMPDIR/rec.XXXXXX")"
   _make_recording_stub "claude" 0 "$record_file"
   _source_engine "gemini"
 
@@ -371,7 +371,7 @@ GHEOF
 
 @test "retry: stubbed 124 in the retry loop → engine invoked exactly once (no in-run retry)" {
   local record_file
-  record_file="$(mktemp)"
+  record_file="$(mktemp "$BATS_TEST_TMPDIR/rec.XXXXXX")"
   _make_recording_stub "claude" 124 "$record_file"
   export RETRY_BASE_DELAY_SEC=0   # no backoff sleep in tests
   _source_engine "claude"
@@ -386,7 +386,7 @@ GHEOF
 
 @test "retry: stubbed 137 in the retry loop → still retries (invoked twice), regression guard" {
   local record_file
-  record_file="$(mktemp)"
+  record_file="$(mktemp "$BATS_TEST_TMPDIR/rec.XXXXXX")"
   _make_recording_stub "claude" 137 "$record_file"
   export RETRY_BASE_DELAY_SEC=0   # no backoff sleep in tests
   _source_engine "claude"

--- a/tests/dev-lead/unit/test_engine_fallback.bats
+++ b/tests/dev-lead/unit/test_engine_fallback.bats
@@ -344,6 +344,61 @@ GHEOF
   rm -f "$gemini_record" "$copilot_record"
 }
 
+# ── engine-level retry classification (#1028) ─────────────────────────────────
+# A per-tier stage timeout (exit 124 from GNU `timeout`) is deterministic — the
+# model used its whole budget, so re-running at the SAME budget just times out
+# again. is_transient_failure() must therefore NOT classify 124 as retryable,
+# while signal kills (137/143) keep their retry behavior. run_triage is the
+# in-run retry loop that consumes this classifier; run_writer/run_agentic do not
+# retry at all, so dropping 124 from the shared classifier makes every caller
+# consistent (no engine-level same-budget retry on a timeout anywhere).
+
+@test "retry: is_transient_failure does NOT classify 124 (timeout) as retryable" {
+  _source_engine "claude"
+
+  run is_transient_failure 124
+  [ "$status" -ne 0 ]
+}
+
+@test "retry: is_transient_failure still classifies 137/143 (signal kills) as retryable" {
+  _source_engine "claude"
+
+  run is_transient_failure 137
+  [ "$status" -eq 0 ]
+  run is_transient_failure 143
+  [ "$status" -eq 0 ]
+}
+
+@test "retry: stubbed 124 in the retry loop → engine invoked exactly once (no in-run retry)" {
+  local record_file
+  record_file="$(mktemp)"
+  _make_recording_stub "claude" 124 "$record_file"
+  export RETRY_BASE_DELAY_SEC=0   # no backoff sleep in tests
+  _source_engine "claude"
+
+  run run_triage "$TEST_PROMPT"
+
+  [ "$status" -eq 124 ]
+  # A deterministic per-tier timeout must not be re-run at the same budget.
+  [ "$(wc -l < "$record_file")" -eq 1 ]
+  rm -f "$record_file"
+}
+
+@test "retry: stubbed 137 in the retry loop → still retries (invoked twice), regression guard" {
+  local record_file
+  record_file="$(mktemp)"
+  _make_recording_stub "claude" 137 "$record_file"
+  export RETRY_BASE_DELAY_SEC=0   # no backoff sleep in tests
+  _source_engine "claude"
+
+  run run_triage "$TEST_PROMPT"
+
+  [ "$status" -eq 137 ]
+  # Signal kills stay transient: RETRY_MAX_ATTEMPTS=2 → one retry → two invocations.
+  [ "$(wc -l < "$record_file")" -eq 2 ]
+  rm -f "$record_file"
+}
+
 @test "sidecar: stale reason cleared on success" {
   printf 'engine-error\n' > /tmp/dev-lead-failure-reason
   _make_stub "claude" 0


### PR DESCRIPTION
Closes #1028

Implemented by dev-lead agent. Please review.