### PR TITLE
fix(pr-review): stop forwarding lsp_pilot_variant to the pinned reusable (restore reviews)

### DIFF
--- a/.github/workflows/pr-review-trigger.yml
+++ b/.github/workflows/pr-review-trigger.yml
@@ -83,7 +83,10 @@ jobs:
       pr_url: ${{ inputs.pr_url || '' }}
       dry_run: ${{ inputs.dry_run || '' }}
       force_review: ${{ inputs.force_review || '' }}
-      # Forward the LSP pilot A/B leg (empty for event triggers). 'none'/'' both
-      # mean today's behaviour on the reusable side.
-      lsp_pilot_variant: ${{ inputs.lsp_pilot_variant || '' }}
+      # NOTE: lsp_pilot_variant forwarding removed — the pinned reusable
+      # pr-review.yml@pr-review/next does not (yet) declare that input, so passing
+      # it fails workflow validation → startup_failure on every review dispatch
+      # (fleet-wide review outage, #1031/#1034 caller-vs-channel skew). Re-add
+      # this line only after the input is promoted to the pr-review/next reusable.
+      # The workflow_dispatch input above is retained (harmless, unused for now).
     secrets: inherit

--- a/tests/dev-lead/integration/test_pr_review_lsp_pilot_plumbing.py
+++ b/tests/dev-lead/integration/test_pr_review_lsp_pilot_plumbing.py
@@ -138,9 +138,13 @@ def check_trigger(fails: list[str]) -> None:
     job = _review_job(doc)
     with_block = job.get("with") or {}
     forwarded = str(with_block.get(INPUT, ""))
-    if not forwarded:
-        fails.append(f"{TRIGGER}: review job does not forward {INPUT} to the reusable (AC #5)")
-    elif f"inputs.{INPUT}" not in forwarded:
+    # Forwarding is intentionally absent while the pinned pr-review/next reusable
+    # does not yet declare lsp_pilot_variant (caller-vs-channel input skew — passing
+    # an undeclared input to a reusable is a workflow-validation error that causes
+    # startup_failure on every review dispatch). Absent forwarding is accepted here;
+    # when the input is promoted to the pr-review/next channel, re-add the with:
+    # line in pr-review-trigger.yml and tighten this check back to require it.
+    if forwarded and f"inputs.{INPUT}" not in forwarded:
         fails.append(
             f"{TRIGGER}: forwarded {INPUT} does not reference inputs.{INPUT} (got: {forwarded!r})"
         )
@@ -165,7 +169,8 @@ def main() -> int:
         return 1
 
     print("PASS: pr-review.yml exports the capture gate + variant and gates LSP wiring; "
-          "pr-review-trigger.yml declares and forwards lsp_pilot_variant")
+          "pr-review-trigger.yml declares lsp_pilot_variant (forwarding absent while "
+          "pinned channel lacks the input — see check_trigger comments)")
     return 0
 
 


### PR DESCRIPTION
## Fleet-wide PR-review outage — root cause + fix

**Symptom:** every PR-review dispatch has `startup_failure`d since ~03:16 UTC today; no PR can get a code-owner (donpetry-bot) review. Only the `PR Review Agent — Trigger` workflow is affected (all other workflows healthy).

**Root cause:** #1031/#1034 (`a492721ad`) added `lsp_pilot_variant: ${{ inputs.lsp_pilot_variant || '' }}` to the `with:` block that calls `pr-review.yml@pr-review/next`. That **channel-pinned reusable (last updated 2026-06-21) does not declare that input** — passing an undeclared input to a reusable is a workflow-file validation error → startup_failure on every dispatch (repository_dispatch / workflow_dispatch / check_suite). Caller-vs-channel skew.

**Fix:** remove only the forwarding line. The `workflow_dispatch` input definition is retained (valid `type: choice`, harmless while unused). Re-add the forwarding once the input is promoted to the `pr-review/next` reusable (then #1031's LSP-pilot A/B leg works end-to-end).

## ⚠️ Merge note
This restores the review pipeline, but **merging it requires the very review gate it fixes** — so it needs an **admin-merge / direct authorization** to break the cycle. CI on this PR should be green; the code-owner review will keep failing until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)