### PR TITLE
fix: authenticate cross-repo git via gh, guard clone failures (readme-refresh)

### DIFF
--- a/scripts/aw-readme-refresh.sh
+++ b/scripts/aw-readme-refresh.sh
@@ -208,7 +208,7 @@ process_repo() {
   # Auth is handled by gh's git credential helper (configured in main via `gh auth setup-git`),
   # which works for both PATs and App tokens. Guard the clone so a failure aborts this repo
   # loudly instead of silently generating into an empty directory.
-  if ! git clone --quiet "https://github.com/${full_repo}.git" "$dir" || [ ! -d "$dir/.git" ]; then
+  if ! GIT_TERMINAL_PROMPT=0 git clone --quiet "https://github.com/${full_repo}.git" "$dir" || [ ! -d "$dir/.git" ]; then
     warn "clone failed for $full_repo — skipping this repo"
     return 1
   fi
@@ -353,6 +353,12 @@ fi
 # Route git's github.com credentials through gh (uses GH_TOKEN). This authenticates the
 # cross-repo clone/push for any token type — unlike an embedded x-access-token: or
 # "Authorization: Bearer" header, which GitHub rejects for a classic/fine-grained PAT.
+# Isolate the config writes to a temp file so local runs don't mutate ~/.gitconfig; CI
+# sets GIT_CONFIG_GLOBAL already, so we only override when it is unset.
+if [ -z "${GIT_CONFIG_GLOBAL:-}" ]; then
+  _gc_tmp="$(mktemp)"
+  export GIT_CONFIG_GLOBAL="$_gc_tmp"
+fi
 if ! gh auth setup-git --hostname github.com >/dev/null 2>&1; then
   warn "gh auth setup-git failed — cross-repo git push may not authenticate"
 fi

--- a/scripts/aw-readme-refresh.sh
+++ b/scripts/aw-readme-refresh.sh
@@ -205,9 +205,13 @@ process_repo() {
   local LINT_WARNINGS=""
 
   log "Cloning $full_repo"
-  git clone --quiet \
-    -c http.extraHeader="Authorization: Bearer ${GH_TOKEN}" \
-    "https://github.com/${full_repo}.git" "$dir"
+  # Auth is handled by gh's git credential helper (configured in main via `gh auth setup-git`),
+  # which works for both PATs and App tokens. Guard the clone so a failure aborts this repo
+  # loudly instead of silently generating into an empty directory.
+  if ! git clone --quiet "https://github.com/${full_repo}.git" "$dir" || [ ! -d "$dir/.git" ]; then
+    warn "clone failed for $full_repo — skipping this repo"
+    return 0
+  fi
   local default_branch
   default_branch="$(git -C "$dir" symbolic-ref --short HEAD)"
   # Rolling branch: always reset to default HEAD so the PR reflects "main + fresh READMEs".
@@ -344,6 +348,13 @@ log "Starting README refresh (org=$ORG, dry_run=$DRY_RUN, model=$CLAUDE_MODEL)"
 if ! command -v claude >/dev/null 2>&1; then
   echo "::error::claude CLI not found on PATH" >&2
   exit 1
+fi
+
+# Route git's github.com credentials through gh (uses GH_TOKEN). This authenticates the
+# cross-repo clone/push for any token type — unlike an embedded x-access-token: or
+# "Authorization: Bearer" header, which GitHub rejects for a classic/fine-grained PAT.
+if ! gh auth setup-git --hostname github.com >/dev/null 2>&1; then
+  warn "gh auth setup-git failed — cross-repo git push may not authenticate"
 fi
 
 facts_file="$(gather_facts)"

--- a/scripts/aw-readme-refresh.sh
+++ b/scripts/aw-readme-refresh.sh
@@ -210,7 +210,7 @@ process_repo() {
   # loudly instead of silently generating into an empty directory.
   if ! git clone --quiet "https://github.com/${full_repo}.git" "$dir" || [ ! -d "$dir/.git" ]; then
     warn "clone failed for $full_repo — skipping this repo"
-    return 0
+    return 1
   fi
   local default_branch
   default_branch="$(git -C "$dir" symbolic-ref --short HEAD)"


### PR DESCRIPTION
## Summary

Fixes the first live `readme-refresh` run (triggered post-merge of #1062), which **failed to clone** the target repos:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

### Root cause
GitHub's git-over-HTTPS rejects both the `https://x-access-token:<PAT>@…` URL form and an `Authorization: Bearer <PAT>` extraHeader when the credential is a **classic/fine-grained PAT** (`DON_PETRY_BOT_GH_PAT`) rather than a GitHub App / Actions token. Git then fell back to an interactive username prompt and died. Because the clone was **unguarded**, the script kept going and ran `git -C <dir> diff --cached` outside any repository — producing the `error: unknown option 'cached'` / `git diff --no-index` noise seen in [run 28683616091](https://github.com/petry-projects/.github-private/actions/runs/28683616091) — and silently opened no PR while still exiting 0.

### Fix
- Route git's `github.com` credentials through **`gh auth setup-git`** (uses `GH_TOKEN`; token-type-agnostic — authenticates both the clone and the push).
- Clone with a plain `https://` URL and **guard it**: on failure, `warn` and skip that repo instead of generating into an empty directory.

### Verification
- `shellcheck --severity=warning -x` — clean.
- Isolated **dry-run** (throwaway `GIT_CONFIG_GLOBAL` so the real gitconfig is untouched): clones both repos, generates all four READMEs, and renders correct diff stats (`README.md | 34 +++`, `profile/README.md | 4 +++-`) with **no** git errors.

### After merge
Re-run the dry run to confirm the clone/auth path is green end-to-end in CI:
```
gh workflow run readme-refresh.yml --repo petry-projects/.github-private -f dry_run=true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAsu1rBxAkMnAqFZaWKV6t

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when refreshing multiple repositories by skipping repos that fail to clone instead of continuing with an empty workspace.
  * Reduced authentication-related clone and push failures by using a more consistent Git login setup.
  * Isolated temporary Git configuration changes so they don’t affect unrelated commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->