### PR TITLE
feat: implement issue #1031 — fix(#844): plumb LSP_PILOT_ENABLED env + decouple capture from LSP wiring so the pilot A/B runs in CI

### DIFF
--- a/.github/workflows/pr-review-trigger.yml
+++ b/.github/workflows/pr-review-trigger.yml
@@ -44,6 +44,21 @@ on:
         required: false
         default: "false"
         type: string
+      lsp_pilot_variant:
+        # LSP pilot A/B leg (epic #839, story #844, issue #1031). Drives the
+        # off-vs-on comparison on this repo's own PRs: dispatch the same PR with
+        # 'off' then 'on' to drop two joinable lsp_pilot_run records.
+        #   on   → wire the LSP MCP + capture  (lsp-on,  B leg)
+        #   off  → capture only, no LSP wiring (lsp-off, A control leg)
+        #   none → today's behaviour (defers to vars.LSP_PILOT_ENABLED)
+        description: "LSP pilot A/B leg: on | off | none"
+        required: false
+        default: "none"
+        type: choice
+        options:
+          - none
+          - "off"
+          - "on"
   repository_dispatch:
     # Triggered by the petry-projects/.github mention-listener (via
     # pr-review-mention.yml). Payload: { pr_url, force_review }.
@@ -68,4 +83,7 @@ jobs:
       pr_url: ${{ inputs.pr_url || '' }}
       dry_run: ${{ inputs.dry_run || '' }}
       force_review: ${{ inputs.force_review || '' }}
+      # Forward the LSP pilot A/B leg (empty for event triggers). 'none'/'' both
+      # mean today's behaviour on the reusable side.
+      lsp_pilot_variant: ${{ inputs.lsp_pilot_variant || '' }}
     secrets: inherit

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -32,6 +32,18 @@ on:
         type: string
         required: false
         default: ""
+      # LSP-MCP review pilot A/B leg selector (epic #839, story #844, issue #1031).
+      # Decouples pilot capture from LSP wiring so ONE production pipeline can emit
+      # both control legs:
+      #   on   → wire the LSP MCP (setup step) AND capture   → lsp-on  (B leg)
+      #   off  → capture only, skip LSP wiring               → lsp-off (A control)
+      #   none/'' → today's behaviour (defers to the legacy vars.LSP_PILOT_ENABLED)
+      # A trigger stub forwards this so the A/B can be driven on this repo's PRs.
+      lsp_pilot_variant:
+        description: "LSP pilot A/B leg: on (wire LSP + capture) | off (capture only) | none"
+        type: string
+        required: false
+        default: ""
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         required: false
@@ -182,6 +194,26 @@ jobs:
       # server handshake (`--debug mcp`) and surface a ::notice:: for a healthy
       # connection. Off by default; never changes the review verdict.
       REVIEW_MCP_DEBUG: ${{ vars.REVIEW_MCP_DEBUG || '' }}
+      # ── LSP-MCP review pilot capture gate (epic #839, story #844, issue #1031) ─
+      # engine.sh's _lsp_pilot_active() and review-one-pr.sh's emit trap gate on
+      # the ENV var LSP_PILOT_ENABLED — NOT the repo variable. Export it here so a
+      # production review actually captures the stream-json transcript and appends
+      # the kind:"lsp_pilot_run" record to TOKEN_LOG_FILE (Gap 1). On when the
+      # legacy repo variable is set OR a pilot A/B variant (on|off) is
+      # dispatched/defaulted. Empty (the default) → no capture, no records, no
+      # extra flags — byte-for-byte unchanged for the consumer repos (AC #4).
+      LSP_PILOT_ENABLED: >-
+        ${{ (vars.LSP_PILOT_ENABLED == 'true'
+             || inputs.lsp_pilot_variant == 'on' || inputs.lsp_pilot_variant == 'off'
+             || vars.LSP_PILOT_VARIANT == 'on' || vars.LSP_PILOT_VARIANT == 'off')
+            && 'true' || '' }}
+      # A/B leg selector that DECOUPLES capture from LSP wiring (Gap 2). 'on' wires
+      # the LSP MCP (the setup step below) → lsp-on (B); 'off' skips wiring → lsp-off
+      # (A control), capture only. lpe_variant() treats this as authoritative;
+      # empty/'none' preserves the legacy vars.LSP_PILOT_ENABLED behaviour (falls
+      # back to REVIEW_MCP_CONFIG detection). The dispatch input beats the repo-var
+      # default so the A/B can be driven per-run.
+      LSP_PILOT_VARIANT: ${{ inputs.lsp_pilot_variant || vars.LSP_PILOT_VARIANT || '' }}
       # Downstream-impact pass (epic #748 / discussion #653): annotate a review
       # with the consumer repos that pin a shared surface the PR changes. Enabled
       # by default here; set the repo variable DOWNSTREAM_IMPACT_ENABLED=false to
