### PR TITLE
feat: implement issue #1076 — autocut: make the cut idempotent — reuse an existing release tag at the target commit instead of bumping (prevents orphan-tag spam on a blocked next-move)

### DIFF
--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -864,9 +864,11 @@ _next_release_version() {
 # already-cut release at the target commit instead of minting a duplicate on a retry-after-partial-
 # failure (the orphan-tag spam of #1076). Best-effort: any API gap yields empty (→ cut a new bump).
 _host_release_version_at_commit() {
-  local agent="$1" commit="$2" host ref obj type csha
+  [ $# -lt 2 ] && return 0
+  local agent="$1" commit="$2" host ref="" obj="" type="" csha=""
   host="$(_agent_field "$agent" host)"
   { [ -z "$host" ] || [ -z "$commit" ]; } && return 0
+  local matching=""
   while IFS=$'\t' read -r ref obj type; do
     [ -z "$obj" ] && continue
     if [ "$type" = "tag" ]; then
@@ -875,11 +877,12 @@ _host_release_version_at_commit() {
       csha="$obj"
     fi
     if [ -n "$csha" ] && [ "$csha" = "$commit" ]; then
-      printf '%s\n' "${ref#refs/tags/${agent}/v}"
-      return 0
+      matching="${matching} ${ref#refs/tags/${agent}/v}"
     fi
-  done < <(gh api "repos/$host/git/matching-refs/tags/$agent/v" \
+  done < <(gh api "repos/$host/git/matching-refs/tags/$agent/v" --paginate \
              --jq '.[]? | [.ref, (.object?.sha // "" | tostring), (.object?.type // "" | tostring)] | @tsv' 2>/dev/null)
+  # shellcheck disable=SC2086
+  [ -n "$matching" ] && max_semver $matching
   return 0
 }
 

--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -853,6 +853,32 @@ _next_release_version() {
   bump_version "$highest" "$bump"
 }
 
+# _host_release_version_at_commit <agent> <commit> — echo the MAJOR.MINOR.PATCH of an existing
+# <agent>/vX.Y.Z release tag on the host whose (dereferenced) commit equals <commit>, or empty if
+# none points there. Annotated tags (object.type=tag) are dereferenced to their commit via a
+# second git/tags/<obj> call, mirroring _gh_candidate_cut_date. This lets autocut REUSE an
+# already-cut release at the target commit instead of minting a duplicate on a retry-after-partial-
+# failure (the orphan-tag spam of #1076). Best-effort: any API gap yields empty (→ cut a new bump).
+_host_release_version_at_commit() {
+  local agent="$1" commit="$2" host ref obj type csha
+  host="$(_agent_field "$agent" host)"
+  { [ -z "$host" ] || [ -z "$commit" ]; } && return 0
+  while IFS=$'\t' read -r ref obj type; do
+    [ -z "$obj" ] && continue
+    if [ "$type" = "tag" ]; then
+      csha="$(gh api "repos/$host/git/tags/$obj" --jq '(.object?.sha // "" | tostring)' 2>/dev/null || echo "")"
+    else
+      csha="$obj"
+    fi
+    if [ -n "$csha" ] && [ "$csha" = "$commit" ]; then
+      printf '%s\n' "${ref#refs/tags/${agent}/v}"
+      return 0
+    fi
+  done < <(gh api "repos/$host/git/matching-refs/tags/$agent/v" \
+             --jq '.[]? | [.ref, (.object?.sha // "" | tostring), (.object?.type // "" | tostring)] | @tsv' 2>/dev/null)
+  return 0
+}
+
 # _autocut_agent <agent> <dry:true|false> — cut a new candidate for ONE agent if its reusable
 # blob on the host default-branch HEAD differs from the blob at the current `next` candidate.
 # Idempotent: no-op when the blobs match or main HEAD already equals the next candidate.
@@ -881,6 +907,24 @@ _autocut_agent() {
   # is byte-identical between main and the current next candidate.
   if [ "$mainsha" = "$next_commit" ] || { [ -n "$next_blob" ] && [ "$main_blob" = "$next_blob" ]; }; then
     echo "autocut $agent: reusable unchanged on $host (next candidate up to date) — no cut."
+    return 0
+  fi
+  # Idempotent reuse (#1076): if a <agent>/vX.Y.Z release tag already points at the target commit
+  # (main HEAD), do NOT cut a new version — just (re)move `next` onto that existing release via
+  # `cut-release.sh --promote`. This is the partial-failure retry path: last tick the cut succeeded
+  # but the `next` move was blocked (e.g. by the release-channel-tags ruleset), so re-attempting the
+  # move against the already-cut tag converges instead of minting a fresh orphaned version each tick.
+  local existing
+  existing="$(_host_release_version_at_commit "$agent" "$mainsha")"
+  if [ -n "$existing" ]; then
+    echo "autocut $agent: release tag v$existing already points at $host $defbranch HEAD (${mainsha:0:12}) — reusing it, moving next (no new cut)."
+    if [ "$dry" = true ]; then
+      echo "[DRY-RUN] would: cut-release.sh $agent $existing --channel next --promote --push"
+      return 0
+    fi
+    bash "$CUT_RELEASE" "$agent" "$existing" --channel next --promote --push \
+      || { echo "::warning::autocut $agent: cut-release --promote failed for v$existing (best-effort, continuing)"; return 0; }
+    echo "autocut $agent: moved next onto existing v$existing (${mainsha:0:12})."
     return 0
   fi
   bump="$(_autocut_bump "$agent")"

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -786,11 +786,14 @@ GHEOF
 # SHAs, the `next` commit (git for a this-repo agent, gh api for a cross-repo one), the existing
 # release-tag versions (matching-refs), and a cut-release.sh stand-in (CUT_RELEASE) that logs args.
 _autocut_stub() {
-  # args: agent host reusable main_blob next_blob mainsha nextsha versions_ws [bump] [release_at_main]
-  # release_at_main (optional): the version whose <agent>/vX.Y.Z tag points at MAINSHA (the target
-  # commit). Empty → no release tag points at main HEAD (the plain "cut a new bump" path). Non-empty →
-  # exercises the idempotent-reuse path (#1076): autocut must reuse that tag via --promote, not bump.
-  local agent="$1" host="$2" reusable="$3" MAIN_BLOB="$4" NEXT_BLOB="$5" MAINSHA="$6" NEXTSHA="$7" versions="$8" bump="${9:-}" RELEASE_AT_MAIN="${10:-}"
+  # args: agent host reusable main_blob next_blob mainsha nextsha versions_ws [bump] [release_at_main_ws] [annot_tag]
+  # release_at_main_ws (optional, space-separated): versions whose <agent>/vX.Y.Z tag points at MAINSHA.
+  # Empty → no release tag points at main HEAD (plain "cut a new bump" path).
+  # annot_tag (optional, non-empty): use annotated-tag type (type=tag) for release_at_main entries,
+  # exercising the git/tags/<obj> dereference path in _host_release_version_at_commit.
+  local agent="$1" host="$2" reusable="$3" MAIN_BLOB="$4" NEXT_BLOB="$5" MAINSHA="$6" NEXTSHA="$7" versions="$8" bump="${9:-}" RELEASE_AT_MAIN="${10:-}" ANNOT_TAG="${11:-}"
+  # Synthetic tag-object SHA for annotated-tag dereference tests (distinct from any commit SHA).
+  local TAGOBJ_SHA="4242424242424242424242424242424242424242"
   STUB_BIN="$(mktemp -d "$BATS_TEST_TMPDIR/stub.XXXXXX")"; export PATH="$STUB_BIN:$PATH"
   export CUT_LOG="$STUB_BIN/cut.log"; : > "$CUT_LOG"
   export CUT_RELEASE="$STUB_BIN/cut-release"
@@ -799,11 +802,19 @@ _autocut_stub() {
 echo "\$*" >> "$CUT_LOG"
 CUTEOF
   chmod +x "$CUT_RELEASE"
-  local refs="" tsv="" v sha
+  local refs="" tsv="" v sha is_at_main type_val ram
   for v in $versions; do
     refs+="refs/tags/$agent/v$v"$'\n'
-    if [ "$v" = "$RELEASE_AT_MAIN" ]; then sha="$MAINSHA"; else sha="deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"; fi
-    tsv+="refs/tags/$agent/v$v	$sha	commit"$'\n'
+    is_at_main=false
+    for ram in $RELEASE_AT_MAIN; do [ "$v" = "$ram" ] && is_at_main=true && break; done
+    if $is_at_main && [ -n "$ANNOT_TAG" ]; then
+      sha="$TAGOBJ_SHA"; type_val="tag"
+    elif $is_at_main; then
+      sha="$MAINSHA"; type_val="commit"
+    else
+      sha="deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"; type_val="commit"
+    fi
+    tsv+="refs/tags/$agent/v$v	$sha	$type_val"$'\n'
   done
   cat > "$STUB_BIN/gh" <<GHEOF
 #!/usr/bin/env bash
@@ -817,6 +828,7 @@ case "\$*" in
     # .ref query (highest-version bump) needs just the refs.
     if [[ "\$*" == *"@tsv"* ]]; then printf '%s' "$tsv"; else printf '%s' "$refs"; fi
     ;;
+  *"git/tags/$TAGOBJ_SHA"*) echo "$MAINSHA" ;;
   *"git/ref/tags/$agent/next"*) printf '%s\tcommit\n' "$NEXTSHA" ;;
   *"run list"*) echo "[]" ;;
   *) echo "{}" ;;
@@ -927,7 +939,7 @@ GITEOF
     blobMAIN blobNEXT aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa cccccccccccccccccccccccccccccccccccccccc "1.5.0 1.5.1" "" "1.5.1"
   run env CANARY_AUTO_CUT=true CANARY_RINGS="$AUTOCUT_RINGS" CUT_RELEASE="$CUT_RELEASE" bash "$ORCH" autocut
   [ "$status" -eq 0 ]
-  [ "$(grep -c . "$CUT_LOG")" -eq 1 ]
+  [ "$(grep -c . "$CUT_LOG" || true)" -eq 1 ]
   grep -q -- "--promote" "$CUT_LOG"
 }
 
@@ -951,4 +963,27 @@ GITEOF
   [[ "$output" == *"1.5.1"* ]]
   [[ "$output" == *"--promote"* ]]
   [ ! -s "$CUT_LOG" ]   # dry-run never invokes the real cut/promote
+}
+
+@test "orchestrator: autocut reuses an existing annotated release tag at main HEAD via --promote (#1076)" {
+  # Same reuse path as the lightweight-tag test above, but with an annotated tag (object.type=tag).
+  # Exercises the git/tags/<obj> dereference call in _host_release_version_at_commit — the path
+  # NOT covered by the lightweight-tag tests.
+  _autocut_stub dev-lead petry-projects/.github-private .github/workflows/dev-lead-reusable.yml \
+    blobMAIN blobNEXT aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa cccccccccccccccccccccccccccccccccccccccc "1.5.0 1.5.1" "" "1.5.1" "annotated"
+  run env CANARY_AUTO_CUT=true CANARY_RINGS="$AUTOCUT_RINGS" CUT_RELEASE="$CUT_RELEASE" bash "$ORCH" autocut
+  [ "$status" -eq 0 ]
+  grep -q "dev-lead 1.5.1 --channel next --promote --push" "$CUT_LOG"
+  ! grep -q -- "--ref" "$CUT_LOG"
+}
+
+@test "orchestrator: autocut picks the highest semver when multiple release tags point at main HEAD (#1076)" {
+  # Orphan-tag-spam scenario: both v1.5.0 and v1.5.1 point at main HEAD. autocut must reuse
+  # v1.5.1 (the highest), not v1.5.0 (a potentially first-found lower version).
+  _autocut_stub dev-lead petry-projects/.github-private .github/workflows/dev-lead-reusable.yml \
+    blobMAIN blobNEXT aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa cccccccccccccccccccccccccccccccccccccccc "1.5.0 1.5.1" "" "1.5.0 1.5.1"
+  run env CANARY_AUTO_CUT=true CANARY_RINGS="$AUTOCUT_RINGS" CUT_RELEASE="$CUT_RELEASE" bash "$ORCH" autocut
+  [ "$status" -eq 0 ]
+  grep -q "dev-lead 1.5.1 --channel next --promote --push" "$CUT_LOG"
+  ! grep -q "1.5.0 --channel next" "$CUT_LOG"
 }

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -771,8 +771,11 @@ GHEOF
 # SHAs, the `next` commit (git for a this-repo agent, gh api for a cross-repo one), the existing
 # release-tag versions (matching-refs), and a cut-release.sh stand-in (CUT_RELEASE) that logs args.
 _autocut_stub() {
-  # args: agent host reusable main_blob next_blob mainsha nextsha versions_ws [bump]
-  local agent="$1" host="$2" reusable="$3" MAIN_BLOB="$4" NEXT_BLOB="$5" MAINSHA="$6" NEXTSHA="$7" versions="$8" bump="${9:-}"
+  # args: agent host reusable main_blob next_blob mainsha nextsha versions_ws [bump] [release_at_main]
+  # release_at_main (optional): the version whose <agent>/vX.Y.Z tag points at MAINSHA (the target
+  # commit). Empty → no release tag points at main HEAD (the plain "cut a new bump" path). Non-empty →
+  # exercises the idempotent-reuse path (#1076): autocut must reuse that tag via --promote, not bump.
+  local agent="$1" host="$2" reusable="$3" MAIN_BLOB="$4" NEXT_BLOB="$5" MAINSHA="$6" NEXTSHA="$7" versions="$8" bump="${9:-}" RELEASE_AT_MAIN="${10:-}"
   STUB_BIN="$(mktemp -d "$BATS_TEST_TMPDIR/stub.XXXXXX")"; export PATH="$STUB_BIN:$PATH"
   export CUT_LOG="$STUB_BIN/cut.log"; : > "$CUT_LOG"
   export CUT_RELEASE="$STUB_BIN/cut-release"
@@ -781,8 +784,12 @@ _autocut_stub() {
 echo "\$*" >> "$CUT_LOG"
 CUTEOF
   chmod +x "$CUT_RELEASE"
-  local refs="" v
-  for v in $versions; do refs+="refs/tags/$agent/v$v"$'\n'; done
+  local refs="" tsv="" v sha
+  for v in $versions; do
+    refs+="refs/tags/$agent/v$v"$'\n'
+    if [ "$v" = "$RELEASE_AT_MAIN" ]; then sha="$MAINSHA"; else sha="deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"; fi
+    tsv+="refs/tags/$agent/v$v	$sha	commit"$'\n'
+  done
   cat > "$STUB_BIN/gh" <<GHEOF
 #!/usr/bin/env bash
 case "\$*" in
@@ -790,7 +797,11 @@ case "\$*" in
   *"contents/"*"ref=$MAINSHA"*) echo "$MAIN_BLOB" ;;
   *"contents/"*"ref=$NEXTSHA"*) echo "$NEXT_BLOB" ;;
   *"/commits/"*) echo "$MAINSHA" ;;
