### PR TITLE
feat(canary-rollout): gated scheduled fleet auto-promote (#1045 part b) + host-aware cross-repo tag moves (#1054)

### DIFF
--- a/.github/workflows/canary-rollout.yml
+++ b/.github/workflows/canary-rollout.yml
@@ -15,10 +15,15 @@
 # is a HARD requirement: if the token cannot be minted the job fails — it must not
 # silently degrade to github.token, which cannot move protected `.github` tags (#868).
 #
-#   - schedule (every 4h): read-only `evaluate-all` ONLY — evaluates EVERY agent in
+#   - schedule (every 4h): the gated fleet auto-promote (#1045 part b). When the org
+#     variable CANARY_AUTO_PROMOTE == 'true' the timer runs `promote-all` — the gate
+#     advances each PROMOTE-ready agent one ring per run and leaves BLOCKED/REGRESSION
+#     agents untouched (human approval is OVERRIDE-ONLY, never a required gate). When the
+#     variable is unset/false it runs read-only `evaluate-all` — evaluates EVERY agent in
 #     canary-rings.json (fleet-wide, #1025 P1) and emits each one's per-version gate +
-#     health report (#502 observability). Never promotes on the timer.
-#   - workflow_dispatch: `evaluate` | `promote` | `rollback`, human-gated.
+#     health report (#502 observability). The arm variable is the single kill-switch.
+#   - workflow_dispatch: `evaluate` | `evaluate-all` | `promote` | `promote-all` |
+#     `rollback`, human-gated (promote/promote-all default to --dry-run).
 # ─────────────────────────────────────────────────────────────────────────────
 name: Canary Rollout
 
@@ -28,9 +33,9 @@ on:
   workflow_dispatch:
     inputs:
       command:
-        description: "evaluate (read-only) | promote (gated tag move) | rollback"
+        description: "evaluate | evaluate-all (read-only) | promote | promote-all (gated tag move) | rollback"
         type: choice
-        options: [evaluate, promote, rollback]
+        options: [evaluate, evaluate-all, promote, promote-all, rollback]
         default: evaluate
       agent:
         description: "agent to act on"
@@ -107,12 +112,16 @@ jobs:
       - name: Run canary-rollout
         id: run
         env:
-          # On the 4h timer, force read-only fleet-wide evaluate-all — never promote on a
-          # schedule, and evaluate EVERY agent in the registry, not just dev-lead (#1025 P1).
-          CMD: ${{ github.event_name == 'schedule' && 'evaluate-all' || github.event.inputs.command }}
+          # On the 4h timer the arm variable decides: CANARY_AUTO_PROMOTE=='true' runs the
+          # gated fleet auto-promote (promote-all, #1045 part b); anything else runs read-only
+          # fleet-wide evaluate-all (#1025 P1). Either way EVERY registry agent is covered, not
+          # just dev-lead. The gate — not the schedule — decides which agents actually advance.
+          CMD: ${{ github.event_name == 'schedule' && (vars.CANARY_AUTO_PROMOTE == 'true' && 'promote-all' || 'evaluate-all') || github.event.inputs.command }}
           AGENT: ${{ github.event.inputs.agent || 'dev-lead' }}
           OVERRIDE: ${{ github.event.inputs.override }}
-          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          # Scheduled promote-all is a REAL move (DRY_RUN=false); dispatch honours the input
+          # (which defaults to true — dispatch promote/promote-all are dry unless set false).
+          DRY_RUN: ${{ github.event_name == 'schedule' && 'false' || github.event.inputs.dry_run }}
           RING: ${{ github.event.inputs.ring }}
           TO: ${{ github.event.inputs.to }}
           # cut-release.sh (cross-repo tag moves on petry-projects/.github) and the
@@ -126,6 +135,11 @@ jobs:
             evaluate-all) args=(evaluate-all) ;;   # fleet-wide read-only (the 4h timer, #1025 P1)
             promote)
               args=(promote "$AGENT")