@@ -358,11 +390,14 @@ jobs:
               ;;
           esac
 
-      # ── LSP-MCP review pilot (epic #839, story #842) ─────────────────────
-      # Opt-in ONLY: runs when the repo variable LSP_PILOT_ENABLED == 'true'.
-      # When off (the default) this step is skipped entirely, REVIEW_MCP_CONFIG
-      # stays unset, and the review behaves byte-for-byte as today (the engine's
-      # existing .github/review-mcp.json default is untouched). When on, the
+      # ── LSP-MCP review pilot (epic #839, story #842/#844) ────────────────
+      # Opt-in ONLY: these WIRING steps run when the repo variable
+      # LSP_PILOT_ENABLED == 'true' OR the pilot variant resolves to 'on' (the B
+      # leg). The 'off' (A control) leg deliberately does NOT run them — it
+      # captures a review WITHOUT wiring the LSP MCP (issue #1031, Gap 2).
+      # When neither is set (the default) these steps are skipped entirely,
+      # REVIEW_MCP_CONFIG stays unset, and the review behaves byte-for-byte as
+      # today (the engine's .github/review-mcp.json default is untouched). When on, the
       # script installs the pinned LSP-MCP candidate + bash-language-server and
       # threads the deep/audit-only MCP knobs into $GITHUB_ENV. A missing tool
       # degrades gracefully (::warning:: + skip) — it never fails the workflow.
@@ -375,7 +410,9 @@ jobs:
       # its cache-hit output is threaded into the setup step for the cold-start metric.
       - name: Cache LSP index
         id: lsp-cache
-        if: ${{ vars.LSP_PILOT_ENABLED == 'true' }}
+        # Wire the LSP toolchain for the legacy repo var OR the 'on' (B) leg only.
+        # The 'off' (A) control leg deliberately skips wiring — capture without LSP.
+        if: ${{ vars.LSP_PILOT_ENABLED == 'true' || (inputs.lsp_pilot_variant || vars.LSP_PILOT_VARIANT) == 'on' }}
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.local
@@ -384,7 +421,9 @@ jobs:
             lsp-pilot-${{ runner.os }}-${{ vars.LSP_CANDIDATE || 'agent-lsp' }}-${{ vars.AGENT_LSP_VERSION || 'v0.15.0' }}-bls${{ vars.BASH_LANGUAGE_SERVER_VERSION || '5.6.0' }}-
 
       - name: Set up LSP pilot servers (opt-in)
-        if: ${{ vars.LSP_PILOT_ENABLED == 'true' }}
+        # Wire the LSP MCP for the legacy repo var OR the 'on' (B) leg only; the
+        # 'off' (A) control leg captures WITHOUT wiring REVIEW_MCP_CONFIG.
+        if: ${{ vars.LSP_PILOT_ENABLED == 'true' || (inputs.lsp_pilot_variant || vars.LSP_PILOT_VARIANT) == 'on' }}
         env:
           LSP_CANDIDATE: ${{ vars.LSP_CANDIDATE || 'agent-lsp' }}
           AGENT_LSP_VERSION: ${{ vars.AGENT_LSP_VERSION || 'v0.15.0' }}

--- a/.github/workflows/test-dev-lead.yml
+++ b/.github/workflows/test-dev-lead.yml
@@ -12,6 +12,9 @@ on:
       - '.github/workflows/dependency-audit.yml'
       - '.github/workflows/auto-rebase.yml'
       - '.github/workflows/auto-rebase-retry.yml'
+      # LSP pilot capture/decoupling plumbing lives in the pr-review workflows (#1031).
+      - '.github/workflows/pr-review.yml'
+      - '.github/workflows/pr-review-trigger.yml'
       - 'tests/dev-lead/**'
       - 'prompts/dev-lead/**'
       - '.github/review-mcp.json'
@@ -34,6 +37,8 @@ on:
       - '.github/workflows/dependency-audit.yml'
       - '.github/workflows/auto-rebase.yml'
       - '.github/workflows/auto-rebase-retry.yml'
+      - '.github/workflows/pr-review.yml'
+      - '.github/workflows/pr-review-trigger.yml'
   workflow_dispatch: {}
 
 permissions:
@@ -152,3 +157,16 @@ jobs:
         run: python3 -m pip install --quiet pyyaml
       - name: Validate auto-rebase.yml uses @auto-rebase/next (not a SHA or frozen tag)
         run: python3 tests/dev-lead/integration/test_auto_rebase_stub.py
