### PR TITLE
feat: implement issue #1069 — canary-rollout: auto-cut a new version when a reusable changes on main (close the last manual seam)

### DIFF
--- a/.github/workflows/canary-rollout.yml
+++ b/.github/workflows/canary-rollout.yml
@@ -17,7 +17,13 @@
 # is a HARD requirement: if the token cannot be minted the job fails — it must not
 # silently degrade to github.token, which cannot move protected `.github` tags (#868).
 #
-#   - schedule (every 4h): the gated fleet auto-promote (#1045 part b). When the org
+#   - schedule (every 4h): the ordering is autocut → promote-all → sync-issues.
+#     FIRST `autocut` (#1069) — the FRONT END that closes the last manual seam: gated by the
+#     org variable CANARY_AUTO_CUT (the single kill-switch), it cuts a new <agent>/vX.Y.Z +
+#     moves `next` whenever a registered reusable's blob on its host main HEAD differs from the
+#     current `next` candidate, seeding the soak/promote pipeline with no manual cut-release.sh.
+#     A freshly cut candidate SOAKS the same tick (dwell=0 < floor). It is best-effort — a
+#     failure here never fails the run. THEN the gated fleet auto-promote (#1045 part b). When the org
 #     variable CANARY_AUTO_PROMOTE == 'true' the timer runs `promote-all` — the gate
 #     advances each PROMOTE-ready agent one ring per run and leaves BLOCKED/REGRESSION
 #     agents untouched (human approval is OVERRIDE-ONLY, never a required gate). When the
@@ -38,9 +44,9 @@ on:
   workflow_dispatch:
     inputs:
       command:
-        description: "evaluate | evaluate-all (read-only) | promote | promote-all (gated tag move) | rollback | sync-issues"
+        description: "autocut (gated cut+seed) | evaluate | evaluate-all (read-only) | promote | promote-all (gated tag move) | rollback | sync-issues"
         type: choice
-        options: [evaluate, evaluate-all, promote, promote-all, rollback, sync-issues]
+        options: [autocut, evaluate, evaluate-all, promote, promote-all, rollback, sync-issues]
         default: evaluate
       agent:
         description: "agent to act on"
@@ -114,9 +120,25 @@ jobs:
           # authorized under the release-channel-tags ruleset bypass (#868).
           token: ${{ steps.app-token.outputs.token }}
 
+      # FRONT END (#1069): cut a new candidate + move `next` whenever a registered reusable's
+      # blob on its host main HEAD differs from the current `next` candidate. Runs FIRST on the
+      # scheduled tick (before promote-all) so a freshly cut candidate begins soaking the same
+      # tick. Gated by CANARY_AUTO_CUT (the single kill-switch) — the script no-ops unless it is
+      # 'true'. Best-effort: a cut/detection hiccup must never fail the scheduled promotion run.
+      - name: Autocut new candidates (front end)
+        if: github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          CANARY_AUTO_CUT: ${{ vars.CANARY_AUTO_CUT }}
+        run: |
+          set -uo pipefail
+          bash scripts/canary-rollout.sh autocut || echo "::warning::autocut failed (non-fatal)"
+
       - name: Run canary-rollout
         id: run
         env:
+          # autocut kill-switch — honored when a dispatch runs `autocut` (the script no-ops unless 'true').
+          CANARY_AUTO_CUT: ${{ vars.CANARY_AUTO_CUT }}
           # On the 4h timer the arm variable decides: CANARY_AUTO_PROMOTE=='true' runs the
           # gated fleet auto-promote (promote-all, #1045 part b); anything else runs read-only
           # fleet-wide evaluate-all (#1025 P1). Either way EVERY registry agent is covered, not
@@ -139,6 +161,10 @@ jobs:
           set -euo pipefail
           args=()
           case "$CMD" in