+              [ "$OVERRIDE" = "true" ] && args+=(--override)
+              [ "$DRY_RUN" != "false" ] && args+=(--dry-run)   # default-safe: dry unless explicitly false
+              ;;
+            promote-all)                                       # gated fleet auto-promote (the SCHEDULED arm, #1045b)
+              args=(promote-all)
               [ "$OVERRIDE" = "true" ] && args+=(--override)
               [ "$DRY_RUN" != "false" ] && args+=(--dry-run)   # default-safe: dry unless explicitly false
               ;;

--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -97,6 +97,7 @@ _gh_tag_commit() {
 # `git tag -f` fails with "nonexistent object" for a host commit absent from this checkout
 # (#1054). Tries PATCH (existing ref) then falls back to POST (create the ref).
 _gh_move_tag() {
+  [ $# -lt 3 ] && return 1
   local repo="$1" tag="$2" sha="$3"
   gh api -X PATCH "repos/$repo/git/refs/tags/$tag" \
       -f sha="$sha" -F force=true >/dev/null 2>&1 && return 0
@@ -500,7 +501,7 @@ cmd_promote() {
   # keeps its tags on ITS host and must move them there via gh api — local `git tag -f`
   # fails with "nonexistent object" for a host commit absent from this checkout (#1054).
   local host cross=false
-  host="$(_agent_field "$agent" host)"
+  host="$(_jq -r --arg a "$agent" '.agents[$a].host // "" | tostring')"
   [ -n "$host" ] && [ "$host" != "$THIS_REPO" ] && cross=true
   echo "advancing $agent/$frontier -> ${cand:0:12}$( [ "$cross" = true ] && echo " on $host" )"
   if [ "$dry" = true ]; then
@@ -515,8 +516,9 @@ cmd_promote() {
     _gh_move_tag "$host" "$agent/$frontier" "$cand" \
       || { echo "::error::failed to move $agent/$frontier -> ${cand:0:12} on $host" >&2; return 1; }
   else
-    git tag -f "$agent/$frontier" "$cand"
-    git push --force origin "$agent/$frontier"
+    git tag -f "$agent/$frontier" "$cand" \
+      && git push --force origin "$agent/$frontier" \
+      || { echo "::error::failed to move $agent/$frontier -> ${cand:0:12} locally" >&2; return 1; }
   fi
   echo "promoted $agent/$frontier -> ${cand:0:12}"
   # Expose the move so the workflow can record a GitHub Deployment (traceability, #502).
@@ -529,11 +531,12 @@ cmd_promote() {
 # auto-promote and the SCHEDULED arm of the automation (#1045 part b). Iterates every
 # registry agent and calls cmd_promote for each, so each PROMOTE-ready agent advances
 # exactly one ring per run while BLOCKED/REGRESSION agents are left untouched by the gate
-# (no --override here). A per-agent failure is logged and skipped so one agent cannot halt
-# the fleet sweep. Flags are forwarded verbatim to every cmd_promote.
+# unless --override is passed (the scheduled workflow never passes it). A per-agent
+# failure is logged and skipped so one agent cannot halt the fleet sweep. Flags are
+# forwarded verbatim to every cmd_promote.
 cmd_promote_all() {
   local agents rc=0 agent
-  agents="$(_jq -r '.agents | keys[]' 2>/dev/null || true)"
+  agents="$(_jq -r '.agents? | keys[]?' 2>/dev/null || true)"
   if [ -z "$agents" ]; then
     echo "no agents registered in $CANARY_RINGS — nothing to promote."; return 0
   fi
@@ -563,7 +566,7 @@ cmd_rollback() {
   # Host-aware, mirroring cmd_promote: a cross-repo agent's release + channel tags live on
   # ITS host, so both the target lookup and the move go through gh api, not local git (#1054).
   local host cross=false
-  host="$(_agent_field "$agent" host)"
+  host="$(_jq -r --arg a "$agent" '.agents[$a].host // "" | tostring')"
   [ -n "$host" ] && [ "$host" != "$THIS_REPO" ] && cross=true
   local target
   if [ "$cross" = true ]; then
@@ -585,8 +588,9 @@ cmd_rollback() {
     _gh_move_tag "$host" "$agent/$ring" "$target" \
       || { echo "::error::failed to move $agent/$ring -> $to on $host" >&2; return 1; }
   else
-    git tag -f "$agent/$ring" "$target"
-    git push --force origin "$agent/$ring"
+    git tag -f "$agent/$ring" "$target" \
+      && git push --force origin "$agent/$ring" \
+      || { echo "::error::failed to move $agent/$ring -> $to locally" >&2; return 1; }
   fi
   echo "rolled back $agent/$ring -> $to"
 }

--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 #   canary-rollout.sh evaluate     <agent>             # read-only gate + health report (also the #502 report)
 #   canary-rollout.sh evaluate-all                     # read-only evaluate for EVERY registry agent (fleet-wide; the 4h timer)
 #   canary-rollout.sh promote  <agent> [--override] [--allow-pre-existing] [--dry-run]
+#   canary-rollout.sh promote-all [--override] [--allow-pre-existing] [--dry-run]  # gated fleet auto-promote (the SCHEDULED arm, #1045b)
 #   canary-rollout.sh rollback <agent> <ring> --to <vX.Y.Z> [--dry-run]
 #   canary-rollout.sh resolve  <agent> <channel>       # debug: print resolved member repos
 #
@@ -89,25 +90,18 @@ _gh_tag_commit() {
   fi
 }
 
-# _gh_move_tag <repo> <tag> <sha> — point refs/tags/<tag> at <sha> on <repo> via the
-# GitHub API (force-move if it exists, create if not). The host-aware promote-WRITE
-# analogue of channel_commit's host-aware READ (#1049): a cross-repo agent's channel tag
-# lives on ITS host and the candidate commit is not in this checkout's object DB, so a
-# local `git tag -f` cannot move it — it fails with "trying to write ref ... with
-# nonexistent object" and would target the wrong repo (#1054). Mirrors cut-release.sh's
-# gh_move_tag (the #959/#992 host-aware channel move). Requires GH_TOKEN with
-# contents:write on <repo>.
+# _gh_move_tag <repo> <tag> <sha> — force-move (or create) the lightweight ref
+# refs/tags/<tag> on <repo> to <sha> via the GitHub API. The cross-repo counterpart of
+# `git tag -f <tag> <sha> && git push --force`: a cross-repo agent's channel tags live on
+# ITS host, so the promote/rollback move must go through gh api, not local git — local
+# `git tag -f` fails with "nonexistent object" for a host commit absent from this checkout
+# (#1054). Tries PATCH (existing ref) then falls back to POST (create the ref).
 _gh_move_tag() {
-  if [ $# -lt 3 ]; then
-    echo "::error::_gh_move_tag requires repo, tag, and sha" >&2
-    return 2
-  fi
   local repo="$1" tag="$2" sha="$3"
-  if gh api "repos/$repo/git/ref/tags/$tag" >/dev/null 2>&1; then
-    gh api -X PATCH "repos/$repo/git/refs/tags/$tag" -f "sha=$sha" -F "force=true" >/dev/null
-  else
-    gh api -X POST "repos/$repo/git/refs" -f "ref=refs/tags/$tag" -f "sha=$sha" >/dev/null
-  fi
+  gh api -X PATCH "repos/$repo/git/refs/tags/$tag" \
+      -f sha="$sha" -F force=true >/dev/null 2>&1 && return 0
+  gh api -X POST "repos/$repo/git/refs" \
+      -f ref="refs/tags/$tag" -f sha="$sha" >/dev/null 2>&1
 }
 
 # channel_commit <agent> <channel> — commit the channel tag <agent>/<channel> resolves to
@@ -501,33 +495,55 @@ cmd_promote() {
     return 0
   fi
   [ "$state" != "PROMOTE" ] && echo "::warning::advancing $agent/$frontier despite gate state '$state' (triage=$triage)"
-  echo "advancing $agent/$frontier -> ${cand:0:12}"
-  # Host-aware write, mirroring the #1049 read split: a cross-repo agent's channel tag
-  # lives on ITS host and the candidate commit is not in this checkout, so the tag must
-  # be moved on the host via the GitHub API — a local `git tag -f` would fail on the
-  # nonexistent object and write to the wrong repo (#1054). This-repo agents (dev-lead,
-  # pr-review) keep the local tag path.
-  local host; host="$(_agent_field "$agent" host)"
-  if [ -n "$host" ] && [ "$host" != "$THIS_REPO" ]; then
-    if [ "$dry" = true ]; then
-      echo "[DRY-RUN] would: move tag $agent/$frontier -> $cand on $host via gh api"
-      return 0
-    fi
-    _gh_move_tag "$host" "$agent/$frontier" "$cand"
-    echo "promoted $agent/$frontier -> ${cand:0:12} on $host"
-  else
-    if [ "$dry" = true ]; then
+  # Host-aware move: an agent hosted in THIS repo moves its channel tag via local git; a
+  # cross-repo agent (host != THIS_REPO, e.g. the #482 reusables on petry-projects/.github)
+  # keeps its tags on ITS host and must move them there via gh api — local `git tag -f`
+  # fails with "nonexistent object" for a host commit absent from this checkout (#1054).
+  local host cross=false
+  host="$(_agent_field "$agent" host)"
+  [ -n "$host" ] && [ "$host" != "$THIS_REPO" ] && cross=true
+  echo "advancing $agent/$frontier -> ${cand:0:12}$( [ "$cross" = true ] && echo " on $host" )"
+  if [ "$dry" = true ]; then
+    if [ "$cross" = true ]; then
+      echo "[DRY-RUN] would: gh api PATCH repos/$host/git/refs/tags/$agent/$frontier sha=$cand (force)"
+    else
       echo "[DRY-RUN] would: git tag -f $agent/$frontier $cand && git push --force origin $agent/$frontier"
-      return 0
     fi
+    return 0
+  fi
+  if [ "$cross" = true ]; then
+    _gh_move_tag "$host" "$agent/$frontier" "$cand" \
+      || { echo "::error::failed to move $agent/$frontier -> ${cand:0:12} on $host" >&2; return 1; }
+  else
     git tag -f "$agent/$frontier" "$cand"
     git push --force origin "$agent/$frontier"
-    echo "promoted $agent/$frontier -> ${cand:0:12}"
   fi
+  echo "promoted $agent/$frontier -> ${cand:0:12}"
   # Expose the move so the workflow can record a GitHub Deployment (traceability, #502).
   if [ -n "${GITHUB_OUTPUT:-}" ]; then
     { echo "promoted_agent=$agent"; echo "promoted_ring=$frontier"; echo "promoted_sha=$cand"; } >> "$GITHUB_OUTPUT"
   fi
+}
+
+# cmd_promote_all [--override] [--allow-pre-existing] [--dry-run] — the gated fleet
+# auto-promote and the SCHEDULED arm of the automation (#1045 part b). Iterates every
+# registry agent and calls cmd_promote for each, so each PROMOTE-ready agent advances
+# exactly one ring per run while BLOCKED/REGRESSION agents are left untouched by the gate
+# (no --override here). A per-agent failure is logged and skipped so one agent cannot halt
+# the fleet sweep. Flags are forwarded verbatim to every cmd_promote.
+cmd_promote_all() {
+  local agents rc=0 agent
+  agents="$(_jq -r '.agents | keys[]' 2>/dev/null || true)"
+  if [ -z "$agents" ]; then
+    echo "no agents registered in $CANARY_RINGS — nothing to promote."; return 0
+  fi
+  echo "== canary-rollout promote-all: fleet-wide (gate standard: .github#548) =="
+  while IFS= read -r agent; do
+    [ -z "$agent" ] && continue
+    echo "──────── agent: $agent ────────"
+    cmd_promote "$agent" "$@" || { rc=$?; echo "::warning::promote of $agent returned $rc (continuing fleet)"; }
+  done <<< "$agents"
+  return "$rc"
 }
 
 cmd_rollback() {
@@ -544,15 +560,34 @@ cmd_rollback() {
     esac; shift
   done
   [ -z "$to" ] && { echo "::error::rollback requires --to <vX.Y.Z>" >&2; return 2; }
-  local target; target="$(git rev-parse -q --verify "refs/tags/$agent/$to^{commit}" 2>/dev/null || true)"
+  # Host-aware, mirroring cmd_promote: a cross-repo agent's release + channel tags live on
+  # ITS host, so both the target lookup and the move go through gh api, not local git (#1054).
+  local host cross=false
+  host="$(_agent_field "$agent" host)"
+  [ -n "$host" ] && [ "$host" != "$THIS_REPO" ] && cross=true
+  local target
+  if [ "$cross" = true ]; then
+    target="$(_gh_tag_commit "$host" "$agent/$to")"
+  else
+    target="$(git rev-parse -q --verify "refs/tags/$agent/$to^{commit}" 2>/dev/null || true)"
+  fi
   [ -z "$target" ] && { echo "::error::release tag $agent/$to not found" >&2; return 1; }
-  echo "rolling back $agent/$ring -> $to (${target:0:12})"
+  echo "rolling back $agent/$ring -> $to (${target:0:12})$( [ "$cross" = true ] && echo " on $host" )"
   if [ "$dry" = true ]; then
-    echo "[DRY-RUN] would: git tag -f $agent/$ring $target && git push --force origin $agent/$ring"
+    if [ "$cross" = true ]; then
+      echo "[DRY-RUN] would: gh api PATCH repos/$host/git/refs/tags/$agent/$ring sha=$target (force)"
+    else
+      echo "[DRY-RUN] would: git tag -f $agent/$ring $target && git push --force origin $agent/$ring"
+    fi
     return 0
   fi
-  git tag -f "$agent/$ring" "$target"
-  git push --force origin "$agent/$ring"
+  if [ "$cross" = true ]; then
+    _gh_move_tag "$host" "$agent/$ring" "$target" \
+      || { echo "::error::failed to move $agent/$ring -> $to on $host" >&2; return 1; }
+  else
+    git tag -f "$agent/$ring" "$target"
+    git push --force origin "$agent/$ring"
+  fi
   echo "rolled back $agent/$ring -> $to"
 }
 
@@ -573,9 +608,10 @@ main() {
     evaluate)     [ $# -ge 1 ] || { echo "usage: evaluate <agent>" >&2; return 2; }; cmd_evaluate "$@" ;;
     evaluate-all) cmd_evaluate_all ;;
     promote)      [ $# -ge 1 ] || { echo "usage: promote <agent> [--override] [--allow-pre-existing] [--dry-run]" >&2; return 2; }; cmd_promote "$@" ;;
+    promote-all)  cmd_promote_all "$@" ;;
     rollback)     [ $# -ge 2 ] || { echo "usage: rollback <agent> <ring> --to <vX.Y.Z>" >&2; return 2; }; cmd_rollback "$@" ;;
     resolve)      [ $# -ge 2 ] || { echo "usage: resolve <agent> <channel>" >&2; return 2; }; resolve_members "$@" ;;
-    *) echo "::error::usage: canary-rollout.sh {evaluate|evaluate-all|promote|rollback|resolve} <agent> ..." >&2; return 2 ;;
+    *) echo "::error::usage: canary-rollout.sh {evaluate|evaluate-all|promote|promote-all|rollback|resolve} <agent> ..." >&2; return 2 ;;
   esac
 }
 

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -513,35 +513,69 @@ GITEOF
   [[ "$output" == *"PROMOTE"* ]]
 }
 
-# ── orchestrator: PROMOTING a cross-repo agent moves the tag on `host`, not local git ─
-# (#1054, companion to #1049) #1049 made tag *reads* host-aware, but the promote *write*
-# path still moved tags with local `git tag -f` + `git push origin`. For a cross-repo
-# agent (host = petry-projects/.github) the candidate commit is NOT in this checkout's
-# object DB and the channel tag lives on the HOST — so `git tag -f <agent>/stable <cand>`
-# fails with "trying to write ref ... with nonexistent object" (exit 128) and, even if it
-# didn't, would write to the WRONG repo. The write must go through the host GitHub API.
-# The git stub below FAILS on `tag -f`/`push`, so if the code regressed to the local path
-# these tests would exit non-zero — exactly the #1054 bug.
+# ── orchestrator: promote-all — the gated fleet auto-promote (the SCHEDULED arm, #1045b) ─
+@test "orchestrator: promote-all iterates every registry agent and forwards to promote (dry-run, no push)" {
+  _make_stub_bin
+  cat > "$STUB_BIN/gh" <<'GHEOF'
+#!/usr/bin/env bash
+case "$*" in
+  *"run list"*) echo "[]" ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN/gh"
+  local pushlog="$STUB_BIN/push.log"
+  # Reuse the dev-lead git stub but log any push so we can assert the sweep never mutates.
+  cat > "$STUB_BIN/git" <<GITEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"for-each-ref"*) : ;;
+  *"push"*) echo "\$*" >> "$pushlog" ;;
+  *) : ;;
+esac
+GITEOF
+  chmod +x "$STUB_BIN/git"
+
+  run env CANARY_RINGS="$RINGS" bash "$ORCH" promote-all --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"promote-all: fleet-wide"* ]]
+  # Every registry agent gets its own section (the loop covers the whole fleet, not dev-lead only).
+  [[ "$output" == *"agent: dev-lead"* ]]
+  [[ "$output" == *"agent: auto-rebase"* ]]
+  [[ "$output" == *"agent: pr-review-mention"* ]]
+  # A real move is never pushed under --dry-run.
+  [ ! -f "$pushlog" ]
+}
+
+# ── orchestrator: cross-repo promote MOVES the channel tag on the HOST via gh api (#1054) ─
+# A cross-repo agent (host = petry-projects/.github) keeps its channel tags on the host, so
+# the promote move must go through `gh api PATCH .../git/refs/tags/...`, NOT local `git tag -f`
+# (which fails "nonexistent object" for a host commit absent from this checkout — #1054).
+@test "orchestrator: cross-repo promote --dry-run shows the host gh-api move, not a local git tag (#1054)" {
+  _crossrepo_stub 2 1 success   # auto-rebase ring1->stable PROMOTE
+  run env CANARY_RINGS="$RINGS" bash "$ORCH" promote auto-rebase --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY-RUN"* ]]
+  [[ "$output" == *"gh api PATCH repos/petry-projects/.github/git/refs/tags/auto-rebase/stable"* ]]
+  [[ "$output" != *"git tag -f"* ]]
+}
+
 _crossrepo_promote_stub() {
-  # next=ring0=ring1 on the candidate (cccc); stable on the OLD baseline (bbbb):
-  # frontier = ring1, transition = ring1->stable — the ring1->stable promotion is pending.
+  # Like _crossrepo_stub but the gh stub LOGS any ref mutation (PATCH/POST) to $MOVE_LOG so
+  # a REAL promote can be asserted to move the tag on the host (never touching local git).
   local cut_days="$1" run_days_ago="$2" conclusion="$3"
   STUB_BIN="$(mktemp -d "$BATS_TEST_TMPDIR/stub.XXXXXX")"; export PATH="$STUB_BIN:$PATH"
-  MOVELOG="$STUB_BIN/move.log"
+  export MOVE_LOG="$STUB_BIN/move.log"
   local cand="cccccccccccccccccccccccccccccccccccccccc"
   local old="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
   local cut_iso run_iso
   cut_iso="$(date -u -d "-${cut_days} days" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v"-${cut_days}d" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
   run_iso="$(date -u -d "-${run_days_ago} days" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v"-${run_days_ago}d" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
-  # gh: channel/release tag reads feed the gate (as in _crossrepo_stub); the tag MOVE
-  # comes in as a PATCH (existing tag) or POST (new tag) to git/refs on the HOST repo and
-  # is appended to MOVELOG. NOTE: reads use singular `git/ref/tags/...`, the move uses
-  # plural `git/refs/tags/...` — the patterns below are deliberately disjoint.
   cat > "$STUB_BIN/gh" <<GHEOF
 #!/usr/bin/env bash
 case "\$*" in
-  *"-X PATCH"*"git/refs/tags/auto-rebase/stable"*) echo "\$*" >> "$MOVELOG"; echo "{}" ;;
-  *"-X POST"*"git/refs"*) echo "\$*" >> "$MOVELOG"; echo "{}" ;;
+  *"-X PATCH"*"git/refs/tags/"*) echo "\$*" >> "$MOVE_LOG"; echo "{}"; exit 0 ;;
+  *"-X POST"*"git/refs"*)        echo "\$*" >> "$MOVE_LOG"; echo "{}"; exit 0 ;;
   *"git/ref/tags/auto-rebase/next"*)   echo "$cand commit" ;;
   *"git/ref/tags/auto-rebase/ring0"*)  echo "$cand commit" ;;
   *"git/ref/tags/auto-rebase/ring1"*)  echo "$cand commit" ;;
