### PR TITLE
feat: implement issue #1049 — canary-rollout evaluate mis-reports all 6 cross-repo (#482) reusables as 'fully rolled out' — reads local tags, not .github

### DIFF
--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -79,11 +79,11 @@ resolve_members() {
 # gh_release_commit). Empty on any error / absent tag (never fails the caller).
 _gh_tag_commit() {
   local repo="$1" tag="$2" ref_info obj type
-  ref_info="$(gh api "repos/$repo/git/ref/tags/$tag" --jq '.object.sha + " " + .object.type' 2>/dev/null)" || return 0
+  ref_info="$(gh api "repos/$repo/git/ref/tags/$tag" --jq '[(.object?.sha // "" | tostring), (.object?.type // "" | tostring)] | @tsv' 2>/dev/null)" || return 0
   [ -z "$ref_info" ] && return 0
   read -r obj type <<< "$ref_info"
   if [ "$type" = "tag" ]; then
-    gh api "repos/$repo/git/tags/$obj" --jq '.object.sha' 2>/dev/null || true
+    gh api "repos/$repo/git/tags/$obj" --jq '(.object?.sha // "" | tostring)' 2>/dev/null || true
   else
     printf '%s\n' "$obj"
   fi
@@ -137,13 +137,13 @@ _gh_candidate_cut_date() {
     [ -z "$obj" ] && continue
     if [ "$type" = "tag" ]; then
       IFS=$'\t' read -r csha cdate < <(gh api "repos/$repo/git/tags/$obj" \
-        --jq '[.object.sha, .tagger.date] | @tsv' 2>/dev/null) || true
+        --jq '[(.object?.sha // "" | tostring), (.tagger?.date // "" | tostring)] | @tsv' 2>/dev/null) || true
     else
       csha="$obj"; cdate=""
     fi
     if [ "$csha" = "$commit" ]; then _to_z "$cdate"; return 0; fi
   done < <(gh api "repos/$repo/git/matching-refs/tags/$agent/v" \
-             --jq '.[] | [.ref, .object.sha, .object.type] | @tsv' 2>/dev/null)
+             --jq '.[]? | [.ref, (.object?.sha // "" | tostring), (.object?.type // "" | tostring)] | @tsv' 2>/dev/null)
   echo ""
 }
 

--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -37,6 +37,14 @@ source "${_HERE}/lib/canary-rollout.sh"
 DEFAULT_RINGS="$(cd "${_HERE}/.." && pwd)/standards/canary-rings.json"
 CANARY_RINGS="${CANARY_RINGS:-$DEFAULT_RINGS}"
 
+# THIS_REPO — the repo this checkout belongs to. Agents hosted HERE (dev-lead, pr-review)
+# keep their channel/release tags in this checkout and resolve them via local git. A
+# cross-repo agent (host != THIS_REPO, e.g. the #482 reusables hosted in petry-projects/
+# .github) keeps its <name>/<channel> and <name>/vX.Y.Z tags on ITS host, so those tags
+# must be resolved there via `gh api` — reading local refs resolves empty and the frontier
+# falsely reports "fully rolled out" (#1049). Mirrors cut-release.sh's CROSS_REPO_TARGET.
+THIS_REPO="petry-projects/.github-private"
+
 _jq()  { jq "$@" "$CANARY_RINGS"; }
 _agent_field() { _jq -r --arg a "$1" ".agents[\$a].$2"; }
 
@@ -66,11 +74,35 @@ resolve_members() {
   return 0
 }
 
