### PR TITLE
fix(canary-rollout): sync-issues must not abort under set -e when issue-create fails (#1081)

### DIFF
--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -744,16 +744,20 @@ cmd_sync_issues() {
     read -r cand frontier transition state _d _f _s _t cum_fail cum_startup _cb triage < <(_frontier_state "$agent")
     host="$(_agent_field "$agent" host)"
     local blk="—" num_state num istate
-    num_state="$(_issue_find canary-blocker "<!-- canary-blocker:$agent -->")"
+    # Best-effort (#1081): these substitutions call gh/jq. Under `set -euo pipefail`
+    # a bare assignment propagates a non-zero exit and would abort the whole step —
+    # before the fleet dashboard renders and before the intended fallback warnings
+    # below. `|| true` keeps sync-issues degrading gracefully (empty → handled).
+    num_state="$(_issue_find canary-blocker "<!-- canary-blocker:$agent -->" || true)"
     num="${num_state%%$'\t'*}"; istate="${num_state##*$'\t'}"
     if [ "$state" = "BLOCKED" ]; then
       local evidence body title
-      evidence="$(_blocker_evidence "$agent" "$cand")"
+      evidence="$(_blocker_evidence "$agent" "$cand" || true)"
       body="$(_blocker_body "$agent" "$transition" "$cand" "$cum_fail" "$cum_startup" "$triage" "$host" "$evidence")"
       title="Canary blocker: $agent $transition (cum_fail=$cum_fail, $triage)"
       if [ -z "$num" ]; then
         if [ "$dry" = true ]; then echo "  [DRY] would OPEN blocker issue for $agent ($triage)"; blk="(new)"; else
-          num="$(_gh_issue_create "$title" "$body" "canary-blocker")"
+          num="$(_gh_issue_create "$title" "$body" "canary-blocker" || true)"
           if [ -n "$num" ]; then
             [ "$triage" = "REGRESSION" ] && gh issue edit "$num" --repo "$ISSUE_REPO" --add-label needs-human >/dev/null 2>&1 || true
             echo "  opened blocker issue #$num for $agent"; blk="#$num"

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -741,6 +741,21 @@ GHEOF
   grep -q "dev-lead" "$summ"
 }
 
+@test "orchestrator: sync-issues survives a failing 'gh issue create' — no abort under set -e, still renders the fleet summary (#1081)" {
+  # Regression: the blocker-issue create failing (App lacks Issues:write, rate-limit, …)
+  # must NOT abort the whole step before the dashboard renders. Make `gh issue create` exit
+  # non-zero and assert graceful degradation: warning logged, table still written, status 0.
+  _sync_stub failure '[]'
+  sed -i 's#"issue create"\*).*#"issue create"*) echo "gh: HTTP 403 (Issues:write?)" >\&2; exit 1 ;;#' "$STUB_BIN/gh"
+  local summ="$BATS_TEST_TMPDIR/summary_fail.md"; : > "$summ"
+  run env CANARY_RINGS="$SYNC_RINGS" ISSUE_REPO="petry-projects/.github-private" GITHUB_STEP_SUMMARY="$summ" bash "$ORCH" sync-issues
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"could not open blocker issue for dev-lead (Issues:write on the App?)"* ]]
+  [[ "$output" == *"wrote fleet-status table to the job summary"* ]]
+  grep -q "Canary Rollout — fleet status" "$summ"
+  grep -q "dev-lead" "$summ"
+}
+
 @test "orchestrator: sync-issues auto-closes a cleared agent's open blocker issue" {
   # dev-lead now clean (success → not BLOCKED) but an OPEN blocker issue #501 exists → close it.
   _sync_stub success '[{"number":501,"state":"OPEN","body":"<!-- canary-blocker:dev-lead -->"}]'

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -746,7 +746,7 @@ GHEOF
   # must NOT abort the whole step before the dashboard renders. Make `gh issue create` exit
   # non-zero and assert graceful degradation: warning logged, table still written, status 0.
   _sync_stub failure '[]'
-  sed -i 's#"issue create"\*).*#"issue create"*) echo "gh: HTTP 403 (Issues:write?)" >\&2; exit 1 ;;#' "$STUB_BIN/gh"
+  sed 's#"issue create"\*).*#"issue create"*) echo "gh: HTTP 403 (Issues:write?)" >\&2; exit 1 ;;#' "$STUB_BIN/gh" > "$STUB_BIN/gh.tmp" && mv "$STUB_BIN/gh.tmp" "$STUB_BIN/gh" && chmod +x "$STUB_BIN/gh"
   local summ="$BATS_TEST_TMPDIR/summary_fail.md"; : > "$summ"
   run env CANARY_RINGS="$SYNC_RINGS" ISSUE_REPO="petry-projects/.github-private" GITHUB_STEP_SUMMARY="$summ" bash "$ORCH" sync-issues
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Fixes #1081.

## Symptom
`sync-issues` has emitted `##[warning]issue sync failed (non-fatal)` on **every** scheduled `canary-rollout` run since deploy → no `canary-blocker` issues filed, no fleet-status table in the job summary. The auto-triage/observability layer (#1063) is dark, even though promotion gating works.

## Root cause
`cmd_sync_issues` runs under `set -euo pipefail`. For the one BLOCKED agent with no existing issue it hits the **bare assignment** `num="$(_gh_issue_create …)"` (canary-rollout.sh:756). `_gh_issue_create` is a `gh … | grep | tail` pipeline → non-zero under `pipefail` whenever `gh` fails or `grep` matches nothing. Because it's a bare assignment (not `local`), `set -e` aborts the whole step — **before** the dashboard renders (~line 790) and **before** the intended `Issues:write on the App?` warning (line 760). Non-blocked agents print nothing, so the step goes silent ~3 min then dies. Same family as #594.

Compounding: the release-manager App appears to **lack `Issues:write`** on this repo (the `canary-blocker` label was never created, no issue ever filed) — so `gh issue create` 403s every time.

## Fix
Guard the three gh/jq-touching command substitutions in `cmd_sync_issues` (`_issue_find`, `_blocker_evidence`, `_gh_issue_create`) with `|| true`. Failures now fall through to the existing empty-value handling: the warning is logged and **the dashboard still renders**. Graceful degradation — green run + fleet table every tick, whether or not issue-filing is permitted.

## Test
New regression test (`#1081`) makes `gh issue create` exit non-zero and asserts the step exits 0, warns, and still writes the fleet summary. It fails on the pre-fix code. **75/75 bats pass.**

## Follow-up (config — cannot self-apply)
To actually file blocker issues, grant the release-manager GitHub App **`Issues:write`** on `petry-projects/.github-private`. Until then this fix keeps the run green and the dashboard live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)