@@ -553,30 +587,30 @@ case "\$*" in
 esac
 GHEOF
   chmod +x "$STUB_BIN/gh"
-  # git: a cross-repo agent has NO local refs and the candidate commit is not in this
-  # object DB — so any attempt to move/push the tag locally is the #1054 bug. Fail loudly.
-  cat > "$STUB_BIN/git" <<'GITEOF'
+  # A cross-repo agent has NO local refs; if the code regressed to `git tag -f`, this stub
+  # would record the attempt (and the move.log would stay empty) — the test would fail.
+  cat > "$STUB_BIN/git" <<GITEOF
 #!/usr/bin/env bash
-case "$*" in
-  *"tag -f"*) echo "fatal: cannot update ref (nonexistent object)" >&2; exit 128 ;;
-  *"push"*)   echo "fatal: push to wrong repo" >&2; exit 128 ;;
-  *) : ;;   # reads for a cross-repo agent go through gh, not local git
+case "\$*" in
+  *"tag -f"*|*"push"*) echo "LOCAL:\$*" >> "$MOVE_LOG" ;;
+  *) : ;;
 esac
 GITEOF
   chmod +x "$STUB_BIN/git"
 }
 
-@test "orchestrator: promoting a cross-repo agent moves the channel tag on host via gh api, not local git (#1054)" {
-  _crossrepo_promote_stub 2 1 success
-  run env CANARY_RINGS="$RINGS" bash "$ORCH" promote auto-rebase
+@test "orchestrator: cross-repo promote (real) moves the host channel tag via gh api + records the output (#1054)" {
+  _crossrepo_promote_stub 2 1 success   # auto-rebase ring1->stable PROMOTE
+  local out="$BATS_TEST_TMPDIR/gh_output"; : > "$out"
+  run env CANARY_RINGS="$RINGS" GITHUB_OUTPUT="$out" bash "$ORCH" promote auto-rebase
   [ "$status" -eq 0 ]
   [[ "$output" == *"promoted auto-rebase/stable"* ]]
-  [[ "$output" == *"petry-projects/.github"* ]]
-  # the move went through the HOST GitHub API, targeting the candidate commit
-  run cat "$MOVELOG"
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"git/refs/tags/auto-rebase/stable"* ]]
-  [[ "$output" == *"cccccccccccccccccccccccccccccccccccccccc"* ]]
+  # The move went through gh api PATCH on the HOST, never local git tag/push.
+  grep -q "PATCH repos/petry-projects/.github/git/refs/tags/auto-rebase/stable" "$MOVE_LOG"
+  ! grep -q "^LOCAL:" "$MOVE_LOG"
+  # The move is exposed for the workflow's GitHub Deployment step (#502).
+  grep -q "promoted_agent=auto-rebase" "$out"
+  grep -q "promoted_ring=stable" "$out"
 }
 
 @test "orchestrator: cross-repo promote --dry-run shows the host move but touches neither git nor the API (#1054)" {
@@ -586,5 +620,5 @@ GITEOF
   [[ "$output" == *"DRY-RUN"* ]]
   [[ "$output" == *"auto-rebase/stable"* ]]
   [[ "$output" == *"petry-projects/.github"* ]]
-  [ ! -f "$MOVELOG" ]
+  [ ! -f "$MOVE_LOG" ]
 }