+
+  lsp-pilot-plumbing:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Install PyYAML
+        run: python3 -m pip install --quiet pyyaml
+      - name: Validate pr-review LSP-pilot capture gate + variant decoupling plumbing
+        run: python3 tests/dev-lead/integration/test_pr_review_lsp_pilot_plumbing.py

--- a/scripts/lsp_pilot_emit.sh
+++ b/scripts/lsp_pilot_emit.sh
@@ -41,7 +41,7 @@ lpe_pilot_active() { [ "${LSP_PILOT_ENABLED:-}" = "true" ]; }
 # LSP_PILOT_VARIANT (on|off, issue #1031) that is AUTHORITATIVE — this is what
 # DECOUPLES capture from LSP wiring, so a production review can emit the lsp-off
 # (A) control leg even here, where engine.sh auto-defaults REVIEW_MCP_CONFIG to
-# the committed .github/review-mcp.json (the unrelated GitHub review MCP) and
+# the committed .github/review-mcp.json (the Context7 MCP) and
 # review-one-pr.sh sources engine.sh — which would otherwise mislabel A as lsp-on.
 # When unset/"none", fall back to detecting the wired MCP (REVIEW_MCP_CONFIG →
 # readable file, the exact activation condition engine.sh's _mcp_review_flags

--- a/scripts/lsp_pilot_emit.sh
+++ b/scripts/lsp_pilot_emit.sh
@@ -13,7 +13,8 @@
 #
 # Contract (mirrors lsp_pilot_run.sh's run_variant semantics so both sides join
 # and render via scripts/lsp_pilot_compare.sh UNCHANGED):
-#   variant     lsp-on  when the LSP MCP is wired (REVIEW_MCP_CONFIG → readable
+#   variant     the explicit LSP_PILOT_VARIANT (on|off, #1031) when set, else
+#               lsp-on when the LSP MCP is wired (REVIEW_MCP_CONFIG → readable
 #               file, as setup-lsp-pilot.sh sets it), else lsp-off.
 #   candidate   agent-lsp (override: LSP_CANDIDATE) on the lsp-on leg; baseline
 #               on the lsp-off leg.
@@ -36,10 +37,21 @@ _LPE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # gate: off → emit_record is a no-op and no consumer repo is affected.
 lpe_pilot_active() { [ "${LSP_PILOT_ENABLED:-}" = "true" ]; }
 
-# lpe_variant — "lsp-on" when the LSP MCP is wired (REVIEW_MCP_CONFIG points at a
+# lpe_variant — the A/B leg label. When the pipeline explicitly selects a leg via
+# LSP_PILOT_VARIANT (on|off, issue #1031) that is AUTHORITATIVE — this is what
+# DECOUPLES capture from LSP wiring, so a production review can emit the lsp-off
+# (A) control leg even here, where engine.sh auto-defaults REVIEW_MCP_CONFIG to
+# the committed .github/review-mcp.json (the unrelated GitHub review MCP) and
+# review-one-pr.sh sources engine.sh — which would otherwise mislabel A as lsp-on.
+# When unset/"none", fall back to detecting the wired MCP (REVIEW_MCP_CONFIG →
 # readable file, the exact activation condition engine.sh's _mcp_review_flags
-# uses), else "lsp-off".
+# uses), preserving the legacy vars.LSP_PILOT_ENABLED path and lsp_pilot_run.sh's
+# run_variant() semantics.
 lpe_variant() {
+  case "${LSP_PILOT_VARIANT:-}" in
+    on)  printf 'lsp-on\n';  return 0 ;;
+    off) printf 'lsp-off\n'; return 0 ;;
+  esac
   if [ -n "${REVIEW_MCP_CONFIG:-}" ] && [ -f "${REVIEW_MCP_CONFIG}" ] && [ -r "${REVIEW_MCP_CONFIG}" ]; then
     printf 'lsp-on\n'
   else

--- a/tests/dev-lead/integration/test_pr_review_lsp_pilot_plumbing.py
+++ b/tests/dev-lead/integration/test_pr_review_lsp_pilot_plumbing.py
@@ -41,13 +41,15 @@ def _load(path: str):
         return yaml.safe_load(fh)
 
 
-def _on(doc: dict):
+def _on(doc: dict | None):
+    if not doc:
+        return {}
     # PyYAML parses the bare `on:` key as the boolean True (YAML 1.1).
     return doc.get("on", doc.get(True)) or {}
 
 
-def _review_job(doc: dict) -> dict:
-    jobs = doc.get("jobs") or {}
+def _review_job(doc: dict | None) -> dict:
+    jobs = (doc or {}).get("jobs") or {}
     job = jobs.get("review")
     return job if isinstance(job, dict) else {}
 

