### PR TITLE
feat: implement issue #1059 — canary-rollout: deployment-record step 422s for cross-repo promotions (creates on GITHUB_REPOSITORY, not the SHA's host) + only records the last of a promote-all

### DIFF
--- a/.github/workflows/canary-rollout.yml
+++ b/.github/workflows/canary-rollout.yml
@@ -127,6 +127,10 @@ jobs:
           # cut-release.sh (cross-repo tag moves on petry-projects/.github) and the
           # gate's cross-repo run-history reads both authenticate with the App token.
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # Per-move promotions log: cmd_promote appends one TSV line (agent ring sha host)
+          # per real move here, so the record step can create one Deployment per promotion on
+          # the correct host — GITHUB_OUTPUT alone is last-wins across a promote-all (#1059).
+          CANARY_PROMOTIONS_LOG: ${{ runner.temp }}/canary-promotions.tsv
         run: |
           set -euo pipefail
           args=()
@@ -153,25 +157,35 @@ jobs:
           echo "::notice::canary-rollout ${args[*]}"
           bash scripts/canary-rollout.sh "${args[@]}"
 
-      # Record a GitHub Deployment for a real (non-dry-run) promotion — traceability
-      # for the tag move (#502). Uses the same App token (Deployments:write).
-      - name: Record deployment for promotion
-        if: steps.run.outputs.promoted_ring != ''
+      # Record a GitHub Deployment per real promotion — traceability for the tag move (#502).
+      # Each promotion is a TSV line (agent<TAB>ring<TAB>sha<TAB>host) appended by cmd_promote;
+      # record ONE deployment per line ON THE OWNING HOST. A cross-repo candidate SHA lives on
+      # the host, not GITHUB_REPOSITORY, so recording it here would 422 "No ref found" (#1059).
+      # Guarded (|| ::warning) and `if: always()` so a traceability hiccup can never fail a run
+      # whose tag moves already succeeded. Uses the same App token (Deployments:write).
+      - name: Record deployments for promotions
+        if: always()
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PROMOTED_AGENT: ${{ steps.run.outputs.promoted_agent }}
-          PROMOTED_RING: ${{ steps.run.outputs.promoted_ring }}
-          PROMOTED_SHA: ${{ steps.run.outputs.promoted_sha }}
+          CANARY_PROMOTIONS_LOG: ${{ runner.temp }}/canary-promotions.tsv
         run: |
           set -euo pipefail
-          gh api -X POST "repos/${GITHUB_REPOSITORY}/deployments" --input - <<JSON
-          {
-            "ref": "${PROMOTED_SHA}",
-            "environment": "canary-${PROMOTED_AGENT}-${PROMOTED_RING}",
-            "auto_merge": false,
-            "required_contexts": [],
-            "transient_environment": false,
-            "production_environment": false,
-            "description": "canary-rollout promoted ${PROMOTED_AGENT}/${PROMOTED_RING} -> ${PROMOTED_SHA}"
-          }
-          JSON
+          log="${CANARY_PROMOTIONS_LOG}"
+          if [ ! -s "$log" ]; then
+            echo "no promotions recorded — nothing to deploy."
+            exit 0
+          fi
+          while IFS=$'\t' read -r agent ring sha host; do
+            [ -z "$sha" ] && continue
+            [ -z "$host" ] && host="${GITHUB_REPOSITORY}"
+            if jq -nc \
+                 --arg ref "$sha" \
+                 --arg env "canary-${agent}-${ring}" \
+                 --arg desc "canary-rollout promoted ${agent}/${ring} -> ${sha}" \
+                 '{ref:$ref, environment:$env, auto_merge:false, required_contexts:[], transient_environment:false, production_environment:false, description:$desc}' \
+               | gh api -X POST "repos/${host}/deployments" --input - >/dev/null; then
+              echo "recorded deployment: ${agent}/${ring} -> ${sha} on ${host}"
+            else
+              echo "::warning::deployment record failed for ${agent}/${ring} -> ${sha} on ${host} (tag move already succeeded; not failing the run — #1059)"
+            fi
+          done < "$log"