### PR DESCRIPTION
## What & why

Closes **#1045 part b** (gated scheduled auto-promote — the timer advances the fleet, **no manual step**) and **#1054** (cross-repo PROMOTE failed with `nonexistent object`).

Part a (#1047) expanded the dispatch agent list. Part b makes the **schedule** do the promoting, gated by the soak standard (#548) — human approval is **override-only**, never a required gate.

## Automation (#1045b)
- **`promote-all`** (`cmd_promote_all`): iterates every registry agent and forwards to `cmd_promote`. Each PROMOTE-ready agent advances **one ring per run**; BLOCKED/REGRESSION agents are left untouched by the gate (no `--override` on the sweep). A per-agent failure is logged and skipped so one agent can't halt the fleet.
- **Workflow schedule**: runs the gated auto-promote when the org variable **`CANARY_AUTO_PROMOTE == 'true'`** (`promote-all`, real move), else read-only `evaluate-all`. The arm variable is the single **kill-switch**. Dispatch gains `evaluate-all`/`promote-all` options (promote-all defaults to `--dry-run`).

## Cross-repo fix (#1054)
- **`_gh_move_tag`**: force-move/create a channel tag on a cross-repo agent's **host** via `gh api` (PATCH then POST) — the counterpart of `git tag -f` + push.
- **`cmd_promote` / `cmd_rollback`** are now host-aware: THIS-repo agents move tags via local git; the 6 #482 reusables (hosted on `petry-projects/.github`) move via `gh api`. Local `git tag -f` failed with `nonexistent object <sha>` for a host commit absent from this checkout.

## Tests
+3 bats — promote-all fleet iteration; cross-repo promote dry-run takes the host gh-api path (not local git); real cross-repo promote moves the host tag via `gh api PATCH` + records `GITHUB_OUTPUT`. **55/55 passing.** `bash -n` + shellcheck clean; workflow YAML validated.

## Rollout after merge
1. Dispatch `promote-all` `dry_run=true` (observe verdicts), then `dry_run=false` — the two ring1→stable PROMOTE-ready reusables (`dependabot-automerge`, `dependabot-rebase`) advance on `petry-projects/.github` via cross-repo `gh api`.
2. Arm the timer: `gh variable set CANARY_AUTO_PROMOTE --org petry-projects --body true`. Kill-switch = unset/flip to false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)