### PR TITLE
fix(canary-rollout): record deployment on the promoted commit's host + per-promotion (#1059)

### DIFF
--- a/.github/workflows/canary-rollout.yml
+++ b/.github/workflows/canary-rollout.yml
@@ -127,6 +127,9 @@ jobs:
           # cut-release.sh (cross-repo tag moves on petry-projects/.github) and the
           # gate's cross-repo run-history reads both authenticate with the App token.
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # One TSV line per real promotion (agent, ring, sha, owning-repo) so the deployment
+          # step records a deployment for EVERY move in a promote-all run, on the right host.
+          CANARY_PROMOTIONS_LOG: ${{ runner.temp }}/promotions.tsv
         run: |
           set -euo pipefail
           args=()
@@ -153,25 +156,31 @@ jobs:
           echo "::notice::canary-rollout ${args[*]}"
           bash scripts/canary-rollout.sh "${args[@]}"
 
-      # Record a GitHub Deployment for a real (non-dry-run) promotion — traceability
-      # for the tag move (#502). Uses the same App token (Deployments:write).
-      - name: Record deployment for promotion
-        if: steps.run.outputs.promoted_ring != ''
+      # Record a GitHub Deployment per real (non-dry-run) promotion — traceability for the
+      # tag moves (#502). Reads the promotions log so a promote-all run records EVERY move,
+      # each on the repo that owns the moved commit (a cross-repo agent's SHA lives on its
+      # host, not GITHUB_REPOSITORY — creating it there 422s "No ref found", #1059).
+      # always() + best-effort per line: a traceability hiccup must never mark a SUCCESSFUL
+      # tag move as a failed run.
+      - name: Record deployment for promotions
+        if: always() && hashFiles(format('{0}/promotions.tsv', runner.temp)) != ''
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PROMOTED_AGENT: ${{ steps.run.outputs.promoted_agent }}
-          PROMOTED_RING: ${{ steps.run.outputs.promoted_ring }}
-          PROMOTED_SHA: ${{ steps.run.outputs.promoted_sha }}
+          CANARY_PROMOTIONS_LOG: ${{ runner.temp }}/promotions.tsv
         run: |
-          set -euo pipefail
-          gh api -X POST "repos/${GITHUB_REPOSITORY}/deployments" --input - <<JSON
+          set -uo pipefail
+          while IFS=$'\t' read -r agent ring sha repo; do
+            [ -z "${agent:-}" ] && continue
+            echo "recording deployment: ${agent}/${ring} -> ${sha:0:12} on ${repo}"
+            gh api -X POST "repos/${repo}/deployments" --input - <<JSON || echo "::warning::deployment record failed for ${agent}/${ring} on ${repo} (tag move already succeeded)"
           {
-            "ref": "${PROMOTED_SHA}",
-            "environment": "canary-${PROMOTED_AGENT}-${PROMOTED_RING}",
+            "ref": "${sha}",
+            "environment": "canary-${agent}-${ring}",
             "auto_merge": false,
             "required_contexts": [],
             "transient_environment": false,
             "production_environment": false,
-            "description": "canary-rollout promoted ${PROMOTED_AGENT}/${PROMOTED_RING} -> ${PROMOTED_SHA}"
+            "description": "canary-rollout promoted ${agent}/${ring} -> ${sha}"
           }
           JSON
+          done < "${CANARY_PROMOTIONS_LOG}"