+            autocut)                                           # gated cut+seed of new candidates (#1069)
+              args=(autocut)
+              [ "$DRY_RUN" != "false" ] && args+=(--dry-run)   # default-safe: dry unless explicitly false
+              ;;
             evaluate)     args=(evaluate "$AGENT") ;;
             evaluate-all) args=(evaluate-all) ;;   # fleet-wide read-only (the 4h timer, #1025 P1)
             promote)

--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -831,14 +831,14 @@ _host_release_versions() {
   host="$(_agent_field "$agent" host)"
   [ -z "$host" ] && return 0
   gh api "repos/$host/git/matching-refs/tags/$agent/v" --jq '.[]?.ref' 2>/dev/null \
-    | sed -n "s#^refs/tags/${agent}/v##p"
+    | sed -n "s#^refs/tags/${agent}/v##p" || true
 }
 
 # _autocut_bump <agent> — the configured bump level for the agent (registry knob
 # .agents[a].autocut.bump), defaulting to patch. Anything but minor/major → patch.
 _autocut_bump() {
   local b
-  b="$(_jq -r --arg a "$1" '.agents[$a].autocut.bump // "patch"')"
+  b="$(_jq -r --arg a "$1" '.agents[$a]?.autocut?.bump // "patch"')"
   case "$b" in major|minor|patch) echo "$b" ;; *) echo "patch" ;; esac
 }
 

--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -11,7 +11,14 @@ set -euo pipefail
 # Channel tags ARE the rollout state (#502): the frontier is derived from where each
 # channel tag resolves; there is no separate state store.
 #
+# The FRONT END that closes the last manual seam (#1069): `autocut` polls each registered
+# reusable and, when its blob on the host's main HEAD differs from the current `next`
+# candidate, cuts a new immutable <agent>/vX.Y.Z and moves `next` onto it — seeding the soak/
+# promote pipeline with no manual `cut-release.sh`. It is gated by CANARY_AUTO_CUT (the single
+# kill-switch), runs BEFORE promote-all on the scheduled tick, and is best-effort.
+#
 # Usage:
+#   canary-rollout.sh autocut      [--dry-run]         # cut+seed new candidates for changed reusables (gated by CANARY_AUTO_CUT)
 #   canary-rollout.sh evaluate     <agent>             # read-only gate + health report (also the #502 report)
 #   canary-rollout.sh evaluate-all                     # read-only evaluate for EVERY registry agent (fleet-wide; the 4h timer)
 #   canary-rollout.sh promote  <agent> [--override] [--allow-pre-existing] [--dry-run]
@@ -31,6 +38,7 @@ set -euo pipefail
 #   SOAK_WINDOW_DAYS    optional override of the baseline-window length in days
 #                       (default: .gate.baseline_window_days, else 14)
 #   CANARY_FAILURE_CATEGORY  optional triage hint (comment-cap|rate-limit|infra|data)
+#   CANARY_AUTO_CUT     autocut kill-switch — autocut is a no-op unless this == 'true'
 #   GH_TOKEN            credential; the workflow mints a GitHub App token and passes it here
 
 _HERE="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
@@ -38,6 +46,10 @@ _HERE="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 source "${_HERE}/lib/canary-rollout.sh"
 DEFAULT_RINGS="$(cd "${_HERE}/.." && pwd)/standards/canary-rings.json"
 CANARY_RINGS="${CANARY_RINGS:-$DEFAULT_RINGS}"
+
+# CUT_RELEASE — the cut-release.sh invoked by `autocut` to cut a new candidate. A
+# sibling of this script by default; overridable so tests can stub the cut (#1069).
+CUT_RELEASE="${CUT_RELEASE:-${_HERE}/cut-release.sh}"
 
 # THIS_REPO — the repo this checkout belongs to. Agents hosted HERE (dev-lead, pr-review)
 # keep their channel/release tags in this checkout and resolve them via local git. A
@@ -788,6 +800,124 @@ cmd_sync_issues() {
   return 0
 }
 