-# channel_commit <agent> <channel> — commit a channel tag resolves to (short-circuits
-# to empty if the tag does not exist).
+# _gh_tag_commit <repo> <tag> — echo the COMMIT sha <tag> resolves to on <repo> via the
+# GitHub API, dereferencing an annotated tag object (mirrors cut-release.sh's
+# gh_release_commit). Empty on any error / absent tag (never fails the caller).
+_gh_tag_commit() {
+  local repo="$1" tag="$2" ref_info obj type
+  ref_info="$(gh api "repos/$repo/git/ref/tags/$tag" --jq '.object.sha + " " + .object.type' 2>/dev/null)" || return 0
+  [ -z "$ref_info" ] && return 0
+  read -r obj type <<< "$ref_info"
+  if [ "$type" = "tag" ]; then
+    gh api "repos/$repo/git/tags/$obj" --jq '.object.sha' 2>/dev/null || true
+  else
+    printf '%s\n' "$obj"
+  fi
+}
+
+# channel_commit <agent> <channel> — commit the channel tag <agent>/<channel> resolves to
+# (empty if the tag does not exist). Agents hosted in THIS repo resolve against the local
+# checkout; a cross-repo agent's channel tags live on ITS host, so they are resolved there
+# via the GitHub API — reading local refs resolves empty and the frontier falsely reports
+# "fully rolled out" (#1049).
 channel_commit() {
-  git rev-parse -q --verify "refs/tags/$1/$2^{commit}" 2>/dev/null \
-    || git rev-parse -q --verify "$1/$2^{commit}" 2>/dev/null || true
+  local agent="$1" channel="$2" host
+  host="$(_agent_field "$agent" host)"
+  if [ -n "$host" ] && [ "$host" != "$THIS_REPO" ]; then
+    _gh_tag_commit "$host" "$agent/$channel"
+    return 0
+  fi
+  git rev-parse -q --verify "refs/tags/$agent/$channel^{commit}" 2>/dev/null \
+    || git rev-parse -q --verify "$agent/$channel^{commit}" 2>/dev/null || true
 }
 
 # _gate_field <agent> <field> — read .agents[a].gate.<field> (empty if absent).
@@ -95,12 +127,39 @@ _epoch() {
     || echo 0
 }
 
+# _gh_candidate_cut_date <repo> <agent> <commit> — ISO-8601 Zulu tagger date of the
+# release tag <agent>/vX.Y.Z on <repo> whose (dereferenced) commit equals <commit>. The
+# cross-repo analogue of the local for-each-ref path: a cross-repo agent's release tags
+# live on its host, not this checkout (#1049). Empty if no matching release tag is found.
+_gh_candidate_cut_date() {
+  local repo="$1" agent="$2" commit="$3" obj type csha cdate
+  while IFS=$'\t' read -r _ obj type; do
+    [ -z "$obj" ] && continue
+    if [ "$type" = "tag" ]; then
+      IFS=$'\t' read -r csha cdate < <(gh api "repos/$repo/git/tags/$obj" \
+        --jq '[.object.sha, .tagger.date] | @tsv' 2>/dev/null) || true
+    else
+      csha="$obj"; cdate=""
+    fi
+    if [ "$csha" = "$commit" ]; then _to_z "$cdate"; return 0; fi
+  done < <(gh api "repos/$repo/git/matching-refs/tags/$agent/v" \
+             --jq '.[] | [.ref, .object.sha, .object.type] | @tsv' 2>/dev/null)
+  echo ""
+}
+
 # candidate_cut_date <agent> <candidate_commit> — ISO-8601 Zulu tagger date of the
 # immutable release tag <agent>/vX.Y.Z that points at the candidate commit. This is the
 # per-candidate cumulative-window start (#548): health is measured since the candidate's
 # OWN cut, NOT a rolling window — so a pre-cut failure of a prior version is excluded.
