### PR TITLE
feat: implement issue #1036 — Populate canary-rings.json with the 6 #482 reusables (registry is dev-lead-only → evaluate-all covers nothing else)

### DIFF
--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -40,6 +40,49 @@ CANARY_RINGS="${CANARY_RINGS:-$DEFAULT_RINGS}"
 _jq()  { jq "$@" "$CANARY_RINGS"; }
 _agent_field() { _jq -r --arg a "$1" ".agents[\$a].$2"; }
 
+# This-repo identifier — agents whose registry .host differs are "cross-repo": their
+# release/channel tags live in the host repo and are resolved/moved via gh api.
+_THIS_REPO="petry-projects/.github-private"
+
+# _agent_host <agent> — echo the host repo from the registry (empty if absent).
+_agent_host() { _jq -r --arg a "$1" '.agents[$a].host // empty'; }
+
+# _agent_is_cross_repo <agent> — return 0 if the agent's reusable lives in another repo.
+_agent_is_cross_repo() {
+  local host; host="$(_agent_host "$1")"
+  [ -n "$host" ] && [ "$host" != "$_THIS_REPO" ]
+}
+
+# _gh_channel_commit <host> <tag_ref> — resolve the commit SHA a channel tag points to
+# on a remote repo (dereferencing annotated tag objects). Empty if absent or on error.
+_gh_channel_commit() {
+  local host="$1" tag_ref="$2" ref_json obj type
+  ref_json="$(gh api "repos/${host}/git/ref/tags/${tag_ref}" 2>/dev/null)" || { echo ""; return 0; }
+  [ -z "$ref_json" ] && { echo ""; return 0; }
+  obj="$(jq -r '.object.sha // empty' 2>/dev/null <<< "$ref_json")"
+  type="$(jq -r '.object.type // empty' 2>/dev/null <<< "$ref_json")"
+  [ -z "$obj" ] && { echo ""; return 0; }
+  if [ "$type" = "tag" ]; then
+    gh api "repos/${host}/git/tags/${obj}" 2>/dev/null \
+      | jq -r '.object.sha // empty' 2>/dev/null || echo ""
+  else
+    echo "$obj"
+  fi
+}
+
+# _gh_move_channel_tag <host> <tag_ref> <sha> — force-move (or create) a lightweight
+# channel tag on a remote repo via gh api (mirrors `git tag -f && git push --force`).
+_gh_move_channel_tag() {
+  local host="$1" tag_ref="$2" sha="$3"
+  if gh api "repos/${host}/git/ref/tags/${tag_ref}" >/dev/null 2>&1; then
+    gh api -X PATCH "repos/${host}/git/refs/tags/${tag_ref}" \
+      -f "sha=$sha" -F "force=true" >/dev/null
+  else
+    gh api -X POST "repos/${host}/git/refs" \
+      -f "ref=refs/tags/${tag_ref}" -f "sha=$sha" >/dev/null
+  fi
+}
+
 # ordered_channels <agent> — e.g. "next,ring0,ring1,stable"
 ordered_channels() {
   _jq -r --arg a "$1" '.agents[$a].rings | sort_by(.order) | map(.channel) | join(",")'
@@ -66,9 +109,15 @@ resolve_members() {
   return 0
 }
 
-# channel_commit <agent> <channel> — commit a channel tag resolves to (short-circuits
-# to empty if the tag does not exist).
+# channel_commit <agent> <channel> — commit a channel tag resolves to. For cross-repo
+# agents (host != _THIS_REPO) the tag lives in the host repo and is resolved via gh api.
+# Short-circuits to empty if the tag does not exist.
 channel_commit() {
+  local agent="$1" channel="$2"
+  if _agent_is_cross_repo "$agent"; then
+    _gh_channel_commit "$(_agent_host "$agent")" "${agent}/${channel}"
+    return
+  fi
   git rev-parse -q --verify "refs/tags/$1/$2^{commit}" 2>/dev/null \
     || git rev-parse -q --verify "$1/$2^{commit}" 2>/dev/null || true
 }
@@ -99,8 +148,17 @@ _epoch() {
 # immutable release tag <agent>/vX.Y.Z that points at the candidate commit. This is the
 # per-candidate cumulative-window start (#548): health is measured since the candidate's
 # OWN cut, NOT a rolling window — so a pre-cut failure of a prior version is excluded.
+# For cross-repo agents, the tag lives in the host repo; the commit's committer date is
+# used as the window start (within seconds of the tagger date for automated releases).
 candidate_cut_date() {
-  local agent="$1" commit="$2" obj deref cdate c
+  local agent="$1" commit="$2"
+  if _agent_is_cross_repo "$agent"; then
+    local host; host="$(_agent_host "$agent")"
+    gh api "repos/${host}/commits/${commit}" 2>/dev/null \
+      | jq -r '.commit.committer.date // empty' 2>/dev/null || echo ""
+    return 0
+  fi
+  local obj deref cdate c
   while IFS='|' read -r obj deref cdate; do
     c="$deref"; [ -z "$c" ] && c="$obj"
     if [ "$c" = "$commit" ]; then _to_z "$cdate"; return 0; fi
@@ -231,12 +289,21 @@ _baseline_daily() {
 # workflow blob differs between the candidate SHA and the prior channel SHA, else 0. Used
 # by triage to confirm a CANDIDATE REGRESSION (#548): a failure whose reusable is identical
 # to the prior version is pre-existing, not introduced by the candidate.
+# For cross-repo agents, blob SHAs are fetched from the host repo via gh api.
 _reusable_differs() {
   local agent="$1" cand="$2" prior="$3" reusable a b
   reusable="$(_agent_field "$agent" reusable)"
   [ -z "$reusable" ] || [ -z "$cand" ] || [ -z "$prior" ] && { echo 0; return 0; }
-  a="$(git rev-parse -q --verify "${cand}:${reusable}" 2>/dev/null || echo "")"
-  b="$(git rev-parse -q --verify "${prior}:${reusable}" 2>/dev/null || echo "")"
+  if _agent_is_cross_repo "$agent"; then
+    local host; host="$(_agent_host "$agent")"
+    a="$(gh api "repos/${host}/contents/${reusable}?ref=${cand}" 2>/dev/null \
+      | jq -r '.sha // empty' 2>/dev/null || echo "")"
+    b="$(gh api "repos/${host}/contents/${reusable}?ref=${prior}" 2>/dev/null \
+      | jq -r '.sha // empty' 2>/dev/null || echo "")"
+  else
+    a="$(git rev-parse -q --verify "${cand}:${reusable}" 2>/dev/null || echo "")"
+    b="$(git rev-parse -q --verify "${prior}:${reusable}" 2>/dev/null || echo "")"
+  fi
   [ -n "$a" ] && [ "$a" != "$b" ] && { echo 1; return 0; }
   echo 0
 }
@@ -423,12 +490,22 @@ cmd_promote() {
   [ "$state" != "PROMOTE" ] && echo "::warning::advancing $agent/$frontier despite gate state '$state' (triage=$triage)"
   echo "advancing $agent/$frontier -> ${cand:0:12}"
   if [ "$dry" = true ]; then
-    echo "[DRY-RUN] would: git tag -f $agent/$frontier $cand && git push --force origin $agent/$frontier"
+    if _agent_is_cross_repo "$agent"; then
+      echo "[DRY-RUN] would: move $agent/$frontier -> $cand on $(_agent_host "$agent") (gh api)"
+    else
+      echo "[DRY-RUN] would: git tag -f $agent/$frontier $cand && git push --force origin $agent/$frontier"
+    fi
     return 0
   fi
-  git tag -f "$agent/$frontier" "$cand"
-  git push --force origin "$agent/$frontier"
-  echo "promoted $agent/$frontier -> ${cand:0:12}"
+  if _agent_is_cross_repo "$agent"; then
+    local host; host="$(_agent_host "$agent")"
+    _gh_move_channel_tag "$host" "$agent/$frontier" "$cand"
+    echo "promoted $agent/$frontier -> ${cand:0:12} on $host"
+  else
+    git tag -f "$agent/$frontier" "$cand"
+    git push --force origin "$agent/$frontier"
+    echo "promoted $agent/$frontier -> ${cand:0:12}"
+  fi
   # Expose the move so the workflow can record a GitHub Deployment (traceability, #502).
   if [ -n "${GITHUB_OUTPUT:-}" ]; then
     { echo "promoted_agent=$agent"; echo "promoted_ring=$frontier"; echo "promoted_sha=$cand"; } >> "$GITHUB_OUTPUT"
@@ -449,16 +526,32 @@ cmd_rollback() {
     esac; shift
   done
   [ -z "$to" ] && { echo "::error::rollback requires --to <vX.Y.Z>" >&2; return 2; }
-  local target; target="$(git rev-parse -q --verify "refs/tags/$agent/$to^{commit}" 2>/dev/null || true)"
+  local target
+  if _agent_is_cross_repo "$agent"; then
+    local host; host="$(_agent_host "$agent")"
+    target="$(_gh_channel_commit "$host" "$agent/$to")"
+  else
+    target="$(git rev-parse -q --verify "refs/tags/$agent/$to^{commit}" 2>/dev/null || true)"
+  fi
   [ -z "$target" ] && { echo "::error::release tag $agent/$to not found" >&2; return 1; }
   echo "rolling back $agent/$ring -> $to (${target:0:12})"
   if [ "$dry" = true ]; then
-    echo "[DRY-RUN] would: git tag -f $agent/$ring $target && git push --force origin $agent/$ring"
+    if _agent_is_cross_repo "$agent"; then
+      echo "[DRY-RUN] would: move $agent/$ring -> $target on $(_agent_host "$agent") (gh api)"
+    else
+      echo "[DRY-RUN] would: git tag -f $agent/$ring $target && git push --force origin $agent/$ring"
+    fi
     return 0
   fi
-  git tag -f "$agent/$ring" "$target"
-  git push --force origin "$agent/$ring"
-  echo "rolled back $agent/$ring -> $to"
+  if _agent_is_cross_repo "$agent"; then
+    local host; host="$(_agent_host "$agent")"
+    _gh_move_channel_tag "$host" "$agent/$ring" "$target"
+    echo "rolled back $agent/$ring -> $to on $host"
+  else
+    git tag -f "$agent/$ring" "$target"
+    git push --force origin "$agent/$ring"
+    echo "rolled back $agent/$ring -> $to"
+  fi
 }
 
 main() {

--- a/standards/canary-rings.json
+++ b/standards/canary-rings.json
@@ -58,6 +58,228 @@
           }
         }
       }
+    },
+    "agent-shield": {
+      "host": "petry-projects/.github",
+      "reusable": ".github/workflows/agent-shield-reusable.yml",
+      "run_workflow": "agent-shield.yml",
+      "rings": [
+        { "channel": "next",   "order": 0, "members": ["petry-projects/.github-private"] },
+        { "channel": "ring0",  "order": 1, "members": ["petry-projects/.github"] },
+        { "channel": "ring1",  "order": 2, "members": ["petry-projects/TalkTerm", "petry-projects/bmad-bgreat-suite"] },
+        { "channel": "stable", "order": 3, "members": ["*"] }
+      ],
+      "gate": {
+        "_standard": "petry-projects/.github#548 — graduated dwell/sample gate over a per-candidate cumulative window. Registry-configurable per-transition knobs; the values below are the #548 defaults.",
+        "_topology_note": "#482 cross-repo reusable: the reusable lives in the host petry-projects/.github, but the rollout is canaried in .github-private (order 0, the caller-stub/automation repo) BEFORE the host (ring0). waive_sample_if_no_caller lets an agent with no .github-private caller (e.g. dependabot-rebase) soak from ring0 without a fresh next-tier sample.",
+        "baseline_window_days": 14,
+        "baseline_spike_cap_multiple": 3,
+        "control": {
+          "allow_pre_existing": false
+        },
+        "transitions": {
+          "next->ring0": {
+            "dwell_hours": 4,
+            "sample_fraction_permille": 250,
+            "sample_clamp_min": 3,
+            "sample_clamp_max": 15,
+            "waive_sample_if_no_caller": true
+          },
+          "ring0->ring1": {
+            "dwell_hours": 8,
+            "waive_sample": true
+          },
+          "ring1->stable": {
+            "dwell_hours": 12,
+            "sample_min": 1
+          }
+        }
+      }
+    },
+    "dependency-audit": {
+      "host": "petry-projects/.github",
+      "reusable": ".github/workflows/dependency-audit-reusable.yml",
+      "run_workflow": "dependency-audit.yml",
+      "rings": [
+        { "channel": "next",   "order": 0, "members": ["petry-projects/.github-private"] },
+        { "channel": "ring0",  "order": 1, "members": ["petry-projects/.github"] },
+        { "channel": "ring1",  "order": 2, "members": ["petry-projects/TalkTerm", "petry-projects/bmad-bgreat-suite"] },
+        { "channel": "stable", "order": 3, "members": ["*"] }
+      ],
+      "gate": {
+        "_standard": "petry-projects/.github#548 — graduated dwell/sample gate over a per-candidate cumulative window. Registry-configurable per-transition knobs; the values below are the #548 defaults.",
+        "_topology_note": "#482 cross-repo reusable: the reusable lives in the host petry-projects/.github, but the rollout is canaried in .github-private (order 0, the caller-stub/automation repo) BEFORE the host (ring0). waive_sample_if_no_caller lets an agent with no .github-private caller (e.g. dependabot-rebase) soak from ring0 without a fresh next-tier sample.",
+        "baseline_window_days": 14,
+        "baseline_spike_cap_multiple": 3,
+        "control": {
+          "allow_pre_existing": false
+        },
+        "transitions": {
+          "next->ring0": {
+            "dwell_hours": 4,
+            "sample_fraction_permille": 250,
+            "sample_clamp_min": 3,
+            "sample_clamp_max": 15,
+            "waive_sample_if_no_caller": true
+          },
+          "ring0->ring1": {
+            "dwell_hours": 8,
+            "waive_sample": true
+          },
+          "ring1->stable": {
+            "dwell_hours": 12,
+            "sample_min": 1
+          }
+        }
+      }
+    },
+    "auto-rebase": {
+      "host": "petry-projects/.github",
+      "reusable": ".github/workflows/auto-rebase-reusable.yml",
+      "run_workflow": "auto-rebase.yml",
+      "rings": [
+        { "channel": "next",   "order": 0, "members": ["petry-projects/.github-private"] },
+        { "channel": "ring0",  "order": 1, "members": ["petry-projects/.github"] },
+        { "channel": "ring1",  "order": 2, "members": ["petry-projects/TalkTerm", "petry-projects/bmad-bgreat-suite"] },
+        { "channel": "stable", "order": 3, "members": ["*"] }
+      ],
+      "gate": {
+        "_standard": "petry-projects/.github#548 — graduated dwell/sample gate over a per-candidate cumulative window. Registry-configurable per-transition knobs; the values below are the #548 defaults.",
+        "_topology_note": "#482 cross-repo reusable: the reusable lives in the host petry-projects/.github, but the rollout is canaried in .github-private (order 0, the caller-stub/automation repo) BEFORE the host (ring0). waive_sample_if_no_caller lets an agent with no .github-private caller (e.g. dependabot-rebase) soak from ring0 without a fresh next-tier sample.",
+        "baseline_window_days": 14,
+        "baseline_spike_cap_multiple": 3,
+        "control": {
+          "allow_pre_existing": false
+        },
+        "transitions": {
+          "next->ring0": {
+            "dwell_hours": 4,
+            "sample_fraction_permille": 250,
+            "sample_clamp_min": 3,
+            "sample_clamp_max": 15,
+            "waive_sample_if_no_caller": true
+          },
+          "ring0->ring1": {
+            "dwell_hours": 8,
+            "waive_sample": true
+          },
+          "ring1->stable": {
+            "dwell_hours": 12,
+            "sample_min": 1
+          }
+        }
+      }
+    },
+    "dependabot-automerge": {
+      "host": "petry-projects/.github",
+      "reusable": ".github/workflows/dependabot-automerge-reusable.yml",
+      "run_workflow": "dependabot-automerge.yml",
+      "rings": [
+        { "channel": "next",   "order": 0, "members": ["petry-projects/.github-private"] },
+        { "channel": "ring0",  "order": 1, "members": ["petry-projects/.github"] },
+        { "channel": "ring1",  "order": 2, "members": ["petry-projects/TalkTerm", "petry-projects/bmad-bgreat-suite"] },
+        { "channel": "stable", "order": 3, "members": ["*"] }
+      ],
+      "gate": {
+        "_standard": "petry-projects/.github#548 — graduated dwell/sample gate over a per-candidate cumulative window. Registry-configurable per-transition knobs; the values below are the #548 defaults.",
+        "_topology_note": "#482 cross-repo reusable: the reusable lives in the host petry-projects/.github, but the rollout is canaried in .github-private (order 0, the caller-stub/automation repo) BEFORE the host (ring0). waive_sample_if_no_caller lets an agent with no .github-private caller (e.g. dependabot-rebase) soak from ring0 without a fresh next-tier sample.",
+        "baseline_window_days": 14,
+        "baseline_spike_cap_multiple": 3,
+        "control": {
+          "allow_pre_existing": false
+        },
+        "transitions": {
+          "next->ring0": {
+            "dwell_hours": 4,
+            "sample_fraction_permille": 250,
+            "sample_clamp_min": 3,
+            "sample_clamp_max": 15,
+            "waive_sample_if_no_caller": true
+          },
+          "ring0->ring1": {
+            "dwell_hours": 8,
+            "waive_sample": true
+          },
+          "ring1->stable": {
+            "dwell_hours": 12,
+            "sample_min": 1
+          }
+        }
+      }
+    },
+    "dependabot-rebase": {
+      "host": "petry-projects/.github",
+      "reusable": ".github/workflows/dependabot-rebase-reusable.yml",
+      "run_workflow": "dependabot-rebase.yml",
+      "rings": [
+        { "channel": "next",   "order": 0, "members": ["petry-projects/.github-private"] },
+        { "channel": "ring0",  "order": 1, "members": ["petry-projects/.github"] },
+        { "channel": "ring1",  "order": 2, "members": ["petry-projects/TalkTerm", "petry-projects/bmad-bgreat-suite"] },
+        { "channel": "stable", "order": 3, "members": ["*"] }
+      ],
+      "gate": {
+        "_standard": "petry-projects/.github#548 — graduated dwell/sample gate over a per-candidate cumulative window. Registry-configurable per-transition knobs; the values below are the #548 defaults.",
+        "_topology_note": "#482 cross-repo reusable: the reusable lives in the host petry-projects/.github, but the rollout is canaried in .github-private (order 0, the caller-stub/automation repo) BEFORE the host (ring0). dependabot-rebase has NO .github-private caller, so next has zero callers and waive_sample_if_no_caller waives the fresh next->ring0 sample (dwell-only) — the soak effectively starts at ring0.",
+        "baseline_window_days": 14,
+        "baseline_spike_cap_multiple": 3,
+        "control": {
+          "allow_pre_existing": false
+        },
+        "transitions": {
+          "next->ring0": {
+            "dwell_hours": 4,
+            "sample_fraction_permille": 250,
+            "sample_clamp_min": 3,
+            "sample_clamp_max": 15,
+            "waive_sample_if_no_caller": true
+          },
+          "ring0->ring1": {
+            "dwell_hours": 8,
+            "waive_sample": true
+          },
+          "ring1->stable": {
+            "dwell_hours": 12,
+            "sample_min": 1
+          }
+        }
+      }
+    },
+    "pr-review-mention": {
+      "host": "petry-projects/.github",
+      "reusable": ".github/workflows/pr-review-mention-reusable.yml",
+      "run_workflow": "pr-review-mention.yml",
+      "rings": [
+        { "channel": "next",   "order": 0, "members": ["petry-projects/.github-private"] },
+        { "channel": "ring0",  "order": 1, "members": ["petry-projects/.github"] },
+        { "channel": "ring1",  "order": 2, "members": ["petry-projects/TalkTerm", "petry-projects/bmad-bgreat-suite"] },
+        { "channel": "stable", "order": 3, "members": ["*"] }
+      ],
+      "gate": {
+        "_standard": "petry-projects/.github#548 — graduated dwell/sample gate over a per-candidate cumulative window. Registry-configurable per-transition knobs; the values below are the #548 defaults.",
+        "_topology_note": "#482 cross-repo reusable: the reusable lives in the host petry-projects/.github, but the rollout is canaried in .github-private (order 0, the caller-stub/automation repo) BEFORE the host (ring0). waive_sample_if_no_caller lets an agent with no .github-private caller (e.g. dependabot-rebase) soak from ring0 without a fresh next-tier sample.",
+        "baseline_window_days": 14,
+        "baseline_spike_cap_multiple": 3,
+        "control": {
+          "allow_pre_existing": false
+        },
+        "transitions": {
+          "next->ring0": {
+            "dwell_hours": 4,
+            "sample_fraction_permille": 250,
+            "sample_clamp_min": 3,
+            "sample_clamp_max": 15,
+            "waive_sample_if_no_caller": true
+          },
+          "ring0->ring1": {
+            "dwell_hours": 8,
+            "waive_sample": true
+          },
+          "ring1->stable": {
+            "dwell_hours": 12,
+            "sample_min": 1
+          }
+        }
+      }
     }
   }
 }

