### PR TITLE
fix(cut-release): set a git identity before the this-repo annotated-tag cut (#1069)

### DIFF
--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -47,6 +47,15 @@
 #
 set -euo pipefail
 
+# Shared bot git identity — a THIS_REPO cut creates a LOCAL annotated tag (`git tag -a`),
+# which aborts with "fatal: empty ident name" on a GitHub-hosted runner that has no
+# user.name/user.email configured. Cross-repo cuts go through `gh api` (App identity) and
+# are unaffected; only the local path needs this. Sourced (no side effects) so tests can
+# still `source` this file; setup_git_identity is invoked lazily in the this-repo cut path.
+_CRHERE="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=lib/git-identity.sh
+source "${_CRHERE}/lib/git-identity.sh"
+
 # The repo whose git refs hold cross-repo agents' release/channel tags.
 CROSS_REPO_TARGET="petry-projects/.github"
 
@@ -263,6 +272,9 @@ main() {
     echo "::error::release tag '$rel' already exists — immutable tags are never overwritten." >&2
     return 1
   fi
+  # An annotated tag needs a tagger identity; a bare GitHub-hosted runner has none, so the
+  # local `git tag -a` aborts with "fatal: empty ident name" (autocut dev-lead cut, #1069).
+  setup_git_identity
   git tag -a "$rel" "$sha" -m "$agent release v$version"
   echo "created $rel"
   if [ -n "$channel" ]; then

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -52,7 +52,8 @@ set -euo pipefail
 # user.name/user.email configured. Cross-repo cuts go through `gh api` (App identity) and
 # are unaffected; only the local path needs this. Sourced (no side effects) so tests can
 # still `source` this file; setup_git_identity is invoked lazily in the this-repo cut path.
-_CRHERE="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+_CRHERE="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" && pwd -P)"
+readonly _CRHERE
 # shellcheck source=lib/git-identity.sh
 source "${_CRHERE}/lib/git-identity.sh"
 

--- a/tests/test_cut_release.bats
+++ b/tests/test_cut_release.bats
@@ -22,6 +22,18 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
+@test "cut-release: setup_git_identity call precedes git tag -a in the this-repo annotated-tag path" {
+  # Regression guard: asserts the call ordering in source so this test fails
+  # if setup_git_identity is ever removed from before git tag -a (#1069).
+  local script id_line tag_line
+  script="$(dirname "$BATS_TEST_FILENAME")/../scripts/cut-release.sh"
+  id_line=$(grep -n '^[[:space:]]*setup_git_identity[[:space:]]*$' "$script" | cut -d: -f1)
+  tag_line=$(grep -n '^[[:space:]]*git tag -a' "$script" | cut -d: -f1)
+  [ -n "$id_line" ]
+  [ -n "$tag_line" ]
+  [ "$id_line" -lt "$tag_line" ]
+}
+
 @test "valid_agent: pr-review is accepted" {
   run valid_agent "pr-review"
   [ "$status" -eq 0 ]

--- a/tests/test_cut_release.bats
+++ b/tests/test_cut_release.bats
@@ -14,6 +14,14 @@ setup() {
 # valid_agent
 # ---------------------------------------------------------------------------
 
+# A this-repo cut creates a LOCAL annotated tag (`git tag -a`), which aborts with
+# "fatal: empty ident name" on a bare runner. cut-release.sh must source the shared
+# git-identity helper so the this-repo path can set a tagger identity (#1069 regression).
+@test "cut-release wires the shared git-identity helper for the this-repo annotated-tag cut" {
+  run declare -F setup_git_identity
+  [ "$status" -eq 0 ]
+}
+
 @test "valid_agent: pr-review is accepted" {
   run valid_agent "pr-review"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Bug (caught by the armed autocut)
The first armed `autocut` run cut `auto-rebase v2.1.1` + `dependency-audit v2.1.1` successfully (cross-repo, via `gh api`), but **dev-lead's cut failed**:
```
fatal: empty ident name (for <runner@...cloudapp.net>) not allowed
```
`dev-lead` is the one **THIS_REPO** agent, so its cut goes through **local git** (`cut-release.sh` → `git tag -a`, an annotated tag), which needs a tagger `user.name`/`user.email`. A GitHub-hosted runner has none. Cross-repo agents cut via `gh api` (App identity), so they're unaffected — which is exactly why only dev-lead failed. Armed, the timer would retry + fail every 4h.

## Fix
`cut-release.sh` now sources the shared `scripts/lib/git-identity.sh` and calls `setup_git_identity` immediately before the local `git tag -a`. Verified locally: resolves to `donpetry-bot` / `281750570+donpetry-bot@users.noreply.github.com`. Sourcing is side-effect-free, so the test source-guard contract holds. +1 regression guard (helper is wired). **42/42 cut-release tests pass.**

## Validation
Acceptance = re-dispatch `autocut` after merge and confirm `dev-lead v1.5.1` cuts (the same run that already succeeded for the two cross-repo agents). Will confirm on merge.

Refs: #1069 (autocut) · #959/#992 (cut-release cross-repo/promote).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release tag creation so annotated tags work more reliably in local and hosted environments.
  * Prevented release failures when Git identity settings are missing.

* **Tests**
  * Added coverage for the release flow to confirm the Git identity setup is available during tag creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->