--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -521,9 +521,19 @@ cmd_promote() {
       || { echo "::error::failed to move $agent/$frontier -> ${cand:0:12} locally" >&2; return 1; }
   fi
   echo "promoted $agent/$frontier -> ${cand:0:12}"
+  # The repo that OWNS the moved commit: a cross-repo agent's candidate SHA lives on its
+  # host, a local agent's on THIS_REPO. The Deployment MUST be recorded there — creating it
+  # on GITHUB_REPOSITORY 422s ("No ref found") for a cross-repo SHA (#1059).
+  local promoted_host="${host:-$THIS_REPO}"
   # Expose the move so the workflow can record a GitHub Deployment (traceability, #502).
   if [ -n "${GITHUB_OUTPUT:-}" ]; then
-    { echo "promoted_agent=$agent"; echo "promoted_ring=$frontier"; echo "promoted_sha=$cand"; } >> "$GITHUB_OUTPUT"
+    { echo "promoted_agent=$agent"; echo "promoted_ring=$frontier"; echo "promoted_sha=$cand"; echo "promoted_host=$promoted_host"; } >> "$GITHUB_OUTPUT"
+  fi
+  # Append one TSV line per move (agent<TAB>ring<TAB>sha<TAB>host) so promote-all records a
+  # Deployment for EVERY promotion — GITHUB_OUTPUT is last-wins across a fleet sweep, so on
+  # its own it drops all but the final move (#1059).
+  if [ -n "${CANARY_PROMOTIONS_LOG:-}" ]; then
+    printf '%s\t%s\t%s\t%s\n' "$agent" "$frontier" "$cand" "$promoted_host" >> "$CANARY_PROMOTIONS_LOG"
   fi
 }
 

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -622,3 +622,29 @@ GITEOF
   [[ "$output" == *"petry-projects/.github"* ]]
   [ ! -f "$MOVE_LOG" ]
 }
+
+# ── traceability: promote emits the OWNING host + a per-move promotions-log line (#1059) ──
+# The Deployment must be recorded on the repo that owns the moved commit (the host), NOT on
+# GITHUB_REPOSITORY — a cross-repo candidate SHA lives on the host, so recording it on
+# .github-private 422s ("No ref found"). And promote-all does N moves but GITHUB_OUTPUT is
+# last-wins, so the per-move promotions log is what lets the workflow record EVERY deployment.
+@test "orchestrator: cross-repo promote emits promoted_host = the owning host (#1059)" {
+  _crossrepo_promote_stub 2 1 success   # auto-rebase ring1->stable PROMOTE
+  local out="$BATS_TEST_TMPDIR/gh_output"; : > "$out"
+  run env CANARY_RINGS="$RINGS" GITHUB_OUTPUT="$out" bash "$ORCH" promote auto-rebase
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"promoted auto-rebase/stable"* ]]
+  # promoted_host is the host that owns the moved commit, not GITHUB_REPOSITORY.
+  grep -q "promoted_host=petry-projects/.github" "$out"
+}
+
+@test "orchestrator: cross-repo promote appends one TSV promotions-log line per move (#1059)" {
+  _crossrepo_promote_stub 2 1 success   # auto-rebase ring1->stable PROMOTE
+  local plog="$BATS_TEST_TMPDIR/promotions.tsv"; : > "$plog"
+  run env CANARY_RINGS="$RINGS" CANARY_PROMOTIONS_LOG="$plog" bash "$ORCH" promote auto-rebase
+  [ "$status" -eq 0 ]
+  # Exactly one line: agent<TAB>ring<TAB>sha<TAB>host.
+  [ "$(wc -l < "$plog")" -eq 1 ]
+  local expected; expected="$(printf 'auto-rebase\tstable\tcccccccccccccccccccccccccccccccccccccccc\tpetry-projects/.github')"
+  [ "$(cat "$plog")" = "$expected" ]
+}


### PR DESCRIPTION
Closes #1059

Implemented by dev-lead agent. Please review.