+# For a cross-repo agent (host != THIS_REPO) the release tags live on the host, so the
+# date is resolved there via the GitHub API instead of the local for-each-ref (#1049).
 candidate_cut_date() {
-  local agent="$1" commit="$2" obj deref cdate c
+  local agent="$1" commit="$2" host obj deref cdate c
+  host="$(_agent_field "$agent" host)"
+  if [ -n "$host" ] && [ "$host" != "$THIS_REPO" ]; then
+    _gh_candidate_cut_date "$host" "$agent" "$commit"
+    return 0
+  fi
   while IFS='|' read -r obj deref cdate; do
     c="$deref"; [ -z "$c" ] && c="$obj"
     if [ "$c" = "$commit" ]; then _to_z "$cdate"; return 0; fi

--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -43,7 +43,7 @@ CANARY_RINGS="${CANARY_RINGS:-$DEFAULT_RINGS}"
 # .github) keeps its <name>/<channel> and <name>/vX.Y.Z tags on ITS host, so those tags
 # must be resolved there via `gh api` — reading local refs resolves empty and the frontier
 # falsely reports "fully rolled out" (#1049). Mirrors cut-release.sh's CROSS_REPO_TARGET.
-THIS_REPO="petry-projects/.github-private"
+THIS_REPO="${GITHUB_REPOSITORY:-petry-projects/.github-private}"
 
 _jq()  { jq "$@" "$CANARY_RINGS"; }
 _agent_field() { _jq -r --arg a "$1" ".agents[\$a].$2"; }

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -259,8 +259,8 @@ _graduated_stub() {
   local cut_days="$1" run_days_ago="$2" conclusion="$3" reusable_diff="$4"
   STUB_BIN="$(mktemp -d)"; export PATH="$STUB_BIN:$PATH"
   local cut_iso run_iso
-  cut_iso="$(date -u -d "-${cut_days} days" +%Y-%m-%dT%H:%M:%SZ)"
-  run_iso="$(date -u -d "-${run_days_ago} days" +%Y-%m-%dT%H:%M:%SZ)"
+  cut_iso="$(date -u -d "-${cut_days} days" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v"-${cut_days}d" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+  run_iso="$(date -u -d "-${run_days_ago} days" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v"-${run_days_ago}d" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
   # gh: every run-list query returns 20 runs at run_iso with the given conclusion.
   {
     echo '#!/usr/bin/env bash'
@@ -379,8 +379,8 @@ _benign_stub() {
   local cut_days="$1" run_days_ago="$2" step="$3" reusable_diff="$4"
   STUB_BIN="$(mktemp -d "$BATS_TEST_TMPDIR/stub.XXXXXX")"; export PATH="$STUB_BIN:$PATH"
   local cut_iso run_iso
-  cut_iso="$(date -u -d "-${cut_days} days" +%Y-%m-%dT%H:%M:%SZ)"
-  run_iso="$(date -u -d "-${run_days_ago} days" +%Y-%m-%dT%H:%M:%SZ)"
+  cut_iso="$(date -u -d "-${cut_days} days" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v"-${cut_days}d" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+  run_iso="$(date -u -d "-${run_days_ago} days" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v"-${run_days_ago}d" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
   {
     echo '#!/usr/bin/env bash'
     echo 'case "$*" in'
@@ -472,8 +472,8 @@ _crossrepo_stub() {
   local cand="cccccccccccccccccccccccccccccccccccccccc"
   local old="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
   local cut_iso run_iso
-  cut_iso="$(date -u -d "-${cut_days} days" +%Y-%m-%dT%H:%M:%SZ)"
-  run_iso="$(date -u -d "-${run_days_ago} days" +%Y-%m-%dT%H:%M:%SZ)"
+  cut_iso="$(date -u -d "-${cut_days} days" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v"-${cut_days}d" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+  run_iso="$(date -u -d "-${run_days_ago} days" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v"-${run_days_ago}d" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
   # gh: channel tags + the release tag are resolved via the API on the HOST repo; run-list
   # feeds the sample/health. --jq outputs are emitted pre-computed (the stub does not run jq).
   # The channel tags are lightweight (object.type=commit); the release tag is annotated

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -457,3 +457,57 @@ _benign_stub() {
   [[ "$output" != *"DRY-RUN"* ]]
   [[ "$output" == *"REGRESSION"* ]]
 }
+
+# ── orchestrator: cross-repo agents resolve tags on `host`, not the local checkout ─
+# (#1049) A cross-repo agent (host = petry-projects/.github) keeps its <name>/<channel>
+# and <name>/vX.Y.Z tags on the HOST repo, not this checkout. `evaluate` must resolve them
+# there via `gh api` (dereferencing annotated tags) — reading the LOCAL refs makes every
+# ring resolve empty → "all rings equal → fully rolled out", which would falsely SKIP a
+# cross-repo agent that is actually ring1 with stable on an old baseline (READY to promote).
+_crossrepo_stub() {
+  # next=ring0=ring1 on the candidate (cccc); stable on the OLD baseline (bbbb):
+  # frontier = stable, transition = ring1->stable — the ring1->stable promotion is pending.
+  local cut_days="$1" run_days_ago="$2" conclusion="$3"
+  STUB_BIN="$(mktemp -d "$BATS_TEST_TMPDIR/stub.XXXXXX")"; export PATH="$STUB_BIN:$PATH"
+  local cand="cccccccccccccccccccccccccccccccccccccccc"
+  local old="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  local cut_iso run_iso
+  cut_iso="$(date -u -d "-${cut_days} days" +%Y-%m-%dT%H:%M:%SZ)"
+  run_iso="$(date -u -d "-${run_days_ago} days" +%Y-%m-%dT%H:%M:%SZ)"
+  # gh: channel tags + the release tag are resolved via the API on the HOST repo; run-list
+  # feeds the sample/health. --jq outputs are emitted pre-computed (the stub does not run jq).
+  # The channel tags are lightweight (object.type=commit); the release tag is annotated
+  # (object.type=tag), so its commit + tagger date come from a second git/tags/<obj> call.
+  cat > "$STUB_BIN/gh" <<GHEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"git/ref/tags/auto-rebase/next"*)   echo "$cand commit" ;;
+  *"git/ref/tags/auto-rebase/ring0"*)  echo "$cand commit" ;;
+  *"git/ref/tags/auto-rebase/ring1"*)  echo "$cand commit" ;;
+  *"git/ref/tags/auto-rebase/stable"*) echo "$old commit" ;;
+  *"matching-refs/tags/auto-rebase/v"*) printf 'refs/tags/auto-rebase/v1.0.0\ttagobj\ttag\n' ;;
+  *"git/tags/tagobj"*) printf '%s\t%s\n' "$cand" "$cut_iso" ;;
+  *"run list"*) jq -nc --arg d "$run_iso" --arg c "$conclusion" '[range(20)|{conclusion:\$c,createdAt:\$d}]' ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN/gh"
+  # git: a cross-repo agent has NO local refs — every git call resolves empty. If the code
+  # regressed to the local path, channel_commit would be empty for every ring → the frontier
+  # would collapse to "fully rolled out" and this test would fail (that is exactly #1049).
+  cat > "$STUB_BIN/git" <<'GITEOF'
+#!/usr/bin/env bash
+: # no local refs for a cross-repo agent
+GITEOF
+  chmod +x "$STUB_BIN/git"
+}
+
+@test "orchestrator: cross-repo agent resolves channel+release tags on host → ring1->stable pending, NOT 'fully rolled out' (#1049)" {
+  # cut 2 days ago (dwell ≫ 12h), ring1 runs 1 day ago all success → sample ≥ 1, clean.
+  _crossrepo_stub 2 1 success
+  run env CANARY_RINGS="$RINGS" bash "$ORCH" evaluate auto-rebase
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"fully rolled out"* ]]
+  [[ "$output" == *"ring1->stable"* ]]
+  [[ "$output" == *"PROMOTE"* ]]
+}

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -466,7 +466,7 @@ _benign_stub() {
 # cross-repo agent that is actually ring1 with stable on an old baseline (READY to promote).
 _crossrepo_stub() {
   # next=ring0=ring1 on the candidate (cccc); stable on the OLD baseline (bbbb):
-  # frontier = stable, transition = ring1->stable — the ring1->stable promotion is pending.
+  # frontier = ring1, transition = ring1->stable — the ring1->stable promotion is pending.
   local cut_days="$1" run_days_ago="$2" conclusion="$3"
   STUB_BIN="$(mktemp -d "$BATS_TEST_TMPDIR/stub.XXXXXX")"; export PATH="$STUB_BIN:$PATH"
   local cand="cccccccccccccccccccccccccccccccccccccccc"
@@ -475,7 +475,8 @@ _crossrepo_stub() {
   cut_iso="$(date -u -d "-${cut_days} days" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v"-${cut_days}d" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
   run_iso="$(date -u -d "-${run_days_ago} days" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v"-${run_days_ago}d" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
   # gh: channel tags + the release tag are resolved via the API on the HOST repo; run-list
-  # feeds the sample/health. --jq outputs are emitted pre-computed (the stub does not run jq).
+  # feeds the sample/health. Channel/release tag responses are pre-computed strings; the
+  # run-list branch invokes jq to generate timestamped records from the injected parameters.
   # The channel tags are lightweight (object.type=commit); the release tag is annotated
   # (object.type=tag), so its commit + tagger date come from a second git/tags/<obj> call.
   cat > "$STUB_BIN/gh" <<GHEOF


### PR DESCRIPTION
Closes #1049

Implemented by dev-lead agent. Please review.