### PR TITLE
feat(canary-rollout): auto-file blocker issues + rolling dashboard for held promotions (#1063)

### DIFF
--- a/.github/workflows/canary-rollout.yml
+++ b/.github/workflows/canary-rollout.yml
@@ -10,8 +10,9 @@
 # Auth: the mover credential is a GitHub App installation token minted at runtime via
 # actions/create-github-app-token from RELEASE_MANAGER_APP_CLIENT_ID (variable) + RELEASE_MANAGER_APP_KEY (secret) (scoped,
 # rotatable, auditable) — NOT a raw PAT and NOT github.token. The App carries
-# Contents:write (tag moves on the host repos), Deployments:write, Actions:read (the
-# gate reads workflow-run history across every tier repo) and Metadata:read. Minting
+# Contents:write (tag moves on the host repos), Deployments:write, Issues:write (the
+# blocker-issue + dashboard auto-triage, sync-issues), Actions:read (the gate reads
+# workflow-run history across every tier repo) and Metadata:read. Minting
 # is a HARD requirement: if the token cannot be minted the job fails — it must not
 # silently degrade to github.token, which cannot move protected `.github` tags (#868).
 #
@@ -22,8 +23,11 @@
 #     variable is unset/false it runs read-only `evaluate-all` — evaluates EVERY agent in
 #     canary-rings.json (fleet-wide, #1025 P1) and emits each one's per-version gate +
 #     health report (#502 observability). The arm variable is the single kill-switch.
+#     After promoting, the timer also runs `sync-issues`: it upserts one tracked issue per
+#     BLOCKED agent (failing-run evidence attached; REGRESSION → needs-human) and rewrites a
+#     single rolling dashboard issue — a cleared agent's issue auto-closes (auto-triage).
 #   - workflow_dispatch: `evaluate` | `evaluate-all` | `promote` | `promote-all` |
-#     `rollback`, human-gated (promote/promote-all default to --dry-run).
+#     `rollback` | `sync-issues`, human-gated (promote/promote-all/sync-issues default to --dry-run).
 # ─────────────────────────────────────────────────────────────────────────────
 name: Canary Rollout
 
@@ -33,9 +37,9 @@ on:
   workflow_dispatch:
     inputs:
       command:
-        description: "evaluate | evaluate-all (read-only) | promote | promote-all (gated tag move) | rollback"
+        description: "evaluate | evaluate-all (read-only) | promote | promote-all (gated tag move) | rollback | sync-issues"
         type: choice
-        options: [evaluate, evaluate-all, promote, promote-all, rollback]
+        options: [evaluate, evaluate-all, promote, promote-all, rollback, sync-issues]
         default: evaluate
       agent:
         description: "agent to act on"
@@ -151,6 +155,10 @@ jobs:
               args=(rollback "$AGENT" "$RING" --to "$TO")
               [ "$DRY_RUN" != "false" ] && args+=(--dry-run)
               ;;
+            sync-issues)                                       # upsert blocker issues + dashboard (auto-triage)
+              args=(sync-issues)
+              [ "$DRY_RUN" != "false" ] && args+=(--dry-run)   # default-safe: dry unless explicitly false
+              ;;
             *) echo "::error::unknown command: $CMD"; exit 2 ;;
           esac
           echo "::notice::canary-rollout ${args[*]}"
@@ -184,3 +192,18 @@ jobs:
           }
           JSON
           done < "${CANARY_PROMOTIONS_LOG}"
+
+      # Auto-triage: turn the gate's BLOCKED verdicts into tracked work. On the timer, from
+      # the post-promotion fleet state, upsert ONE idempotent issue per BLOCKED agent (with
+      # the failing-run evidence pre-attached; REGRESSION → needs-human) and rewrite a single
+      # rolling dashboard issue; a cleared agent's issue auto-closes. Best-effort + always():
+      # a GitHub-side hiccup must never fail the promotion run. Requires the App to carry
+      # Issues:write — if absent the step logs a warning and continues.
+      - name: Sync blocker + dashboard issues
+        if: always() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          ISSUE_REPO: ${{ github.repository }}
+        run: |
+          set -uo pipefail
+          bash scripts/canary-rollout.sh sync-issues || echo "::warning::issue sync failed (non-fatal)"

