### PR TITLE
ci(canary-rollout): list all registry agents in the dispatch input (#1045 part a)

### DIFF
--- a/.github/workflows/canary-rollout.yml
+++ b/.github/workflows/canary-rollout.yml
@@ -35,7 +35,7 @@ on:
       agent:
         description: "agent to act on"
         type: choice
-        options: [dev-lead]
+        options: [dev-lead, agent-shield, auto-rebase, dependency-audit, dependabot-automerge, dependabot-rebase, pr-review-mention]
         default: dev-lead
       override:
         description: "promote: advance even if the gate is not PROMOTE (records a warning)"


### PR DESCRIPTION
Expands the `agent` workflow_dispatch choice from `[dev-lead]` to all 7 registry agents so manual `evaluate`/`promote`/`rollback` can target the 6 #482 reusables. Unblocks running the workflow to confirm promote-readiness. The gated **scheduled auto-promote** (#1045 part b, decision A) is still dev-lead's to build.

Refs #1045, #1044.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the manual rollout options to include several additional agent selections, giving operators more flexibility when starting a canary rollout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->