--- a/standards/canary-rings.json
+++ b/standards/canary-rings.json
@@ -7,6 +7,25 @@
     "$org_infra": "org_infra_repos minus the host (the host is already in `next`)",
     "*": "every other consumer not named in an earlier ring"
   },
+  "_gate_profiles": {
+    "_note": "Canonical #548 gate defaults shared by the six #482 cross-repo reusables. JSON has no native anchors; introducing a gate_profiles indirection usable by the orchestrator is tracked for a future issue. Until then, these defaults are reproduced inline in each agent entry to keep the registry self-contained. This section is the single source of truth for those defaults and is not read by the orchestrator.",
+    "default_482": {
+      "baseline_window_days": 14,
+      "baseline_spike_cap_multiple": 3,
+      "control": { "allow_pre_existing": false },
+      "transitions": {
+        "next->ring0": {
+          "dwell_hours": 4,
+          "sample_fraction_permille": 250,
+          "sample_clamp_min": 3,
+          "sample_clamp_max": 15,
+          "waive_sample_if_no_caller": true
+        },
+        "ring0->ring1": { "dwell_hours": 8, "waive_sample": true },
+        "ring1->stable": { "dwell_hours": 12, "sample_min": 1 }
+      }
+    }
+  },
   "agents": {
     "dev-lead": {
       "host": "petry-projects/.github-private",

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -491,6 +491,7 @@ _REUSABLES_482="agent-shield dependency-audit auto-rebase dependabot-automerge d
 @test "canary-rings.json: #482 reusables share the ring topology (next=.github-private, ring0=.github, ring1 pair, stable=*)" {
   for a in $_REUSABLES_482; do
     run bash -c "jq -r '.agents[\"$a\"].rings | sort_by(.order) | map(.channel) | join(\",\")' '$RINGS'"
+    [ "$status" -eq 0 ]
     [ "$output" = "next,ring0,ring1,stable" ]
     jq -e --arg a "$a" '.agents[$a].rings[] | select(.channel=="next")  | .members == ["petry-projects/.github-private"]' "$RINGS" >/dev/null
     jq -e --arg a "$a" '.agents[$a].rings[] | select(.channel=="ring0") | .members == ["petry-projects/.github"]' "$RINGS" >/dev/null
@@ -505,6 +506,7 @@ _REUSABLES_482="agent-shield dependency-audit auto-rebase dependabot-automerge d
   run bash -c "source '$ORCH' && CANARY_RINGS='$RINGS' resolve_members agent-shield ring0"
   [ "$status" -eq 0 ]; [ "$output" = "petry-projects/.github" ]
   run bash -c "source '$ORCH' && CANARY_RINGS='$RINGS' resolve_members dependabot-rebase ring1"
+  [ "$status" -eq 0 ]
   [[ "$output" == *"petry-projects/TalkTerm"* ]]
   [[ "$output" == *"petry-projects/bmad-bgreat-suite"* ]]
   run bash -c "source '$ORCH' && CANARY_RINGS='$RINGS' resolve_members pr-review-mention stable"
@@ -517,6 +519,8 @@ _REUSABLES_482="agent-shield dependency-audit auto-rebase dependabot-automerge d
     jq -e --arg a "$a" '.agents[$a].gate.baseline_spike_cap_multiple == 3' "$RINGS" >/dev/null
     jq -e --arg a "$a" '.agents[$a].gate.transitions["next->ring0"].dwell_hours == 4' "$RINGS" >/dev/null
     jq -e --arg a "$a" '.agents[$a].gate.transitions["next->ring0"].sample_fraction_permille == 250' "$RINGS" >/dev/null
+    jq -e --arg a "$a" '.agents[$a].gate.transitions["next->ring0"].sample_clamp_min == 3' "$RINGS" >/dev/null
+    jq -e --arg a "$a" '.agents[$a].gate.transitions["next->ring0"].sample_clamp_max == 15' "$RINGS" >/dev/null
     # waive_sample_if_no_caller covers dependabot-rebase's missing .github-private caller
     # (the "soak starts at ring0" note): a next tier with zero callers waives the fresh sample.
     jq -e --arg a "$a" '.agents[$a].gate.transitions["next->ring0"].waive_sample_if_no_caller == true' "$RINGS" >/dev/null

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -457,3 +457,90 @@ _benign_stub() {
   [[ "$output" != *"DRY-RUN"* ]]
   [[ "$output" == *"REGRESSION"* ]]
 }
+
+# ── canary-rings.json: the 6 #482 cross-repo reusables (#1036) ─────────────────
+# These were rolled out manually via the now-retired bridge and were never onboarded
+# into the registry, so `evaluate-all` could not see them. All 6 host in the public
+# petry-projects/.github repo (cross-repo) and share one ring topology: the rollout is
+# canaried in .github-private (the caller-stub/automation repo) FIRST, then the host.
+_REUSABLES_482="agent-shield dependency-audit auto-rebase dependabot-automerge dependabot-rebase pr-review-mention"
+
+@test "canary-rings.json: all 6 #482 reusables are registered (7 agents incl. dev-lead)" {
+  run jq -e '.agents | keys | length == 7' "$RINGS"
+  [ "$status" -eq 0 ]
+  for a in $_REUSABLES_482; do
+    jq -e --arg a "$a" '.agents | has($a)' "$RINGS" >/dev/null
+  done
+}
+
+@test "canary-rings.json: each #482 reusable has host .github + right reusable path + run_workflow" {
+  # host, reusable path, run_workflow per the #1036 table (col 2 / col 3).
+  _chk() {
+    jq -e --arg a "$1" '.agents[$a].host == "petry-projects/.github"' "$RINGS" >/dev/null
+    jq -e --arg a "$1" --arg r "$2" '.agents[$a].reusable == $r' "$RINGS" >/dev/null
+    jq -e --arg a "$1" --arg w "$3" '.agents[$a].run_workflow == $w' "$RINGS" >/dev/null
+  }
+  _chk agent-shield         ".github/workflows/agent-shield-reusable.yml"         "agent-shield.yml"
+  _chk dependency-audit     ".github/workflows/dependency-audit-reusable.yml"     "dependency-audit.yml"
+  _chk auto-rebase          ".github/workflows/auto-rebase-reusable.yml"          "auto-rebase.yml"
+  _chk dependabot-automerge ".github/workflows/dependabot-automerge-reusable.yml" "dependabot-automerge.yml"
+  _chk dependabot-rebase    ".github/workflows/dependabot-rebase-reusable.yml"    "dependabot-rebase.yml"
+  _chk pr-review-mention    ".github/workflows/pr-review-mention-reusable.yml"    "pr-review-mention.yml"
+}
+
+@test "canary-rings.json: #482 reusables share the ring topology (next=.github-private, ring0=.github, ring1 pair, stable=*)" {
+  for a in $_REUSABLES_482; do
+    run bash -c "jq -r '.agents[\"$a\"].rings | sort_by(.order) | map(.channel) | join(\",\")' '$RINGS'"
+    [ "$output" = "next,ring0,ring1,stable" ]
+    jq -e --arg a "$a" '.agents[$a].rings[] | select(.channel=="next")  | .members == ["petry-projects/.github-private"]' "$RINGS" >/dev/null
+    jq -e --arg a "$a" '.agents[$a].rings[] | select(.channel=="ring0") | .members == ["petry-projects/.github"]' "$RINGS" >/dev/null
+    jq -e --arg a "$a" '.agents[$a].rings[] | select(.channel=="ring1") | (.members | index("petry-projects/TalkTerm")) and (.members | index("petry-projects/bmad-bgreat-suite"))' "$RINGS" >/dev/null
+    jq -e --arg a "$a" '.agents[$a].rings[] | select(.channel=="stable") | .members == ["*"]' "$RINGS" >/dev/null
+  done
+}
+
+@test "orchestrator: resolve_members for a #482 cross-repo reusable (next=.github-private, ring0=.github, stable=*)" {
+  run bash -c "source '$ORCH' && CANARY_RINGS='$RINGS' resolve_members agent-shield next"
+  [ "$status" -eq 0 ]; [ "$output" = "petry-projects/.github-private" ]
+  run bash -c "source '$ORCH' && CANARY_RINGS='$RINGS' resolve_members agent-shield ring0"
+  [ "$status" -eq 0 ]; [ "$output" = "petry-projects/.github" ]
+  run bash -c "source '$ORCH' && CANARY_RINGS='$RINGS' resolve_members dependabot-rebase ring1"
+  [[ "$output" == *"petry-projects/TalkTerm"* ]]
+  [[ "$output" == *"petry-projects/bmad-bgreat-suite"* ]]
+  run bash -c "source '$ORCH' && CANARY_RINGS='$RINGS' resolve_members pr-review-mention stable"
+  [ "$status" -eq 0 ]; [ "$output" = "*" ]
+}
+
+@test "canary-rings.json: #482 reusables carry the #548 per-transition gate knobs" {
+  for a in $_REUSABLES_482; do
+    jq -e --arg a "$a" '.agents[$a].gate.baseline_window_days == 14' "$RINGS" >/dev/null
+    jq -e --arg a "$a" '.agents[$a].gate.baseline_spike_cap_multiple == 3' "$RINGS" >/dev/null
+    jq -e --arg a "$a" '.agents[$a].gate.transitions["next->ring0"].dwell_hours == 4' "$RINGS" >/dev/null
+    jq -e --arg a "$a" '.agents[$a].gate.transitions["next->ring0"].sample_fraction_permille == 250' "$RINGS" >/dev/null
+    # waive_sample_if_no_caller covers dependabot-rebase's missing .github-private caller
+    # (the "soak starts at ring0" note): a next tier with zero callers waives the fresh sample.
+    jq -e --arg a "$a" '.agents[$a].gate.transitions["next->ring0"].waive_sample_if_no_caller == true' "$RINGS" >/dev/null
+    jq -e --arg a "$a" '.agents[$a].gate.transitions["ring0->ring1"].dwell_hours == 8' "$RINGS" >/dev/null
+    jq -e --arg a "$a" '.agents[$a].gate.transitions["ring0->ring1"].waive_sample == true' "$RINGS" >/dev/null
+    jq -e --arg a "$a" '.agents[$a].gate.transitions["ring1->stable"].dwell_hours == 12' "$RINGS" >/dev/null
+    jq -e --arg a "$a" '.agents[$a].gate.transitions["ring1->stable"].sample_min == 1' "$RINGS" >/dev/null
+    jq -e --arg a "$a" '.agents[$a].gate.control.allow_pre_existing == false' "$RINGS" >/dev/null
+  done
+}
+
+@test "orchestrator: evaluate-all reports all 7 registered agents (dev-lead + the 6 #482)" {
+  _make_stub_bin
+  cat > "$STUB_BIN/gh" <<'GHEOF'
+#!/usr/bin/env bash
+case "$*" in
+  *"run list"*) echo "[]" ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN/gh"
+  run env CANARY_RINGS="$RINGS" bash "$ORCH" evaluate-all
+  [ "$status" -eq 0 ]
+  for a in dev-lead $_REUSABLES_482; do
+    [[ "$output" == *"agent: $a"* ]]
+  done
+}

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -498,7 +498,8 @@ GHEOF
   STUB_BIN="$(mktemp -d)"; export PATH="$STUB_BIN:$PATH"
   cat > "$STUB_BIN/git" <<'GITEOF'
 #!/usr/bin/env bash
-: ; GITEOF
+:
+GITEOF
   chmod +x "$STUB_BIN/git"
   # Different blob sha for cand vs prior → differs=1 (candidate regression possible).
   cat > "$STUB_BIN/gh" <<'GHEOF'

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -431,6 +431,109 @@ _benign_stub() {
   [[ "$output" == *"REGRESSION"* ]]
 }
 
+# ── orchestrator: cross-repo agent support (gh api stubs) ──────────────────────
+# For agents whose host != petry-projects/.github-private (i.e. the six #482 reusables),
+# channel_commit, candidate_cut_date, _reusable_differs, promote, and rollback must
+# use gh api rather than local git. The stubs below simulate petry-projects/.github tags.
+_make_cross_repo_stub_bin() {
+  STUB_BIN="$(mktemp -d)"; export PATH="$STUB_BIN:$PATH"
+  # git: cross-repo channel tags live in petry-projects/.github, not locally.
+  cat > "$STUB_BIN/git" <<'GITEOF'
+#!/usr/bin/env bash
+case "$*" in
+  *"for-each-ref"*) : ;;
+  *"rev-parse"*) : ;;
+  *) : ;;
+esac
+GITEOF
+  chmod +x "$STUB_BIN/git"
+  # gh: stub api calls for petry-projects/.github tag/commit/blob lookups.
+  # agent-shield/next → annotated tag object tagobj1111 → commit cccc...
+  # agent-shield/{ring0,ring1,stable} → lightweight ref pointing to bbbb...
+  cat > "$STUB_BIN/gh" <<'GHEOF'
+#!/usr/bin/env bash
+args="$*"
+case "$args" in
+  api*"repos/petry-projects/.github/git/ref/tags/agent-shield/next"*)
+    echo '{"object":{"sha":"tagobj1111111111111111111111111111111111","type":"tag"}}' ;;
+  api*"repos/petry-projects/.github/git/tags/tagobj"*)
+    echo '{"object":{"sha":"cccccccccccccccccccccccccccccccccccccccc"}}' ;;
+  api*"repos/petry-projects/.github/git/ref/tags/agent-shield/"*)
+    echo '{"object":{"sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","type":"commit"}}' ;;
+  api*"repos/petry-projects/.github/commits/"*)
+    echo '{"commit":{"committer":{"date":"2026-07-01T10:00:00Z"}}}' ;;
+  api*"repos/petry-projects/.github/contents/"*)
+    echo '{"sha":"blobAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}' ;;
+  api*"repos/petry-projects/.github/git/ref/tags/"*)
+    echo '{"object":{"sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","type":"commit"}}' ;;
+  *"run list"*) echo "[]" ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN/gh"
+}
+
+@test "orchestrator: channel_commit uses gh api for cross-repo agents" {
+  # agent-shield's channel tags live in petry-projects/.github; local git has nothing.
+  _make_cross_repo_stub_bin
+  run bash -c "source '$ORCH' && CANARY_RINGS='$RINGS' channel_commit agent-shield next"
+  [ "$status" -eq 0 ]
+  [ "$output" = "cccccccccccccccccccccccccccccccccccccccc" ]
+}
+
+@test "orchestrator: _reusable_differs uses gh api contents endpoint for cross-repo agents" {
+  # Both blobs return the same sha → differs=0 (no regression introduced).
+  _make_cross_repo_stub_bin
+  run bash -c "
+    source '$ORCH'
+    CANARY_RINGS='$RINGS' _reusable_differs agent-shield \
+      cccccccccccccccccccccccccccccccccccccccc \
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "0" ]
+}
+
+@test "orchestrator: _reusable_differs returns 1 when cross-repo blob changes" {
+  STUB_BIN="$(mktemp -d)"; export PATH="$STUB_BIN:$PATH"
+  cat > "$STUB_BIN/git" <<'GITEOF'
+#!/usr/bin/env bash
+: ; GITEOF
+  chmod +x "$STUB_BIN/git"
+  # Different blob sha for cand vs prior → differs=1 (candidate regression possible).
+  cat > "$STUB_BIN/gh" <<'GHEOF'
+#!/usr/bin/env bash
+case "$*" in
+  api*"?ref=cccc"*) echo '{"sha":"blobAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}' ;;
+  api*"?ref=bbbb"*) echo '{"sha":"blobBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"}' ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN/gh"
+  run bash -c "
+    source '$ORCH'
+    CANARY_RINGS='$RINGS' _reusable_differs agent-shield cccc bbbb
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+}
+
+@test "orchestrator: evaluate for cross-repo agent-shield resolves channel tags via gh api" {
+  _make_cross_repo_stub_bin
+  run env CANARY_RINGS="$RINGS" bash "$ORCH" evaluate agent-shield
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"agent-shield"* ]]
+  [[ "$output" == *"next"* ]]
+}
+
+@test "orchestrator: promote --override --dry-run for cross-repo agent-shield uses gh api path" {
+  _make_cross_repo_stub_bin
+  run env CANARY_RINGS="$RINGS" bash "$ORCH" promote agent-shield --override --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY-RUN"* ]]
+  [[ "$output" == *"petry-projects/.github"* ]]
+}
+
 @test "orchestrator: a non-allowlisted failure (reusable unchanged) still BLOCKS as PRE_EXISTING" {
   # Failed step matches no benign class → counted → BLOCKED, triaged PRE_EXISTING.
   _benign_stub 3 2 "Compile TypeScript" 0


### PR DESCRIPTION
Closes #1036

Implemented by dev-lead agent. Please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added additional rollout configurations for several automated agents, expanding canary coverage across multiple release channels.
  * Improved cross-repo rollout handling for reusable workflows, with clearer channel membership and transition behavior.

* **Tests**
  * Added broader validation for the new rollout configurations, including ring membership, workflow registration, and gate settings.
  * Extended end-to-end coverage to confirm all supported agents are included in the rollout evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->