--- a/tests/dev-lead/integration/test_pr_review_lsp_pilot_plumbing.py
+++ b/tests/dev-lead/integration/test_pr_review_lsp_pilot_plumbing.py
@@ -61,6 +61,9 @@ def _steps(job: dict) -> list:
 
 def check_reusable(fails: list[str]) -> None:
     doc = _load(REUSABLE)
+    if not doc:
+        fails.append(f"{REUSABLE}: failed to parse YAML (document is None/empty)")
+        return
     on = _on(doc)
 
     # workflow_call input declared so a trigger stub can forward it.
@@ -123,6 +126,9 @@ def check_reusable(fails: list[str]) -> None:
 
 def check_trigger(fails: list[str]) -> None:
     doc = _load(TRIGGER)
+    if not doc:
+        fails.append(f"{TRIGGER}: failed to parse YAML (document is None/empty)")
+        return
     on = _on(doc)
 
     wd_inputs = ((on.get("workflow_dispatch") or {}).get("inputs")) or {}

--- a/tests/dev-lead/integration/test_pr_review_lsp_pilot_plumbing.py
+++ b/tests/dev-lead/integration/test_pr_review_lsp_pilot_plumbing.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Validate the LSP-pilot capture/decoupling plumbing in the pr-review workflows.
+
+Issue #1031 (story #844, epic #839) closes two gaps that left the LSP pilot inert
+in real CI:
+
+  * Gap 1 — the capture gate is never plumbed. engine.sh's `_lsp_pilot_active()`
+    and review-one-pr.sh's emit trap gate on the ENV var `LSP_PILOT_ENABLED`, but
+    the workflow only referenced the repo variable `vars.LSP_PILOT_ENABLED`
+    (never exported to the job env). This guards that pr-review.yml exports
+    `LSP_PILOT_ENABLED` to the review job so a production run actually captures a
+    transcript and emits a `lsp_pilot_run` record.
+
+  * Gap 2 — capture and LSP wiring can't be decoupled. This guards that an
+    independent `lsp_pilot_variant` (on|off|none) control exists: `on` wires the
+    LSP MCP (lsp-on/B leg), `off` captures without wiring (lsp-off/A control leg),
+    and the two LSP-wiring steps are gated so `off` skips them.
+
+  * AC #5 — the ring-0 trigger stub pr-review-trigger.yml declares and forwards
+    the new dispatch input so the A/B can be driven on this repo's own PRs.
+
+Off-pilot (neither var nor input set) must stay byte-for-byte unchanged (AC #4):
+the exported env resolves to empty and the wiring steps stay skipped.
+"""
+from __future__ import annotations
+
+import sys
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+REUSABLE = ".github/workflows/pr-review.yml"
+TRIGGER = ".github/workflows/pr-review-trigger.yml"
+INPUT = "lsp_pilot_variant"
+
+
+def _load(path: str):
+    with open(path, encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def _on(doc: dict):
+    # PyYAML parses the bare `on:` key as the boolean True (YAML 1.1).
+    return doc.get("on", doc.get(True)) or {}
+
+
+def _review_job(doc: dict) -> dict:
+    jobs = doc.get("jobs") or {}
+    job = jobs.get("review")
+    return job if isinstance(job, dict) else {}
+
+
+def _steps(job: dict) -> list:
+    steps = job.get("steps") or []
+    return [s for s in steps if isinstance(s, dict)]
+
+
+def check_reusable(fails: list[str]) -> None:
+    doc = _load(REUSABLE)
+    on = _on(doc)
+
+    # workflow_call input declared so a trigger stub can forward it.
+    wc_inputs = ((on.get("workflow_call") or {}).get("inputs")) or {}
+    if INPUT not in wc_inputs:
+        fails.append(f"{REUSABLE}: workflow_call.inputs.{INPUT} is not declared")
+
+    job = _review_job(doc)
+    env = job.get("env") or {}
+
+    enabled = str(env.get("LSP_PILOT_ENABLED", ""))
+    if not enabled:
+        fails.append(f"{REUSABLE}: review job env does not export LSP_PILOT_ENABLED (Gap 1)")
+    else:
+        # The capture gate must turn on for the legacy repo var AND for a
+        # dispatched/defaulted on|off variant.
+        for needle in ("vars.LSP_PILOT_ENABLED", "lsp_pilot_variant", "'on'", "'off'"):
+            if needle not in enabled:
+                fails.append(
+                    f"{REUSABLE}: LSP_PILOT_ENABLED expression is missing {needle!r} "
+                    f"(got: {enabled!r})"
+                )
+
+    variant = str(env.get("LSP_PILOT_VARIANT", ""))
+    if not variant:
+        fails.append(f"{REUSABLE}: review job env does not export LSP_PILOT_VARIANT (Gap 2)")
+    else:
+        if "lsp_pilot_variant" not in variant:
+            fails.append(
+                f"{REUSABLE}: LSP_PILOT_VARIANT must resolve from inputs.{INPUT} "
+                f"(got: {variant!r})"
+            )
+
+    # The two LSP-wiring steps must run only for the legacy var OR variant 'on'
+    # — never for the 'off' control leg (that's the decoupling).
+    wiring_ids = {"lsp-cache"}
+    wiring_names = {"Set up LSP pilot servers (opt-in)"}
+    found = 0
+    for step in _steps(job):
+        is_wiring = step.get("id") in wiring_ids or step.get("name") in wiring_names
+        if not is_wiring:
+            continue
+        found += 1
+        cond = str(step.get("if", ""))
+        if "== 'on'" not in cond:
+            fails.append(
+                f"{REUSABLE}: LSP-wiring step {step.get('name') or step.get('id')!r} "
+                f"'if' does not gate on the 'on' variant (got: {cond!r})"
+            )
+        if "vars.LSP_PILOT_ENABLED == 'true'" not in cond:
+            fails.append(
+                f"{REUSABLE}: LSP-wiring step {step.get('name') or step.get('id')!r} "
+                f"'if' dropped the legacy vars.LSP_PILOT_ENABLED gate (got: {cond!r})"
+            )
+    if found < 2:
+        fails.append(
+            f"{REUSABLE}: expected both LSP-wiring steps (cache + setup), found {found}"
+        )
+
+
+def check_trigger(fails: list[str]) -> None:
+    doc = _load(TRIGGER)
+    on = _on(doc)
+
+    wd_inputs = ((on.get("workflow_dispatch") or {}).get("inputs")) or {}
+    if INPUT not in wd_inputs:
+        fails.append(f"{TRIGGER}: workflow_dispatch.inputs.{INPUT} is not declared (AC #5)")
+
+    job = _review_job(doc)
+    with_block = job.get("with") or {}
+    forwarded = str(with_block.get(INPUT, ""))
+    if not forwarded:
+        fails.append(f"{TRIGGER}: review job does not forward {INPUT} to the reusable (AC #5)")
+    elif f"inputs.{INPUT}" not in forwarded:
+        fails.append(
+            f"{TRIGGER}: forwarded {INPUT} does not reference inputs.{INPUT} (got: {forwarded!r})"
+        )
+
+
+def main() -> int:
+    if yaml is None:
+        print("FAIL: PyYAML is required (pip install pyyaml)", file=sys.stderr)
+        return 2
+
+    fails: list[str] = []
+    for path, fn in ((REUSABLE, check_reusable), (TRIGGER, check_trigger)):
+        try:
+            fn(fails)
+        except FileNotFoundError:
+            fails.append(f"FAIL: {path} not found")
+
+    if fails:
+        print("FAIL: LSP-pilot plumbing checks failed:")
+        for msg in fails:
+            print(f"  - {msg}")
+        return 1
+
+    print("PASS: pr-review.yml exports the capture gate + variant and gates LSP wiring; "
+          "pr-review-trigger.yml declares and forwards lsp_pilot_variant")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/dev-lead/unit/test_lsp_pilot_emit.bats
+++ b/tests/dev-lead/unit/test_lsp_pilot_emit.bats
@@ -92,7 +92,7 @@ JSON
 # ── Decoupling: explicit LSP_PILOT_VARIANT is authoritative (issue #1031) ─────
 # The A/B legs must be selectable independently of REVIEW_MCP_CONFIG, because
 # engine.sh auto-defaults REVIEW_MCP_CONFIG to the committed .github/review-mcp.json
-# (the GitHub review MCP) — so the lsp-off (A) control leg would otherwise be
+# (the Context7 MCP) — so the lsp-off (A) control leg would otherwise be
 # mislabelled lsp-on. LSP_PILOT_VARIANT=off|on overrides the detection.
 
 @test "lpe_variant: LSP_PILOT_VARIANT=off forces lsp-off even with a readable REVIEW_MCP_CONFIG" {

--- a/tests/dev-lead/unit/test_lsp_pilot_emit.bats
+++ b/tests/dev-lead/unit/test_lsp_pilot_emit.bats
@@ -96,9 +96,8 @@ JSON
 # mislabelled lsp-on. LSP_PILOT_VARIANT=off|on overrides the detection.
 
 @test "lpe_variant: LSP_PILOT_VARIANT=off forces lsp-off even with a readable REVIEW_MCP_CONFIG" {
-  local cfg; cfg="$(mktemp)"; echo '{}' > "$cfg"
+  local cfg; cfg="$(mktemp "$STREAM_DIR/cfg.XXXXXX")"; echo '{}' > "$cfg"
   REVIEW_MCP_CONFIG="$cfg" LSP_PILOT_VARIANT=off _call lpe_variant
-  rm -f "$cfg"
   [ "$output" = "lsp-off" ]
 }
 
@@ -110,18 +109,16 @@ JSON
 @test "lpe_variant: LSP_PILOT_VARIANT=none/empty falls back to REVIEW_MCP_CONFIG detection" {
   LSP_PILOT_VARIANT=none _call lpe_variant
   [ "$output" = "lsp-off" ]
-  local cfg; cfg="$(mktemp)"; echo '{}' > "$cfg"
+  local cfg; cfg="$(mktemp "$STREAM_DIR/cfg.XXXXXX")"; echo '{}' > "$cfg"
   REVIEW_MCP_CONFIG="$cfg" LSP_PILOT_VARIANT=none _call lpe_variant
-  rm -f "$cfg"
   [ "$output" = "lsp-on" ]
 }
 
 @test "lpe_candidate: follows the explicit variant (off→baseline, on→agent-lsp)" {
-  local cfg; cfg="$(mktemp)"; echo '{}' > "$cfg"
+  local cfg; cfg="$(mktemp "$STREAM_DIR/cfg.XXXXXX")"; echo '{}' > "$cfg"
   REVIEW_MCP_CONFIG="$cfg" LSP_PILOT_VARIANT=off _call lpe_candidate
   [ "$output" = "baseline" ]
   LSP_PILOT_VARIANT=on _call lpe_candidate
-  rm -f "$cfg"
   [ "$output" = "agent-lsp" ]
 }
 
@@ -185,11 +182,10 @@ JSON
 
 @test "lpe_emit_record: LSP_PILOT_VARIANT=off yields an lsp-off record even with REVIEW_MCP_CONFIG set (A-leg decoupling)" {
   _write_stream "$STREAM_DIR/stream.aaa"
-  local cfg; cfg="$(mktemp)"; echo '{}' > "$cfg"
+  local cfg; cfg="$(mktemp "$STREAM_DIR/cfg.XXXXXX")"; echo '{}' > "$cfg"
   run bash -c 'source "$1"; shift; export LSP_PILOT_ENABLED=true LSP_PILOT_VARIANT=off TOKEN_LOG_FILE="$1" REVIEW_MCP_CONFIG="$2"; shift 2; lpe_emit_record "$@"' \
     bash "$EMIT" "$TOKEN_LOG" "$cfg" \
     "$STREAM_DIR" "https://github.com/petry-projects/.github-private/pull/1031" "shaA" "6.0"
-  rm -f "$cfg"
   [ "$status" -eq 0 ]
   [ "$(wc -l < "$TOKEN_LOG")" -eq 1 ]
   run jq -r '.pr' "$TOKEN_LOG";        [ "$output" = "petry-projects/.github-private#1031@shaA" ]
@@ -199,11 +195,10 @@ JSON
 
 @test "lpe_emit_record: LSP_PILOT_VARIANT=on yields an lsp-on/agent-lsp record (B leg, same PR key)" {
   _write_stream "$STREAM_DIR/stream.aaa"
-  local cfg; cfg="$(mktemp)"; echo '{}' > "$cfg"
+  local cfg; cfg="$(mktemp "$STREAM_DIR/cfg.XXXXXX")"; echo '{}' > "$cfg"
   run bash -c 'source "$1"; shift; export LSP_PILOT_ENABLED=true LSP_PILOT_VARIANT=on TOKEN_LOG_FILE="$1" REVIEW_MCP_CONFIG="$2"; shift 2; lpe_emit_record "$@"' \
     bash "$EMIT" "$TOKEN_LOG" "$cfg" \
     "$STREAM_DIR" "https://github.com/petry-projects/.github-private/pull/1031" "shaA" "6.0"
-  rm -f "$cfg"
   [ "$status" -eq 0 ]
   run jq -r '.pr' "$TOKEN_LOG";        [ "$output" = "petry-projects/.github-private#1031@shaA" ]
   run jq -r '.variant' "$TOKEN_LOG";   [ "$output" = "lsp-on" ]

--- a/tests/dev-lead/unit/test_lsp_pilot_emit.bats
+++ b/tests/dev-lead/unit/test_lsp_pilot_emit.bats
@@ -13,7 +13,7 @@ EMIT="$SCRIPT_DIR/scripts/lsp_pilot_emit.sh"
 _call() { run bash -c 'source "$1"; shift; "$@"' bash "$EMIT" "$@"; }
 
 setup() {
-  unset LSP_PILOT_ENABLED REVIEW_MCP_CONFIG LSP_CANDIDATE TOKEN_LOG_FILE
+  unset LSP_PILOT_ENABLED LSP_PILOT_VARIANT REVIEW_MCP_CONFIG LSP_CANDIDATE TOKEN_LOG_FILE
   STREAM_DIR="$(mktemp -d)"
   TOKEN_LOG="$(mktemp)"
   : > "$TOKEN_LOG"
@@ -89,6 +89,42 @@ JSON
   [ "$output" = "agent-lsp-next" ]
 }
 
+# ── Decoupling: explicit LSP_PILOT_VARIANT is authoritative (issue #1031) ─────
+# The A/B legs must be selectable independently of REVIEW_MCP_CONFIG, because
+# engine.sh auto-defaults REVIEW_MCP_CONFIG to the committed .github/review-mcp.json
+# (the GitHub review MCP) — so the lsp-off (A) control leg would otherwise be
+# mislabelled lsp-on. LSP_PILOT_VARIANT=off|on overrides the detection.
+
+@test "lpe_variant: LSP_PILOT_VARIANT=off forces lsp-off even with a readable REVIEW_MCP_CONFIG" {
+  local cfg; cfg="$(mktemp)"; echo '{}' > "$cfg"
+  REVIEW_MCP_CONFIG="$cfg" LSP_PILOT_VARIANT=off _call lpe_variant
+  rm -f "$cfg"
+  [ "$output" = "lsp-off" ]
+}
+
+@test "lpe_variant: LSP_PILOT_VARIANT=on forces lsp-on even when REVIEW_MCP_CONFIG is unset" {
+  LSP_PILOT_VARIANT=on _call lpe_variant
+  [ "$output" = "lsp-on" ]
+}
+
+@test "lpe_variant: LSP_PILOT_VARIANT=none/empty falls back to REVIEW_MCP_CONFIG detection" {
+  LSP_PILOT_VARIANT=none _call lpe_variant
+  [ "$output" = "lsp-off" ]
+  local cfg; cfg="$(mktemp)"; echo '{}' > "$cfg"
+  REVIEW_MCP_CONFIG="$cfg" LSP_PILOT_VARIANT=none _call lpe_variant
+  rm -f "$cfg"
+  [ "$output" = "lsp-on" ]
+}
+
+@test "lpe_candidate: follows the explicit variant (off→baseline, on→agent-lsp)" {
+  local cfg; cfg="$(mktemp)"; echo '{}' > "$cfg"
+  REVIEW_MCP_CONFIG="$cfg" LSP_PILOT_VARIANT=off _call lpe_candidate
+  [ "$output" = "baseline" ]
+  LSP_PILOT_VARIANT=on _call lpe_candidate
+  rm -f "$cfg"
+  [ "$output" = "agent-lsp" ]
+}
+
 # ── pr join key ──────────────────────────────────────────────────────────────
 
 @test "lpe_pr_key: builds <owner/repo>#<num>@<sha> from a PR URL" {
@@ -143,6 +179,33 @@ JSON
     "$STREAM_DIR" "https://github.com/o/r/pull/7" "sha7" "9.0"
   rm -f "$cfg"
   [ "$status" -eq 0 ]
+  run jq -r '.variant' "$TOKEN_LOG";   [ "$output" = "lsp-on" ]
+  run jq -r '.candidate' "$TOKEN_LOG"; [ "$output" = "agent-lsp" ]
+}
+
+@test "lpe_emit_record: LSP_PILOT_VARIANT=off yields an lsp-off record even with REVIEW_MCP_CONFIG set (A-leg decoupling)" {
+  _write_stream "$STREAM_DIR/stream.aaa"
+  local cfg; cfg="$(mktemp)"; echo '{}' > "$cfg"
+  run bash -c 'source "$1"; shift; export LSP_PILOT_ENABLED=true LSP_PILOT_VARIANT=off TOKEN_LOG_FILE="$1" REVIEW_MCP_CONFIG="$2"; shift 2; lpe_emit_record "$@"' \
+    bash "$EMIT" "$TOKEN_LOG" "$cfg" \
+    "$STREAM_DIR" "https://github.com/petry-projects/.github-private/pull/1031" "shaA" "6.0"
+  rm -f "$cfg"
+  [ "$status" -eq 0 ]
+  [ "$(wc -l < "$TOKEN_LOG")" -eq 1 ]
+  run jq -r '.pr' "$TOKEN_LOG";        [ "$output" = "petry-projects/.github-private#1031@shaA" ]
+  run jq -r '.variant' "$TOKEN_LOG";   [ "$output" = "lsp-off" ]
+  run jq -r '.candidate' "$TOKEN_LOG"; [ "$output" = "baseline" ]
+}
+
+@test "lpe_emit_record: LSP_PILOT_VARIANT=on yields an lsp-on/agent-lsp record (B leg, same PR key)" {
+  _write_stream "$STREAM_DIR/stream.aaa"
+  local cfg; cfg="$(mktemp)"; echo '{}' > "$cfg"
+  run bash -c 'source "$1"; shift; export LSP_PILOT_ENABLED=true LSP_PILOT_VARIANT=on TOKEN_LOG_FILE="$1" REVIEW_MCP_CONFIG="$2"; shift 2; lpe_emit_record "$@"' \
+    bash "$EMIT" "$TOKEN_LOG" "$cfg" \
+    "$STREAM_DIR" "https://github.com/petry-projects/.github-private/pull/1031" "shaA" "6.0"
+  rm -f "$cfg"
+  [ "$status" -eq 0 ]
+  run jq -r '.pr' "$TOKEN_LOG";        [ "$output" = "petry-projects/.github-private#1031@shaA" ]
   run jq -r '.variant' "$TOKEN_LOG";   [ "$output" = "lsp-on" ]
   run jq -r '.candidate' "$TOKEN_LOG"; [ "$output" = "agent-lsp" ]
 }

--- a/tests/dev-lead/unit/test_lsp_pilot_emit.bats
+++ b/tests/dev-lead/unit/test_lsp_pilot_emit.bats
@@ -62,9 +62,8 @@ JSON
 }
 
 @test "lpe_variant: lsp-on when REVIEW_MCP_CONFIG points at a readable file" {
-  local cfg; cfg="$(mktemp)"; echo '{}' > "$cfg"
+  local cfg; cfg="$(mktemp "$STREAM_DIR/cfg.XXXXXX")"; echo '{}' > "$cfg"
   REVIEW_MCP_CONFIG="$cfg" _call lpe_variant
-  rm -f "$cfg"
   [ "$output" = "lsp-on" ]
 }
 
@@ -76,16 +75,14 @@ JSON
 @test "lpe_candidate: baseline for lsp-off, agent-lsp for lsp-on" {
   _call lpe_candidate
   [ "$output" = "baseline" ]
-  local cfg; cfg="$(mktemp)"; echo '{}' > "$cfg"
+  local cfg; cfg="$(mktemp "$STREAM_DIR/cfg.XXXXXX")"; echo '{}' > "$cfg"
   REVIEW_MCP_CONFIG="$cfg" _call lpe_candidate
-  rm -f "$cfg"
   [ "$output" = "agent-lsp" ]
 }
 
 @test "lpe_candidate: honors LSP_CANDIDATE override on the lsp-on leg" {
-  local cfg; cfg="$(mktemp)"; echo '{}' > "$cfg"
+  local cfg; cfg="$(mktemp "$STREAM_DIR/cfg.XXXXXX")"; echo '{}' > "$cfg"
   REVIEW_MCP_CONFIG="$cfg" LSP_CANDIDATE="agent-lsp-next" _call lpe_candidate
-  rm -f "$cfg"
   [ "$output" = "agent-lsp-next" ]
 }
 
@@ -170,11 +167,10 @@ JSON
 
 @test "lpe_emit_record: lsp-on variant uses REVIEW_MCP_CONFIG + agent-lsp candidate" {
   _write_stream "$STREAM_DIR/stream.aaa"
-  local cfg; cfg="$(mktemp)"; echo '{}' > "$cfg"
+  local cfg; cfg="$(mktemp "$STREAM_DIR/cfg.XXXXXX")"; echo '{}' > "$cfg"
   run bash -c 'source "$1"; shift; export LSP_PILOT_ENABLED=true TOKEN_LOG_FILE="$1" REVIEW_MCP_CONFIG="$2"; shift 2; lpe_emit_record "$@"' \
     bash "$EMIT" "$TOKEN_LOG" "$cfg" \
     "$STREAM_DIR" "https://github.com/o/r/pull/7" "sha7" "9.0"
-  rm -f "$cfg"
   [ "$status" -eq 0 ]
   run jq -r '.variant' "$TOKEN_LOG";   [ "$output" = "lsp-on" ]
   run jq -r '.candidate' "$TOKEN_LOG"; [ "$output" = "agent-lsp" ]


### PR DESCRIPTION
Closes #1031

Implemented by dev-lead agent. Please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manual A/B variant option for the PR review flow, allowing runs to be marked as on, off, or legacy behavior.
  * Review runs now carry the selected variant through the workflow and emitted pilot records.

* **Bug Fixes**
  * Improved variant selection so explicit inputs take priority over existing configuration.
  * Added validation to ensure both workflow wiring and variant handling behave consistently across trigger types.

* **Tests**
  * Expanded coverage for pilot variant routing, record generation, and workflow input forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->