--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 #   canary-rollout.sh promote-all [--override] [--allow-pre-existing] [--dry-run]  # gated fleet auto-promote (the SCHEDULED arm, #1045b)
 #   canary-rollout.sh rollback <agent> <ring> --to <vX.Y.Z> [--dry-run]
 #   canary-rollout.sh resolve  <agent> <channel>       # debug: print resolved member repos
+#   canary-rollout.sh sync-issues [--dry-run]          # upsert a blocker issue per BLOCKED agent + a rolling dashboard (auto-triage)
 #
 # Gate standard: .github#548 — graduated per-transition dwell/sample floors over a
 # per-candidate cumulative window (since the candidate's OWN vX.Y.Z cut), a robust
@@ -606,6 +607,188 @@ cmd_rollback() {
   echo "rolled back $agent/$ring -> $to"
 }
 
+# ── blocker-issue + dashboard automation (auto-triage of held promotions) ───────
+# The gate detects + classifies a BLOCKED promotion; sync-issues turns that signal into
+# a tracked work item: one idempotent issue per BLOCKED agent (with the failing-run
+# evidence pre-attached), auto-closed when the gate clears, plus a single rolling
+# dashboard issue of fleet state. Runs on the schedule after promote-all. All GitHub
+# writes are best-effort — a failure here never fails the promotion run.
+ISSUE_REPO="${ISSUE_REPO:-$THIS_REPO}"
+
+# _issue_find <label> <marker> — "<number>\t<STATE>" of the newest issue carrying <marker>
+# in its body (matched locally over the label's issues, not GitHub search — HTML-comment
+# markers are not reliably indexed). Empty if none.
+_issue_find() {
+  local label="$1" marker="$2"
+  gh issue list --repo "$ISSUE_REPO" --label "$label" --state all -L 100 \
+      --json number,state,body 2>/dev/null \
+    | jq -r --arg m "$marker" \
+        '[.[] | select((.body // "") | contains($m))] | sort_by(.number) | last
+         | if . == null then "" else "\(.number)\t\(.state | ascii_upcase)" end' 2>/dev/null \
+    || echo ""
+}
+
+# _gh_issue_create <title> <body> <labels_csv> — create an issue, echo its number.
+_gh_issue_create() {
+  gh issue create --repo "$ISSUE_REPO" --title "$1" --body "$2" --label "$3" 2>/dev/null \
+    | grep -oE '[0-9]+$' | tail -1
+}
+
+# _blocker_evidence <agent> <candidate_commit> — markdown bullets for the in-window failing
+# runs (repo + run link + failed-step signature), capped at 8. Uses the SAME per-candidate
+# window + tier repos the gate counts, so the evidence matches cum_fail.
+_blocker_evidence() {
+  local agent="$1" cand="$2" wf cut_z repo json r n=0 out=""
+  wf="$(_agent_field "$agent" run_workflow)"
+  cut_z="$(candidate_cut_date "$agent" "$cand")"
+  [ -z "$cut_z" ] && { printf '_(no candidate cut date resolved — cannot list failing runs)_\n'; return 0; }
+  local chan_array=() ch all=() seen=" " dedup=()
+  IFS=, read -r -a chan_array <<< "$(ordered_channels "$agent")"
+  for ch in "${chan_array[@]}"; do
+    while IFS= read -r r; do [ -n "$r" ] && [ "$r" != '*' ] && all+=("$r"); done < <(resolve_members "$agent" "$ch")
+  done
+  for r in "${all[@]}"; do case "$seen" in *" $r "*) ;; *) dedup+=("$r"); seen+="$r ";; esac; done
+  for repo in "${dedup[@]}"; do
+    json="$(_run_json "$repo" "$wf" "$cut_z")"
+    local rid sig
+    while IFS= read -r rid; do
+      [ -z "$rid" ] && continue
+      if [ "$n" -ge 8 ]; then out+="- _(…more failing runs; truncated at 8)_"$'\n'; printf '%s' "$out"; return 0; fi
+      sig="$(_run_signature "$repo" "$rid" | tr '\n' ';' | sed 's/;$//')"
+      out+="- \`$repo\` — run [$rid](https://github.com/$repo/actions/runs/$rid); failed steps: ${sig:-unknown}"$'\n'
+      n=$((n+1))
+    done < <(jq -r '.[]?|select(.conclusion=="failure" or .conclusion=="startup_failure")|(.databaseId|tostring)' 2>/dev/null <<< "$json")
+  done
+  [ -z "$out" ] && out="_(no failing runs in the per-candidate window — cum_fail may be startup_failures or a transient count)_"$'\n'
+  printf '%s' "$out"
+}
+
+# _blocker_body <agent> <transition> <cand> <cum_fail> <cum_startup> <triage> <host> <evidence>
+_blocker_body() {
+  local agent="$1" transition="$2" cand="$3" cum_fail="$4" cum_startup="$5" triage="$6" host="$7" evidence="$8" note
+  if [ "$triage" = "REGRESSION" ]; then
+    note="> ⛔ **REGRESSION** — the candidate changed the reusable and a run failed since its cut. HALT + hold; investigate and roll back rather than \`--override\`. (labelled \`needs-human\`)"
+  else
+    note="> ⚠️ **PRE_EXISTING** — the failure is pre-existing/environmental (reusable byte-identical to the prior channel). Report only; the gate will not roll back or advance. Fix-forward, and the armed timer auto-promotes once clean."
+  fi
+  cat <<EOF
+<!-- canary-blocker:$agent -->
+**Automated canary-rollout blocker.** The release gate is holding \`$agent\` and will not promote it until this clears. Filed + maintained by the Canary Rollout workflow (gate standard: .github#548); this issue is **regenerated each run and auto-closes** when the gate passes — do not edit the table below by hand.
+
+| field | value |
+|---|---|
+| agent | \`$agent\` |
+| transition | \`$transition\` |
+| candidate | \`${cand:0:12}\` |
+| host repo | \`$host\` |
+| cumulative failures | **$cum_fail** (startup_failures: $cum_startup) |
+| triage | **$triage** |
+
+$note
+
+### Failing runs in the per-candidate window
+$evidence
+---
+_See the pinned **Canary Rollout — fleet status** dashboard issue (label \`canary-dashboard\`) for the whole fleet._
+EOF
+}
+
+# _dashboard_body <rows_md> <timestamp>
+_dashboard_body() {
+  cat <<EOF
+<!-- canary-dashboard -->
+# Canary Rollout — fleet status (auto)
+
+Regenerated by the Canary Rollout workflow each run — **do not edit by hand.**
+Last updated: \`$2\` · auto-promote armed: \`${CANARY_AUTO_PROMOTE:-unset}\` · gate standard: .github#548.
+
+| agent | state | transition | cum_fail | triage | blocker |
+|---|---|---|---|---|---|
+$1
+
+\`PROMOTE\`/\`COMPLETE\`/\`SOAKING\` need no action. \`BLOCKED\` opens a per-agent issue (label \`canary-blocker\`) with the failing-run evidence; it auto-closes when the gate clears.
+EOF
+}
+
+# cmd_sync_issues [--dry-run] — upsert one blocker issue per BLOCKED agent + rewrite the
+# dashboard. Idempotent (marker-keyed); auto-closes a cleared agent's issue. Best-effort:
+# never fails the run. Reads ISSUE_REPO (default THIS_REPO).
+cmd_sync_issues() {
+  local dry=false; [ "${1:-}" = "--dry-run" ] && dry=true
+  local agents; agents="$(_jq -r '.agents? | keys[]?' 2>/dev/null || true)"
+  [ -z "$agents" ] && { echo "no agents registered in $CANARY_RINGS — nothing to sync."; return 0; }
+  echo "== canary-rollout sync-issues: repo=$ISSUE_REPO dry=$dry (gate standard: .github#548) =="
+  if [ "$dry" != true ]; then
+    local lbl
+    for lbl in canary-blocker canary-dashboard; do
+      gh label create "$lbl" --repo "$ISSUE_REPO" --color ededed --description "canary-rollout automation" >/dev/null 2>&1 || true
+    done
+  fi
+  local rows="" agent
+  while IFS= read -r agent; do
+    [ -z "$agent" ] && continue
+    local cand frontier transition state _d _f _s _t cum_fail cum_startup _cb triage host
+    read -r cand frontier transition state _d _f _s _t cum_fail cum_startup _cb triage < <(_frontier_state "$agent")
+    host="$(_agent_field "$agent" host)"
+    local blk="—" num_state num istate
+    num_state="$(_issue_find canary-blocker "<!-- canary-blocker:$agent -->")"
+    num="${num_state%%$'\t'*}"; istate="${num_state##*$'\t'}"
+    if [ "$state" = "BLOCKED" ]; then
+      local evidence body title
+      evidence="$(_blocker_evidence "$agent" "$cand")"
+      body="$(_blocker_body "$agent" "$transition" "$cand" "$cum_fail" "$cum_startup" "$triage" "$host" "$evidence")"
+      title="Canary blocker: $agent $transition (cum_fail=$cum_fail, $triage)"
+      if [ -z "$num" ]; then
+        if [ "$dry" = true ]; then echo "  [DRY] would OPEN blocker issue for $agent ($triage)"; blk="(new)"; else
+          num="$(_gh_issue_create "$title" "$body" "canary-blocker")"
+          if [ -n "$num" ]; then
+            [ "$triage" = "REGRESSION" ] && gh issue edit "$num" --repo "$ISSUE_REPO" --add-label needs-human >/dev/null 2>&1 || true
+            echo "  opened blocker issue #$num for $agent"; blk="#$num"
+          else echo "::warning::could not open blocker issue for $agent (Issues:write on the App?)"; fi
+        fi
+      else
+        if [ "$dry" = true ]; then echo "  [DRY] would UPDATE blocker issue #$num for $agent"; blk="#$num"; else
+          [ "$istate" = "OPEN" ] || gh issue reopen "$num" --repo "$ISSUE_REPO" >/dev/null 2>&1 || true
+          gh issue edit "$num" --repo "$ISSUE_REPO" --title "$title" --body "$body" >/dev/null 2>&1 \
+            || echo "::warning::could not update blocker issue #$num for $agent"
+          [ "$triage" = "REGRESSION" ] && gh issue edit "$num" --repo "$ISSUE_REPO" --add-label needs-human >/dev/null 2>&1 || true
+          echo "  updated blocker issue #$num for $agent"; blk="#$num"
+        fi
+      fi
+    else
+      # Not blocked — close a stale open blocker issue (the gate cleared).
+      if [ -n "$num" ] && [ "$istate" = "OPEN" ]; then
+        if [ "$dry" = true ]; then echo "  [DRY] would CLOSE cleared blocker issue #$num for $agent ($state)"; else
+          gh issue close "$num" --repo "$ISSUE_REPO" \
+            --comment "✅ Gate cleared — \`$agent\` is now \`$state\`. Closed automatically by canary-rollout." >/dev/null 2>&1 || true
+          echo "  closed cleared blocker issue #$num for $agent"
+        fi
+        blk="#$num (closed)"
+      fi
+    fi
+    rows+="| \`$agent\` | $state | \`$transition\` | $cum_fail | $triage | $blk |"$'\n'
+  done <<< "$agents"
+
+  # Rewrite the single rolling dashboard.
+  local ts dbody dnum_state dnum distate
+  ts="$(date -u +%Y-%m-%dT%H:%MZ 2>/dev/null || echo unknown)"
+  dbody="$(_dashboard_body "${rows%$'\n'}" "$ts")"
+  dnum_state="$(_issue_find canary-dashboard "<!-- canary-dashboard -->")"
+  dnum="${dnum_state%%$'\t'*}"; distate="${dnum_state##*$'\t'}"
+  if [ "$dry" = true ]; then echo "  [DRY] would UPSERT dashboard issue";
+  elif [ -z "$dnum" ]; then
+    dnum="$(_gh_issue_create "Canary Rollout — fleet status (auto)" "$dbody" "canary-dashboard")"
+    if [ -n "$dnum" ]; then echo "  created dashboard issue #$dnum"; gh issue pin "$dnum" --repo "$ISSUE_REPO" >/dev/null 2>&1 || true
+    else echo "::warning::could not create dashboard issue (Issues:write on the App?)"; fi
+  else
+    [ "$distate" = "OPEN" ] || gh issue reopen "$dnum" --repo "$ISSUE_REPO" >/dev/null 2>&1 || true
+    gh issue edit "$dnum" --repo "$ISSUE_REPO" --body "$dbody" >/dev/null 2>&1 \
+      || echo "::warning::could not update dashboard issue #$dnum"
+    echo "  updated dashboard issue #$dnum"
+  fi
+  return 0
+}
+
 main() {
   local cmd
   for cmd in jq gh git; do
@@ -626,7 +809,8 @@ main() {
     promote-all)  cmd_promote_all "$@" ;;
     rollback)     [ $# -ge 2 ] || { echo "usage: rollback <agent> <ring> --to <vX.Y.Z>" >&2; return 2; }; cmd_rollback "$@" ;;
     resolve)      [ $# -ge 2 ] || { echo "usage: resolve <agent> <channel>" >&2; return 2; }; resolve_members "$@" ;;
-    *) echo "::error::usage: canary-rollout.sh {evaluate|evaluate-all|promote|promote-all|rollback|resolve} <agent> ..." >&2; return 2 ;;
+    sync-issues)  cmd_sync_issues "$@" ;;   # upsert blocker issues + dashboard for held promotions
+    *) echo "::error::usage: canary-rollout.sh {evaluate|evaluate-all|promote|promote-all|rollback|resolve|sync-issues} <agent> ..." >&2; return 2 ;;
   esac
 }
 

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -629,3 +629,81 @@ GITEOF
   [[ "$output" == *"petry-projects/.github"* ]]
   [ ! -f "$MOVE_LOG" ]
 }
+
+# ── orchestrator: sync-issues — auto-triage held promotions into tracked issues ──
+# A held (BLOCKED) promotion files/updates ONE idempotent issue per agent with the failing-run
+# evidence; a cleared agent's issue auto-closes; a single rolling dashboard is rewritten each
+# run. dev-lead-only registry keeps the fleet loop to one agent; the gh stub logs issue ops.
+_sync_stub() {
+  # $1 conclusion (failure→BLOCKED | success→cleared); $2 blocker-list JSON; $3 dashboard-list JSON
+  local concl="$1" blocker_list="${2:-[]}" dash_list="${3:-[]}"
+  STUB_BIN="$(mktemp -d "$BATS_TEST_TMPDIR/stub.XXXXXX")"; export PATH="$STUB_BIN:$PATH"
+  export ISSUE_LOG="$STUB_BIN/issue.log"; : > "$ISSUE_LOG"
+  local cut_iso run_iso
+  cut_iso="$(date -u -d '-3 days' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-3d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+  run_iso="$(date -u -d '-2 days' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-2d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+  cat > "$STUB_BIN/git" <<GITEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"for-each-ref"*) echo "cccccccccccccccccccccccccccccccccccccccc||$cut_iso" ;;
+  *"rev-parse"*"cccc"*":"*) echo "blobAAAA" ;;
+  *"rev-parse"*"bbbb"*":"*) echo "blobAAAA" ;;
+  *"rev-parse"*"dev-lead/next"*)   echo "cccccccccccccccccccccccccccccccccccccccc" ;;
+  *"rev-parse"*"dev-lead/ring0"*)  echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" ;;
+  *"rev-parse"*"dev-lead/ring1"*)  echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" ;;
+  *"rev-parse"*"dev-lead/stable"*) echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" ;;
+  *"rev-parse"*) echo "cccccccccccccccccccccccccccccccccccccccc" ;;
+  *) : ;;
+esac
+GITEOF
+  chmod +x "$STUB_BIN/git"
+  cat > "$STUB_BIN/gh" <<GHEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"run list"*) jq -nc --arg d "$run_iso" --arg c "$concl" '[range(3)|{conclusion:\$c,createdAt:\$d,databaseId:12345,workflowName:"Dev-Lead Agent"}]' ;;
+  *"run view"*) echo '{"jobs":[{"steps":[{"name":"Some step","conclusion":"failure"}]}]}' ;;
+  "issue list"*) if [[ "\$*" == *"canary-dashboard"* ]]; then echo '$dash_list'; else echo '$blocker_list'; fi ;;
+  "issue create"*) echo "CREATE|\$*" >> "$ISSUE_LOG"; echo "https://github.com/petry-projects/.github-private/issues/777" ;;
+  "issue edit"*)   echo "EDIT|\$*"   >> "$ISSUE_LOG" ;;
+  "issue close"*)  echo "CLOSE|\$*"  >> "$ISSUE_LOG" ;;
+  "issue reopen"*) echo "REOPEN|\$*" >> "$ISSUE_LOG" ;;
+  "issue pin"*)    echo "PIN|\$*"    >> "$ISSUE_LOG" ;;
+  "label create"*) : ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN/gh"
+  SYNC_RINGS="$BATS_TEST_TMPDIR/sync-rings.json"
+  jq '{org_infra_repos, agents: {"dev-lead": .agents["dev-lead"]}}' "$RINGS" > "$SYNC_RINGS"
+}
+
+@test "orchestrator: sync-issues --dry-run plans the blocker + dashboard without any GitHub writes" {
+  _sync_stub failure '[]' '[]'   # BLOCKED, nothing filed yet
+  run env CANARY_RINGS="$SYNC_RINGS" ISSUE_REPO="petry-projects/.github-private" bash "$ORCH" sync-issues --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"would OPEN blocker issue for dev-lead"* ]]
+  [[ "$output" == *"would UPSERT dashboard"* ]]
+  [ ! -s "$ISSUE_LOG" ]   # dry-run mutates nothing
+}
+
+@test "orchestrator: sync-issues opens a blocker issue (with evidence) + creates & pins the dashboard" {
+  _sync_stub failure '[]' '[]'
+  run env CANARY_RINGS="$SYNC_RINGS" ISSUE_REPO="petry-projects/.github-private" bash "$ORCH" sync-issues
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"opened blocker issue #777 for dev-lead"* ]]
+  # Two creates (blocker + dashboard); the multiline issue body spills the label onto its own
+  # log line, so match the label anywhere rather than on the CREATE| header line.
+  [ "$(grep -c '^CREATE|' "$ISSUE_LOG")" -eq 2 ]
+  grep -q -- "--label canary-blocker" "$ISSUE_LOG"
+  grep -q -- "--label canary-dashboard" "$ISSUE_LOG"
+  grep -q "^PIN|" "$ISSUE_LOG"
+}
+
+@test "orchestrator: sync-issues auto-closes a cleared agent's open blocker issue" {
+  # dev-lead now clean (success → not BLOCKED) but an OPEN blocker issue #501 exists → close it.
+  _sync_stub success '[{"number":501,"state":"OPEN","body":"<!-- canary-blocker:dev-lead -->"}]' '[]'
+  run env CANARY_RINGS="$SYNC_RINGS" ISSUE_REPO="petry-projects/.github-private" bash "$ORCH" sync-issues
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"closed cleared blocker issue #501 for dev-lead"* ]]
+  grep -q "CLOSE|.*501" "$ISSUE_LOG"
+}


### PR DESCRIPTION
Closes **#1063**. Answers the standing ask: *automate the triage of blocked releases.*

## What
Until now the gate detected + classified a BLOCKED promotion but only wrote `::error::`/`::warning::` to the run log — a human still had to read logs and file the issue (that's how #594 and #1059 got filed). New **`sync-issues`** command, run on the schedule after `promote-all`:

- **Per-agent blocker issue** (idempotent, marker `<!-- canary-blocker:<agent> -->`): transition, candidate, `cum_fail`/startup, triage, host repo, and the **failing-run evidence** — repo + run link + failed-step signatures, capped at 8, over the same per-candidate window the gate counts. `REGRESSION` → `needs-human`. Updated each run; **auto-closes** when the gate clears.
- **Rolling dashboard issue** (pinned, marker `<!-- canary-dashboard -->`): full fleet table (state / transition / cum_fail / triage / link to each blocker), rewritten every run.
- Best-effort: `if: always()` + `|| ::warning` so a GitHub-side hiccup never fails the promotion run. Manual `command=sync-issues` (defaults `--dry-run`) for on-demand refresh.

## Requires
The release-manager **App must carry `Issues: write`** (added to the workflow's documented scopes). Until it's granted, the step logs a warning and continues — nothing else breaks.

## Tests
+3 bats (dry-run plans without writes / opens blocker + creates & pins dashboard / auto-closes a cleared agent's issue). **59/59 passing**; `bash -n` + shellcheck clean; YAML validated; smoke-tested against a stubbed fleet (evidence table + dashboard render verified).

Refs: #1045 (promote path) · #594 (the log-signature triage enhancement pairs with this) · #495 / #502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)