+# ── autocut: cut a new candidate when a reusable changes on main (#1069) ────────
+# The FRONT END of the canary pipeline (the promoter's counterpart). At each scheduled
+# tick — gated by CANARY_AUTO_CUT — for each registered agent it compares the reusable
+# blob at the host's default-branch HEAD against the blob at the current `next` candidate;
+# if they differ it cuts a new immutable <agent>/vX.Y.Z (patch bump by default) and moves
+# `next` onto it via cut-release.sh, seeding the candidate into the existing soak/promote
+# pipeline. Detection is done here in .github-private via the App token (which reads every
+# host), so no cross-repo Actions plumbing is needed. Best-effort: never fails the run.
+#
+# Scope/limitation (v1): detection is on the reusable FILE blob only (the registry
+# `reusable` path). A change to a shared library the reusable sources — without the
+# reusable file itself changing — is not detected. Acceptable for v1; could extend to a
+# path-set later.
+
+# _gh_default_branch <repo> — the repo's default branch name (empty on error).
+_gh_default_branch() { gh api "repos/$1" --jq '.default_branch' 2>/dev/null || echo ""; }
+
+# _gh_head_sha <repo> <branch> — the commit SHA at <branch> HEAD (empty on error).
+_gh_head_sha() { gh api "repos/$1/commits/$2" --jq '.sha' 2>/dev/null || echo ""; }
+
+# _gh_blob_sha <repo> <path> <ref> — the git blob SHA of <path> at <ref> (empty on error).
+_gh_blob_sha() { gh api "repos/$1/contents/$2?ref=$3" --jq '.sha' 2>/dev/null || echo ""; }
+
+# _host_release_versions <agent> — echo every MAJOR.MINOR.PATCH (one per line) that has an
+# immutable <agent>/vX.Y.Z tag on the agent's host, via the API (the App token reads every
+# host; release tags are on the remote for both this-repo and cross-repo agents).
+_host_release_versions() {
+  local agent="$1" host
+  host="$(_agent_field "$agent" host)"
+  [ -z "$host" ] && return 0
+  gh api "repos/$host/git/matching-refs/tags/$agent/v" --jq '.[]?.ref' 2>/dev/null \
+    | sed -n "s#^refs/tags/${agent}/v##p"
+}
+
+# _autocut_bump <agent> — the configured bump level for the agent (registry knob
+# .agents[a].autocut.bump), defaulting to patch. Anything but minor/major → patch.
+_autocut_bump() {
+  local b
+  b="$(_jq -r --arg a "$1" '.agents[$a].autocut.bump // "patch"')"
+  case "$b" in major|minor|patch) echo "$b" ;; *) echo "patch" ;; esac
+}
+
+# _next_release_version <agent> <bump> — compute the next release version: bump the highest
+# existing <agent>/vX.Y.Z on the host by <bump>. No existing tags → seed from 0.0.0.
+_next_release_version() {
+  local agent="$1" bump="$2" versions highest
+  versions="$(_host_release_versions "$agent")"
+  # shellcheck disable=SC2086
+  highest="$(max_semver $versions)"
+  [ -z "$highest" ] && highest="0.0.0"
+  bump_version "$highest" "$bump"
+}
+
+# _autocut_agent <agent> <dry:true|false> — cut a new candidate for ONE agent if its reusable
+# blob on the host default-branch HEAD differs from the blob at the current `next` candidate.
+# Idempotent: no-op when the blobs match or main HEAD already equals the next candidate.
+# Best-effort: any resolution gap is a ::warning + skip, never a hard failure.
+_autocut_agent() {
+  local agent="$1" dry="$2"
+  local host reusable defbranch mainsha next_commit main_blob next_blob bump newver
+  host="$(_agent_field "$agent" host)"
+  reusable="$(_agent_field "$agent" reusable)"
+  if [ -z "$host" ] || [ -z "$reusable" ]; then
+    echo "::warning::autocut $agent: missing host/reusable in registry — skipping"; return 0
+  fi
+  defbranch="$(_gh_default_branch "$host")"; [ -z "$defbranch" ] && defbranch="main"
+  mainsha="$(_gh_head_sha "$host" "$defbranch")"
+  if [ -z "$mainsha" ]; then
+    echo "::warning::autocut $agent: could not resolve $host $defbranch HEAD — skipping"; return 0
+  fi
+  main_blob="$(_gh_blob_sha "$host" "$reusable" "$mainsha")"
+  if [ -z "$main_blob" ]; then
+    echo "::warning::autocut $agent: reusable '$reusable' not found at $host@${mainsha:0:12} — skipping"; return 0
+  fi
+  next_commit="$(channel_commit "$agent" next)"
+  next_blob=""
+  [ -n "$next_commit" ] && next_blob="$(_gh_blob_sha "$host" "$reusable" "$next_commit")"
+  # Idempotency: nothing to cut when main HEAD already IS the candidate, or the reusable blob
+  # is byte-identical between main and the current next candidate.
+  if [ "$mainsha" = "$next_commit" ] || { [ -n "$next_blob" ] && [ "$main_blob" = "$next_blob" ]; }; then
+    echo "autocut $agent: reusable unchanged on $host (next candidate up to date) — no cut."
+    return 0
+  fi
+  bump="$(_autocut_bump "$agent")"
+  newver="$(_next_release_version "$agent" "$bump")"
+  echo "autocut $agent: reusable changed on $host ($defbranch ${mainsha:0:12}) vs next ${next_commit:0:12} — cutting v$newver (bump=$bump), moving next."
+  if [ "$dry" = true ]; then
+    echo "[DRY-RUN] would: cut-release.sh $agent $newver --ref $mainsha --channel next --push"
+    return 0
+  fi
+  bash "$CUT_RELEASE" "$agent" "$newver" --ref "$mainsha" --channel next --push \
+    || { echo "::warning::autocut $agent: cut-release failed for v$newver (best-effort, continuing)"; return 0; }
+  echo "autocut $agent: cut v$newver from ${mainsha:0:12} and moved next."
+}
+
+# cmd_autocut [--dry-run] — the scheduled front end. Gated by CANARY_AUTO_CUT (the single
+# kill-switch): a clean no-op unless CANARY_AUTO_CUT == 'true'. Iterates every registry agent;
+# a per-agent failure is logged and skipped so one agent cannot halt the fleet sweep. Runs
+# BEFORE promote-all so a freshly cut candidate begins soaking the same tick (dwell=0 < floor
+# → it SOAKS, does not promote).
+cmd_autocut() {
+  local dry=false; [ "${1:-}" = "--dry-run" ] && dry=true
+  if [ "${CANARY_AUTO_CUT:-}" != "true" ]; then
+    echo "== canary-rollout autocut: DISABLED (CANARY_AUTO_CUT != 'true') — no-op. =="
+    return 0
+  fi
+  local agents agent
+  agents="$(_jq -r '.agents? | keys[]?' 2>/dev/null || true)"
+  [ -z "$agents" ] && { echo "no agents registered in $CANARY_RINGS — nothing to autocut."; return 0; }
+  echo "== canary-rollout autocut: fleet-wide dry=$dry (gate standard: .github#548) =="
+  while IFS= read -r agent; do
+    [ -z "$agent" ] && continue
+    echo "──────── agent: $agent ────────"
+    _autocut_agent "$agent" "$dry" || echo "::warning::autocut of $agent failed (continuing fleet)"
+  done <<< "$agents"
+  return 0
+}
+
 main() {
   local cmd
   for cmd in jq gh git; do
@@ -809,7 +939,8 @@ main() {
     rollback)     [ $# -ge 2 ] || { echo "usage: rollback <agent> <ring> --to <vX.Y.Z>" >&2; return 2; }; cmd_rollback "$@" ;;
     resolve)      [ $# -ge 2 ] || { echo "usage: resolve <agent> <channel>" >&2; return 2; }; resolve_members "$@" ;;
     sync-issues)  cmd_sync_issues "$@" ;;   # upsert blocker issues + dashboard for held promotions
-    *) echo "::error::usage: canary-rollout.sh {evaluate|evaluate-all|promote|promote-all|rollback|resolve|sync-issues} <agent> ..." >&2; return 2 ;;
+    autocut)      cmd_autocut "$@" ;;       # cut a new candidate when a reusable changes on main (#1069)
+    *) echo "::error::usage: canary-rollout.sh {autocut|evaluate|evaluate-all|promote|promote-all|rollback|resolve|sync-issues} <agent> ..." >&2; return 2 ;;
   esac
 }
 