--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -521,9 +521,20 @@ cmd_promote() {
       || { echo "::error::failed to move $agent/$frontier -> ${cand:0:12} locally" >&2; return 1; }
   fi
   echo "promoted $agent/$frontier -> ${cand:0:12}"
-  # Expose the move so the workflow can record a GitHub Deployment (traceability, #502).
+  # Expose the move for the workflow's GitHub Deployment (traceability, #502). The
+  # deployment must be created on the repo that OWNS the moved commit: a cross-repo agent's
+  # candidate SHA lives on its host, NOT on THIS_REPO — creating the deployment against
+  # GITHUB_REPOSITORY 422s with "No ref found" (#1059). So emit the owning repo too.
+  local deploy_repo="$THIS_REPO"; [ "$cross" = true ] && deploy_repo="$host"
+  # GITHUB_OUTPUT is single-valued (last write wins), fine for a single `promote`. For
+  # `promote-all` (many promotions per run) the workflow reads CANARY_PROMOTIONS_LOG — one
+  # TSV line per promotion — so it can record a deployment for EVERY move, not just the last.
   if [ -n "${GITHUB_OUTPUT:-}" ]; then
-    { echo "promoted_agent=$agent"; echo "promoted_ring=$frontier"; echo "promoted_sha=$cand"; } >> "$GITHUB_OUTPUT"
+    { echo "promoted_agent=$agent"; echo "promoted_ring=$frontier"
+      echo "promoted_sha=$cand";   echo "promoted_host=$deploy_repo"; } >> "$GITHUB_OUTPUT"
+  fi
+  if [ -n "${CANARY_PROMOTIONS_LOG:-}" ]; then
+    printf '%s\t%s\t%s\t%s\n' "$agent" "$frontier" "$cand" "$deploy_repo" >> "$CANARY_PROMOTIONS_LOG"
   fi
 }
 

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -602,7 +602,8 @@ GITEOF
 @test "orchestrator: cross-repo promote (real) moves the host channel tag via gh api + records the output (#1054)" {
   _crossrepo_promote_stub 2 1 success   # auto-rebase ring1->stable PROMOTE
   local out="$BATS_TEST_TMPDIR/gh_output"; : > "$out"
-  run env CANARY_RINGS="$RINGS" GITHUB_OUTPUT="$out" bash "$ORCH" promote auto-rebase
+  local plog="$BATS_TEST_TMPDIR/promotions.tsv"; : > "$plog"
+  run env CANARY_RINGS="$RINGS" GITHUB_OUTPUT="$out" CANARY_PROMOTIONS_LOG="$plog" bash "$ORCH" promote auto-rebase
   [ "$status" -eq 0 ]
   [[ "$output" == *"promoted auto-rebase/stable"* ]]
   # The move went through gh api PATCH on the HOST, never local git tag/push.
@@ -611,6 +612,12 @@ GITEOF
   # The move is exposed for the workflow's GitHub Deployment step (#502).
   grep -q "promoted_agent=auto-rebase" "$out"
   grep -q "promoted_ring=stable" "$out"
+  # promoted_host is the OWNING repo (the cross-repo host), so the deployment is created
+  # where the moved commit exists — not GITHUB_REPOSITORY, which would 422 "No ref found" (#1059).
+  grep -q "promoted_host=petry-projects/.github" "$out"
+  # The promotions log gets one TSV line per move (agent, ring, sha, owning-repo) so a
+  # promote-all run can record a deployment for EVERY promotion, not just the last.
+  grep -qP "^auto-rebase\tstable\t[0-9a-f]+\tpetry-projects/\.github$" "$plog"
 }
 
 @test "orchestrator: cross-repo promote --dry-run shows the host move but touches neither git nor the API (#1054)" {


### PR DESCRIPTION
Closes **#1059**.

## Context
The first live `promote-all` (#1045 part b) **promoted `dependabot-automerge/stable` + `dependabot-rebase/stable` successfully** (tags moved on petry-projects/.github via cross-repo `gh api`), but the job went **red** on the *Record deployment* step:
```
gh: No ref found for: b7e6b670... (HTTP 422)
```

## Root cause
The step created the Deployment on `${GITHUB_REPOSITORY}` (.github-private) with `ref=<promoted_sha>`. For a cross-repo agent (the #482 reusables) the SHA lives on the **host** (petry-projects/.github), not .github-private → 422. It also only recorded the **last** promotion of a `promote-all` run (`GITHUB_OUTPUT` last-wins).

## Fix
- `cmd_promote` emits `promoted_host` and appends one TSV line per move (`agent  ring  sha  host`) to `CANARY_PROMOTIONS_LOG`.
- The workflow step reads that log and records **one deployment per promotion on the correct host**, guarded (`|| ::warning`) and `if: always()` — a traceability hiccup can never fail a successful tag move.
- +2 test assertions (`promoted_host` output + promotions-log line). **56/56 bats passing**; `bash -n` + shellcheck clean; YAML validated; deployment loop dry-run verified against a fake `gh`.

No behaviour change to the tag moves themselves (those already succeeded). This makes scheduled `promote-all` runs go green.

Refs: #1045 (promote path) · #1054 (cross-repo move) · #495 / #502 (rollout + observability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)