-  *"matching-refs/tags/$agent/v"*) printf '%s' "$refs" ;;
+  *"matching-refs/tags/$agent/v"*)
+    # The @tsv query (release-at-commit lookup, #1076) needs ref+sha+type; the plain
+    # .ref query (highest-version bump) needs just the refs.
+    if [[ "\$*" == *"@tsv"* ]]; then printf '%s' "$tsv"; else printf '%s' "$refs"; fi
+    ;;
   *"git/ref/tags/$agent/next"*) printf '%s\tcommit\n' "$NEXTSHA" ;;
   *"run list"*) echo "[]" ;;
   *) echo "{}" ;;
@@ -872,4 +883,57 @@ GITEOF
   run env CANARY_AUTO_CUT=true CANARY_RINGS="$AUTOCUT_RINGS" CUT_RELEASE="$CUT_RELEASE" bash "$ORCH" autocut
   [ "$status" -eq 0 ]
   grep -q "auto-rebase 2.1.1 --ref ece45480ece45480ece45480ece45480ece45480 --channel next --push" "$CUT_LOG"
+}
+
+# ── orchestrator: autocut idempotent reuse — a release tag already at main HEAD (#1076) ─
+# When a <agent>/vX.Y.Z already points at the target commit (main HEAD) but `next` is not on it
+# (the partial-failure state: the cut succeeded, the `next` move was blocked), autocut must REUSE
+# that tag by moving `next` onto it via `cut-release.sh --promote` — never mint a new bumped
+# version. This makes a retry converge instead of spamming a fresh orphan tag every tick.
+@test "orchestrator: autocut reuses an existing release tag at main HEAD, moving next via --promote (no new cut) (#1076)" {
+  # Reusable blob differs (would normally cut), but v1.5.1 already points at main HEAD (aaaa),
+  # and next is still on the old commit (cccc). Reuse v1.5.1, do NOT bump to v1.5.2.
+  _autocut_stub dev-lead petry-projects/.github-private .github/workflows/dev-lead-reusable.yml \
+    blobMAIN blobNEXT aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa cccccccccccccccccccccccccccccccccccccccc "1.5.0 1.5.1" "" "1.5.1"
+  run env CANARY_AUTO_CUT=true CANARY_RINGS="$AUTOCUT_RINGS" CUT_RELEASE="$CUT_RELEASE" bash "$ORCH" autocut
+  [ "$status" -eq 0 ]
+  # next is (re)moved onto the EXISTING v1.5.1 via --promote …
+  grep -q "dev-lead 1.5.1 --channel next --promote --push" "$CUT_LOG"
+  # … and NO new bumped version is cut (no orphan v1.5.2 spam).
+  ! grep -q -- "--ref" "$CUT_LOG"
+  ! grep -q "1.5.2" "$CUT_LOG"
+}
+
+@test "orchestrator: autocut retry-after-partial-failure cuts no duplicate version (#1076)" {
+  # Simulate the exact live regression: v1.5.1 was cut at main HEAD last tick but its next move
+  # was blocked, so next is stale. The next tick must NOT cut v1.5.2 — it re-attempts the move
+  # against the already-cut v1.5.1. Exactly ONE cut-release invocation, and it is the --promote.
+  _autocut_stub dev-lead petry-projects/.github-private .github/workflows/dev-lead-reusable.yml \
+    blobMAIN blobNEXT aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa cccccccccccccccccccccccccccccccccccccccc "1.5.0 1.5.1" "" "1.5.1"
+  run env CANARY_AUTO_CUT=true CANARY_RINGS="$AUTOCUT_RINGS" CUT_RELEASE="$CUT_RELEASE" bash "$ORCH" autocut
+  [ "$status" -eq 0 ]
+  [ "$(grep -c . "$CUT_LOG")" -eq 1 ]
+  grep -q -- "--promote" "$CUT_LOG"
+}
+
+@test "orchestrator: autocut still cuts a bumped version when NO release tag points at main HEAD (#1076)" {
+  # No existing tag points at main HEAD (release_at_main empty) → the today behavior is preserved:
+  # cut the bumped v2.1.1 from main HEAD and move next, NOT a --promote.
+  _autocut_stub dev-lead petry-projects/.github-private .github/workflows/dev-lead-reusable.yml \
+    blobMAIN blobNEXT aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa cccccccccccccccccccccccccccccccccccccccc "2.1.0"
+  run env CANARY_AUTO_CUT=true CANARY_RINGS="$AUTOCUT_RINGS" CUT_RELEASE="$CUT_RELEASE" bash "$ORCH" autocut
+  [ "$status" -eq 0 ]
+  grep -q "dev-lead 2.1.1 --ref aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa --channel next --push" "$CUT_LOG"
+  ! grep -q -- "--promote" "$CUT_LOG"
+}
+
+@test "orchestrator: autocut --dry-run on the reuse path prints the --promote without invoking cut-release (#1076)" {
+  _autocut_stub dev-lead petry-projects/.github-private .github/workflows/dev-lead-reusable.yml \
+    blobMAIN blobNEXT aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa cccccccccccccccccccccccccccccccccccccccc "1.5.0 1.5.1" "" "1.5.1"
+  run env CANARY_AUTO_CUT=true CANARY_RINGS="$AUTOCUT_RINGS" CUT_RELEASE="$CUT_RELEASE" bash "$ORCH" autocut --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY-RUN"* ]]
+  [[ "$output" == *"1.5.1"* ]]
+  [[ "$output" == *"--promote"* ]]
+  [ ! -s "$CUT_LOG" ]   # dry-run never invokes the real cut/promote
 }


### PR DESCRIPTION
Closes #1076

Implemented by dev-lead agent. Please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `autocut` now reuses an existing release version when the current main branch commit is already tagged, instead of always creating a new version.
  * When reusing a release, `next` is moved forward to that existing version automatically.
  * Dry-run mode now reflects this reuse flow.

* **Bug Fixes**
  * Improved handling for tagged releases on the current main commit, including annotated tags and multiple matching tags.
  * Partial failures during the promotion step are now treated as warnings, reducing unnecessary sweep failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->