### PR TITLE
feat: implement issue #1054 — canary-rollout PROMOTE fails for cross-repo (#482) agents: uses local 'git tag -f', not host gh-api (companion to #1049)

### DIFF
--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -99,6 +99,10 @@ _gh_tag_commit() {
 # contents:write on <repo>.
 _gh_move_tag() {
   local repo="$1" tag="$2" sha="$3"
+  if [ -z "$repo" ] || [ -z "$tag" ] || [ -z "$sha" ]; then
+    echo "::error::_gh_move_tag requires three arguments: <repo> <tag> <sha>" >&2
+    return 1
+  fi
   if gh api "repos/$repo/git/ref/tags/$tag" >/dev/null 2>&1; then
     gh api -X PATCH "repos/$repo/git/refs/tags/$tag" -f "sha=$sha" -F "force=true" >/dev/null
   else

--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -98,11 +98,11 @@ _gh_tag_commit() {
 # gh_move_tag (the #959/#992 host-aware channel move). Requires GH_TOKEN with
 # contents:write on <repo>.
 _gh_move_tag() {
-  local repo="$1" tag="$2" sha="$3"
-  if [ -z "$repo" ] || [ -z "$tag" ] || [ -z "$sha" ]; then
-    echo "::error::_gh_move_tag requires three arguments: <repo> <tag> <sha>" >&2
-    return 1
+  if [ $# -lt 3 ]; then
+    echo "::error::_gh_move_tag requires repo, tag, and sha" >&2
+    return 2
   fi
+  local repo="$1" tag="$2" sha="$3"
   if gh api "repos/$repo/git/ref/tags/$tag" >/dev/null 2>&1; then
     gh api -X PATCH "repos/$repo/git/refs/tags/$tag" -f "sha=$sha" -F "force=true" >/dev/null
   else

--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -89,6 +89,23 @@ _gh_tag_commit() {
   fi
 }
 
+# _gh_move_tag <repo> <tag> <sha> — point refs/tags/<tag> at <sha> on <repo> via the
+# GitHub API (force-move if it exists, create if not). The host-aware promote-WRITE
+# analogue of channel_commit's host-aware READ (#1049): a cross-repo agent's channel tag
+# lives on ITS host and the candidate commit is not in this checkout's object DB, so a
+# local `git tag -f` cannot move it — it fails with "trying to write ref ... with
+# nonexistent object" and would target the wrong repo (#1054). Mirrors cut-release.sh's
+# gh_move_tag (the #959/#992 host-aware channel move). Requires GH_TOKEN with
+# contents:write on <repo>.
+_gh_move_tag() {
+  local repo="$1" tag="$2" sha="$3"
+  if gh api "repos/$repo/git/ref/tags/$tag" >/dev/null 2>&1; then
+    gh api -X PATCH "repos/$repo/git/refs/tags/$tag" -f "sha=$sha" -F "force=true" >/dev/null
+  else
+    gh api -X POST "repos/$repo/git/refs" -f "ref=refs/tags/$tag" -f "sha=$sha" >/dev/null
+  fi
+}
+
 # channel_commit <agent> <channel> — commit the channel tag <agent>/<channel> resolves to
 # (empty if the tag does not exist). Agents hosted in THIS repo resolve against the local
 # checkout; a cross-repo agent's channel tags live on ITS host, so they are resolved there
@@ -481,13 +498,28 @@ cmd_promote() {
   fi
   [ "$state" != "PROMOTE" ] && echo "::warning::advancing $agent/$frontier despite gate state '$state' (triage=$triage)"
   echo "advancing $agent/$frontier -> ${cand:0:12}"
-  if [ "$dry" = true ]; then
-    echo "[DRY-RUN] would: git tag -f $agent/$frontier $cand && git push --force origin $agent/$frontier"
-    return 0
+  # Host-aware write, mirroring the #1049 read split: a cross-repo agent's channel tag
+  # lives on ITS host and the candidate commit is not in this checkout, so the tag must
+  # be moved on the host via the GitHub API — a local `git tag -f` would fail on the
+  # nonexistent object and write to the wrong repo (#1054). This-repo agents (dev-lead,
+  # pr-review) keep the local tag path.
+  local host; host="$(_agent_field "$agent" host)"
+  if [ -n "$host" ] && [ "$host" != "$THIS_REPO" ]; then
+    if [ "$dry" = true ]; then
+      echo "[DRY-RUN] would: move tag $agent/$frontier -> $cand on $host via gh api"
+      return 0
+    fi
+    _gh_move_tag "$host" "$agent/$frontier" "$cand"
+    echo "promoted $agent/$frontier -> ${cand:0:12} on $host"
+  else
+    if [ "$dry" = true ]; then
+      echo "[DRY-RUN] would: git tag -f $agent/$frontier $cand && git push --force origin $agent/$frontier"
+      return 0
+    fi
+    git tag -f "$agent/$frontier" "$cand"
+    git push --force origin "$agent/$frontier"
+    echo "promoted $agent/$frontier -> ${cand:0:12}"
   fi
-  git tag -f "$agent/$frontier" "$cand"
-  git push --force origin "$agent/$frontier"
-  echo "promoted $agent/$frontier -> ${cand:0:12}"
   # Expose the move so the workflow can record a GitHub Deployment (traceability, #502).
   if [ -n "${GITHUB_OUTPUT:-}" ]; then
     { echo "promoted_agent=$agent"; echo "promoted_ring=$frontier"; echo "promoted_sha=$cand"; } >> "$GITHUB_OUTPUT"

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -512,3 +512,79 @@ GITEOF
   [[ "$output" == *"ring1->stable"* ]]
   [[ "$output" == *"PROMOTE"* ]]
 }
+
+# ── orchestrator: PROMOTING a cross-repo agent moves the tag on `host`, not local git ─
+# (#1054, companion to #1049) #1049 made tag *reads* host-aware, but the promote *write*
+# path still moved tags with local `git tag -f` + `git push origin`. For a cross-repo
+# agent (host = petry-projects/.github) the candidate commit is NOT in this checkout's
+# object DB and the channel tag lives on the HOST — so `git tag -f <agent>/stable <cand>`
+# fails with "trying to write ref ... with nonexistent object" (exit 128) and, even if it
+# didn't, would write to the WRONG repo. The write must go through the host GitHub API.
+# The git stub below FAILS on `tag -f`/`push`, so if the code regressed to the local path
+# these tests would exit non-zero — exactly the #1054 bug.
+_crossrepo_promote_stub() {
+  # next=ring0=ring1 on the candidate (cccc); stable on the OLD baseline (bbbb):
+  # frontier = ring1, transition = ring1->stable — the ring1->stable promotion is pending.
+  local cut_days="$1" run_days_ago="$2" conclusion="$3"
+  STUB_BIN="$(mktemp -d "$BATS_TEST_TMPDIR/stub.XXXXXX")"; export PATH="$STUB_BIN:$PATH"
+  MOVELOG="$STUB_BIN/move.log"
+  local cand="cccccccccccccccccccccccccccccccccccccccc"
+  local old="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  local cut_iso run_iso
+  cut_iso="$(date -u -d "-${cut_days} days" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v"-${cut_days}d" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+  run_iso="$(date -u -d "-${run_days_ago} days" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v"-${run_days_ago}d" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+  # gh: channel/release tag reads feed the gate (as in _crossrepo_stub); the tag MOVE
+  # comes in as a PATCH (existing tag) or POST (new tag) to git/refs on the HOST repo and
+  # is appended to MOVELOG. NOTE: reads use singular `git/ref/tags/...`, the move uses
+  # plural `git/refs/tags/...` — the patterns below are deliberately disjoint.
+  cat > "$STUB_BIN/gh" <<GHEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"-X PATCH"*"git/refs/tags/auto-rebase/stable"*) echo "\$*" >> "$MOVELOG"; echo "{}" ;;
+  *"-X POST"*"git/refs"*) echo "\$*" >> "$MOVELOG"; echo "{}" ;;
+  *"git/ref/tags/auto-rebase/next"*)   echo "$cand commit" ;;
+  *"git/ref/tags/auto-rebase/ring0"*)  echo "$cand commit" ;;
+  *"git/ref/tags/auto-rebase/ring1"*)  echo "$cand commit" ;;
+  *"git/ref/tags/auto-rebase/stable"*) echo "$old commit" ;;
+  *"matching-refs/tags/auto-rebase/v"*) printf 'refs/tags/auto-rebase/v1.0.0\ttagobj\ttag\n' ;;
+  *"git/tags/tagobj"*) printf '%s\t%s\n' "$cand" "$cut_iso" ;;
+  *"run list"*) jq -nc --arg d "$run_iso" --arg c "$conclusion" '[range(20)|{conclusion:\$c,createdAt:\$d}]' ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN/gh"
+  # git: a cross-repo agent has NO local refs and the candidate commit is not in this
+  # object DB — so any attempt to move/push the tag locally is the #1054 bug. Fail loudly.
+  cat > "$STUB_BIN/git" <<'GITEOF'
+#!/usr/bin/env bash
+case "$*" in
+  *"tag -f"*) echo "fatal: cannot update ref (nonexistent object)" >&2; exit 128 ;;
+  *"push"*)   echo "fatal: push to wrong repo" >&2; exit 128 ;;
+  *) : ;;   # reads for a cross-repo agent go through gh, not local git
+esac
+GITEOF
+  chmod +x "$STUB_BIN/git"
+}
+
+@test "orchestrator: promoting a cross-repo agent moves the channel tag on host via gh api, not local git (#1054)" {
+  _crossrepo_promote_stub 2 1 success
+  run env CANARY_RINGS="$RINGS" bash "$ORCH" promote auto-rebase
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"promoted auto-rebase/stable"* ]]
+  [[ "$output" == *"petry-projects/.github"* ]]
+  # the move went through the HOST GitHub API, targeting the candidate commit
+  run cat "$MOVELOG"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"git/refs/tags/auto-rebase/stable"* ]]
+  [[ "$output" == *"cccccccccccccccccccccccccccccccccccccccc"* ]]
+}
+
+@test "orchestrator: cross-repo promote --dry-run shows the host move but touches neither git nor the API (#1054)" {
+  _crossrepo_promote_stub 2 1 success
+  run env CANARY_RINGS="$RINGS" bash "$ORCH" promote auto-rebase --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY-RUN"* ]]
+  [[ "$output" == *"auto-rebase/stable"* ]]
+  [[ "$output" == *"petry-projects/.github"* ]]
+  [ ! -f "$MOVELOG" ]
+}


### PR DESCRIPTION
Closes #1054

Implemented by dev-lead agent. Please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Canary rollout promotions now handle cross-repo agents by updating tags on the configured host when needed.
  * Dry-run output now reflects whether a promotion would use a remote host or local Git flow.

* **Bug Fixes**
  * Improved tag promotion reliability for agents working outside the current repository.
  * Added coverage to ensure promotions target the expected commit and avoid unintended local writes in dry-run mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->