--- a/scripts/lib/canary-rollout.sh
+++ b/scripts/lib/canary-rollout.sh
@@ -80,6 +80,45 @@ robust_sample_target() {
   clamp "$target_raw" "$lo" "$hi"
 }
 
+# ── version-bump math (autocut front end, #1069) ──────────────────────────────
+# Pure semver helpers used by `canary-rollout.sh autocut` to compute the next
+# immutable release version from the highest existing <agent>/vX.Y.Z on the host.
+
+# bump_version <version> <patch|minor|major> — echo MAJOR.MINOR.PATCH bumped by one
+# level. Unknown/absent level defaults to patch (the v1 default). Input must be a
+# strict MAJOR.MINOR.PATCH; callers validate the tag before calling.
+bump_version() {
+  local ver="$1" level="${2:-patch}" major minor patch
+  IFS=. read -r major minor patch <<< "$ver"
+  case "$level" in
+    major) echo "$((major + 1)).0.0" ;;
+    minor) echo "${major}.$((minor + 1)).0" ;;
+    *)     echo "${major}.${minor}.$((patch + 1))" ;;
+  esac
+}
+
+# _semver_gt <a> <b> — return 0 iff semver a is strictly greater than b (compared
+# by major, then minor, then patch). Equal is NOT greater.
+_semver_gt() {
+  local a1 a2 a3 b1 b2 b3
+  IFS=. read -r a1 a2 a3 <<< "$1"
+  IFS=. read -r b1 b2 b3 <<< "$2"
+  if [ "$a1" -ne "$b1" ]; then [ "$a1" -gt "$b1" ]; return; fi
+  if [ "$a2" -ne "$b2" ]; then [ "$a2" -gt "$b2" ]; return; fi
+  [ "$a3" -gt "$b3" ]
+}
+
+# max_semver <version...> — echo the highest strict MAJOR.MINOR.PATCH among the
+# args, ignoring any token that is not a strict semver. Empty if none are valid.
+max_semver() {
+  local v hi=""
+  for v in "$@"; do
+    [[ "$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || continue
+    if [ -z "$hi" ] || _semver_gt "$v" "$hi"; then hi="$v"; fi
+  done
+  echo "$hi"
+}
+
 # dwell_met <dwell_hours> <floor_hours> — echo 1 if the candidate has dwelled at
 # least floor_hours on the source tier, else 0.
 dwell_met() {

--- a/scripts/lib/canary-rollout.sh
+++ b/scripts/lib/canary-rollout.sh
@@ -88,7 +88,7 @@ robust_sample_target() {
 # level. Unknown/absent level defaults to patch (the v1 default). Input must be a
 # strict MAJOR.MINOR.PATCH; callers validate the tag before calling.
 bump_version() {
-  local ver="$1" level="${2:-patch}" major minor patch
+  local ver="$1" level="${2:-patch}" major=0 minor=0 patch=0
   IFS=. read -r major minor patch <<< "$ver"
   case "$level" in
     major) echo "$((major + 1)).0.0" ;;
@@ -100,7 +100,7 @@ bump_version() {
 # _semver_gt <a> <b> — return 0 iff semver a is strictly greater than b (compared
 # by major, then minor, then patch). Equal is NOT greater.
 _semver_gt() {
-  local a1 a2 a3 b1 b2 b3
+  local a1=0 a2=0 a3=0 b1=0 b2=0 b3=0
   IFS=. read -r a1 a2 a3 <<< "$1"
   IFS=. read -r b1 b2 b3 <<< "$2"
   if [ "$a1" -ne "$b1" ]; then [ "$a1" -gt "$b1" ]; return; fi

--- a/standards/canary-rings.json
+++ b/standards/canary-rings.json
@@ -10,6 +10,7 @@
     "$org_infra": "org_infra_repos minus the host (the host is already in `next`)",
     "*": "every other consumer not named in an earlier ring"
   },
+  "_autocut_note": "autocut (#1069): `canary-rollout.sh autocut` (gated by org var CANARY_AUTO_CUT) auto-cuts a new immutable <agent>/vX.Y.Z + moves `next` when a reusable's blob on its host main HEAD differs from the current `next` candidate. Version bump defaults to patch; override per agent with the optional `.agents[<a>].autocut.bump` knob (patch|minor|major).",
   "agents": {
     "dev-lead": {
       "host": "petry-projects/.github-private",

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -61,6 +61,41 @@ setup() {
   [ "$(clamp "$(round_div $((250*sum)) $((1000*n)))" 3 15)" -eq 15 ]
 }
 
+# ── version-bump math (autocut front end, #1069) ──────────────────────────────
+@test "bump_version: patch increments the patch component" {
+  [ "$(bump_version 2.1.0 patch)" = "2.1.1" ]
+  [ "$(bump_version 0.0.0 patch)" = "0.0.1" ]
+}
+@test "bump_version: minor increments minor and zeroes patch" {
+  [ "$(bump_version 2.1.3 minor)" = "2.2.0" ]
+}
+@test "bump_version: major increments major and zeroes minor+patch" {
+  [ "$(bump_version 2.1.3 major)" = "3.0.0" ]
+}
+@test "bump_version: default (no/unknown level) is patch" {
+  [ "$(bump_version 2.1.0)" = "2.1.1" ]
+  [ "$(bump_version 2.1.0 bogus)" = "2.1.1" ]
+}
+
+@test "_semver_gt: compares by major, then minor, then patch" {
+  run _semver_gt 2.1.1 2.1.0; [ "$status" -eq 0 ]
+  run _semver_gt 2.2.0 2.1.9; [ "$status" -eq 0 ]
+  run _semver_gt 3.0.0 2.9.9; [ "$status" -eq 0 ]
+  run _semver_gt 2.1.0 2.1.0; [ "$status" -ne 0 ]   # equal is not greater
+  run _semver_gt 2.1.0 2.1.1; [ "$status" -ne 0 ]
+}
+
+@test "max_semver: picks the highest version" {
+  [ "$(max_semver 2.0.5 2.1.0 2.0.9)" = "2.1.0" ]
+  [ "$(max_semver 1.0.0)" = "1.0.0" ]
+}
+@test "max_semver: ignores non-semver tokens" {
+  [ "$(max_semver 2.1.0 not-a-version 2.1.5 v3.0.0)" = "2.1.5" ]
+}
+@test "max_semver: empty input → empty" {
+  [ -z "$(max_semver)" ]
+}
+
 # ── dwell_met ─────────────────────────────────────────────────────────────────
 @test "dwell_met: at/over floor → 1" { [ "$(dwell_met 4 4)" -eq 1 ]; [ "$(dwell_met 9 8)" -eq 1 ]; }
 @test "dwell_met: under floor → 0" { [ "$(dwell_met 3 4)" -eq 0 ]; }
@@ -726,4 +761,115 @@ GHEOF
   # The header must appear at the start of a line — not concatenated onto the prior content.
   grep -q '^# Canary Rollout' "$summ"
   ! grep -q 'prior.*# Canary Rollout' "$summ"
+}
+
+# ── orchestrator: autocut — auto-cut a new candidate when a reusable changes on main (#1069) ─
+# The front end of the canary pipeline: at each scheduled tick (gated by CANARY_AUTO_CUT), for
+# each registered agent compare the reusable blob at the host's main HEAD against the blob at the
+# current `next` candidate; if they differ, cut a new immutable vX.Y.Z (patch bump default) and
+# move `next` onto it via cut-release.sh. The stub feeds: default_branch, main HEAD, the two blob
+# SHAs, the `next` commit (git for a this-repo agent, gh api for a cross-repo one), the existing
+# release-tag versions (matching-refs), and a cut-release.sh stand-in (CUT_RELEASE) that logs args.
+_autocut_stub() {
+  # args: agent host reusable main_blob next_blob mainsha nextsha versions_ws [bump]
+  local agent="$1" host="$2" reusable="$3" MAIN_BLOB="$4" NEXT_BLOB="$5" MAINSHA="$6" NEXTSHA="$7" versions="$8" bump="${9:-}"
+  STUB_BIN="$(mktemp -d "$BATS_TEST_TMPDIR/stub.XXXXXX")"; export PATH="$STUB_BIN:$PATH"
+  export CUT_LOG="$STUB_BIN/cut.log"; : > "$CUT_LOG"
+  export CUT_RELEASE="$STUB_BIN/cut-release"
+  cat > "$CUT_RELEASE" <<CUTEOF
+#!/usr/bin/env bash
+echo "\$*" >> "$CUT_LOG"
+CUTEOF
+  chmod +x "$CUT_RELEASE"
+  local refs="" v
+  for v in $versions; do refs+="refs/tags/$agent/v$v"$'\n'; done
+  cat > "$STUB_BIN/gh" <<GHEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *".default_branch"*) echo "main" ;;
+  *"contents/"*"ref=$MAINSHA"*) echo "$MAIN_BLOB" ;;
+  *"contents/"*"ref=$NEXTSHA"*) echo "$NEXT_BLOB" ;;
+  *"/commits/"*) echo "$MAINSHA" ;;
+  *"matching-refs/tags/$agent/v"*) printf '%s' "$refs" ;;
+  *"git/ref/tags/$agent/next"*) printf '%s\tcommit\n' "$NEXTSHA" ;;
+  *"run list"*) echo "[]" ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN/gh"
+  cat > "$STUB_BIN/git" <<GITEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"rev-parse"*"$agent/next"*) echo "$NEXTSHA" ;;
+  *) : ;;
+esac
+GITEOF
+  chmod +x "$STUB_BIN/git"
+  AUTOCUT_RINGS="$BATS_TEST_TMPDIR/autocut-rings.json"
+  if [ -n "$bump" ]; then
+    jq --arg a "$agent" --arg b "$bump" \
+      '{version, description, org_infra_repos, member_tokens, agents: {($a): (.agents[$a] + {autocut: {bump: $b}})}}' \
+      "$RINGS" > "$AUTOCUT_RINGS"
+  else
+    jq --arg a "$agent" \
+      '{version, description, org_infra_repos, member_tokens, agents: {($a): .agents[$a]}}' \
+      "$RINGS" > "$AUTOCUT_RINGS"
+  fi
+}
+
+@test "orchestrator: autocut is a no-op when CANARY_AUTO_CUT is not 'true' (kill-switch off)" {
+  _autocut_stub dev-lead petry-projects/.github-private .github/workflows/dev-lead-reusable.yml \
+    blobMAIN blobNEXT aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa cccccccccccccccccccccccccccccccccccccccc "2.1.0"
+  run env CANARY_RINGS="$AUTOCUT_RINGS" CUT_RELEASE="$CUT_RELEASE" bash "$ORCH" autocut
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DISABLED"* ]]
+  [ ! -s "$CUT_LOG" ]   # nothing cut when the kill-switch is off
+}
+
+@test "orchestrator: autocut cuts a patch-bumped version + moves next when the reusable blob differs on main" {
+  _autocut_stub dev-lead petry-projects/.github-private .github/workflows/dev-lead-reusable.yml \
+    blobMAIN blobNEXT aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa cccccccccccccccccccccccccccccccccccccccc "2.1.0"
+  run env CANARY_AUTO_CUT=true CANARY_RINGS="$AUTOCUT_RINGS" CUT_RELEASE="$CUT_RELEASE" bash "$ORCH" autocut
+  [ "$status" -eq 0 ]
+  # Highest existing tag is v2.1.0 → patch bump → v2.1.1, cut from main HEAD, channel next, pushed.
+  grep -q "dev-lead 2.1.1 --ref aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa --channel next --push" "$CUT_LOG"
+}
+
+@test "orchestrator: autocut is idempotent — identical blob on main and next is a clean no-op" {
+  _autocut_stub dev-lead petry-projects/.github-private .github/workflows/dev-lead-reusable.yml \
+    sameBLOB sameBLOB aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa cccccccccccccccccccccccccccccccccccccccc "2.1.0"
+  run env CANARY_AUTO_CUT=true CANARY_RINGS="$AUTOCUT_RINGS" CUT_RELEASE="$CUT_RELEASE" bash "$ORCH" autocut
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no cut"* ]]
+  [ ! -s "$CUT_LOG" ]   # nothing cut when the blob is unchanged
+}
+
+@test "orchestrator: autocut --dry-run prints the intended cut without invoking cut-release --push" {
+  _autocut_stub dev-lead petry-projects/.github-private .github/workflows/dev-lead-reusable.yml \
+    blobMAIN blobNEXT aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa cccccccccccccccccccccccccccccccccccccccc "2.1.0"
+  run env CANARY_AUTO_CUT=true CANARY_RINGS="$AUTOCUT_RINGS" CUT_RELEASE="$CUT_RELEASE" bash "$ORCH" autocut --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY-RUN"* ]]
+  [[ "$output" == *"2.1.1"* ]]
+  [ ! -s "$CUT_LOG" ]   # dry-run never pushes a real cut
+}
+
+@test "orchestrator: autocut honors the registry autocut.bump override (minor)" {
+  _autocut_stub dev-lead petry-projects/.github-private .github/workflows/dev-lead-reusable.yml \
+    blobMAIN blobNEXT aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa cccccccccccccccccccccccccccccccccccccccc "2.1.0" minor
+  run env CANARY_AUTO_CUT=true CANARY_RINGS="$AUTOCUT_RINGS" CUT_RELEASE="$CUT_RELEASE" bash "$ORCH" autocut
+  [ "$status" -eq 0 ]
+  # minor bump of v2.1.0 → v2.2.0
+  grep -q "dev-lead 2.2.0 --ref aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa --channel next --push" "$CUT_LOG"
+}
+
+@test "orchestrator: autocut is cross-repo aware — cuts v2.1.1 for auto-rebase from the host main HEAD (#1069)" {
+  # auto-rebase is hosted in petry-projects/.github; its next candidate + release tags live there,
+  # so the next commit is resolved via gh api (not local git) and the cut is cross-repo.
+  _autocut_stub auto-rebase petry-projects/.github .github/workflows/auto-rebase-reusable.yml \
+    ece45480ece45480ece45480ece45480ece45480 2763750027637500276375002763750027637500 \
+    ece45480ece45480ece45480ece45480ece45480 2763750027637500276375002763750027637500 "2.1.0"
+  run env CANARY_AUTO_CUT=true CANARY_RINGS="$AUTOCUT_RINGS" CUT_RELEASE="$CUT_RELEASE" bash "$ORCH" autocut
+  [ "$status" -eq 0 ]
+  grep -q "auto-rebase 2.1.1 --ref ece45480ece45480ece45480ece45480ece45480 --channel next --push" "$CUT_LOG"
 }


### PR DESCRIPTION
Closes #1069

Implemented by dev-lead agent. Please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated canary “autocut” option for scheduled runs to detect candidate changes, seed a new version, and continue promotion checks.
  * Expanded command options to include autocut and support patch, minor, or major version bumps.

* **Bug Fixes**
  * Prevents unnecessary cuts when the reusable content hasn’t changed.
  * Keeps dry-run behavior intact and makes autocut failures non-blocking during scheduled runs.

* **Documentation**
  * Updated canary rollout guidance to describe the new autocut behavior and version-bump settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->