### PR TITLE
feat: implement issue #1082 — canary-rollout: no auto-discovery of unregistered reusables — registry is hand-maintained; add drift detection for *-reusable.yml missing from canary-rings.json

### DIFF
--- a/.github/workflows/canary-rollout.yml
+++ b/.github/workflows/canary-rollout.yml
@@ -44,9 +44,9 @@ on:
   workflow_dispatch:
     inputs:
       command:
-        description: "autocut (gated cut+seed) | evaluate | evaluate-all (read-only) | promote | promote-all (gated tag move) | rollback | sync-issues"
+        description: "autocut (gated cut+seed) | evaluate | evaluate-all (read-only) | promote | promote-all (gated tag move) | rollback | sync-issues | drift (read-only registry audit)"
         type: choice
-        options: [autocut, evaluate, evaluate-all, promote, promote-all, rollback, sync-issues]
+        options: [autocut, evaluate, evaluate-all, promote, promote-all, rollback, sync-issues, drift]
         default: evaluate
       agent:
         description: "agent to act on"
@@ -186,6 +186,7 @@ jobs:
               args=(sync-issues)
               [ "$DRY_RUN" != "false" ] && args+=(--dry-run)   # default-safe: dry unless explicitly false
               ;;
+            drift) args=(drift) ;;                             # read-only registry/host reusable audit (#1082)
             *) echo "::error::unknown command: $CMD"; exit 2 ;;
           esac
           echo "::notice::canary-rollout ${args[*]}"
@@ -235,3 +236,19 @@ jobs:
         run: |
           set -uo pipefail
           bash scripts/canary-rollout.sh sync-issues || echo "::warning::issue sync failed (non-fatal)"
+
+      # Reusable-registry drift audit (#1082): the registry (.agents{}) is the MANUAL source
+      # of truth for what this pipeline manages — a *-reusable.yml added/renamed on a host but
+      # never registered ships with ZERO staged rollout (no cut/soak/gate/dashboard) until a
+      # human registers it. This read-only step scans every host's .github/workflows for
+      # *-reusable.yml, diffs against the registry, and surfaces (a) unregistered reusables and
+      # (b) stale registry entries whose file is gone — as ::warning:: annotations + a job-summary
+      # table, within one scheduled cycle. Report-only (never registers anything). Best-effort +
+      # always(): a drift-scan hiccup must never fail the promotion run.
+      - name: Reusable-registry drift audit
+        if: always() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -uo pipefail
+          bash scripts/canary-rollout.sh drift || echo "::warning::drift audit failed (non-fatal)"

--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -978,7 +978,7 @@ _agents_for_reusable() {
 # so a new reusable does not silently inherit another agent's benign classes. --emit-stub only.
 _drift_scaffold() {
   local host="$1" path="$2" name
-  name="$(basename "$path")"; name="${name%-reusable.yml}"
+  name="${path##*/}"; name="${name%-reusable.yml}"
   _jq --arg h "$host" --arg p "$path" --arg n "$name" '
     (.agents | to_entries | (map(select(.value.host==$h)) + .) | .[0].value) as $tpl
     | { ($n): ($tpl
@@ -1016,8 +1016,13 @@ cmd_drift() {
       continue
     fi
     registered="$(_registered_reusables_for_host "$host")"
-    echo "  registered reusables ($(printf '%s' "$registered" | grep -c . || true)):$(printf '%s' "$registered" | paste -sd' ' - | sed 's/^/ /;s/^ $//')"
-    echo "  present *-reusable.yml ($(printf '%s' "$present" | grep -c . || true)):$(printf '%s' "$present" | paste -sd' ' - | sed 's/^/ /;s/^ $//')"
+    local reg_arr=() pres_arr=() reg_str="" pres_str=""
+    if [ -n "$registered" ]; then mapfile -t reg_arr <<< "$registered"; fi
+    if [ -n "$present" ]; then mapfile -t pres_arr <<< "$present"; fi
+    [ "${#reg_arr[@]}" -gt 0 ] && reg_str=" ${reg_arr[*]}"
+    [ "${#pres_arr[@]}" -gt 0 ] && pres_str=" ${pres_arr[*]}"
+    echo "  registered reusables (${#reg_arr[@]}):$reg_str"
+    echo "  present *-reusable.yml (${#pres_arr[@]}):$pres_str"
     # unregistered = present on the host but not in the registry.
     unregistered="$(set_difference "$present" "$registered")"
     while IFS= read -r p; do
@@ -1092,7 +1097,7 @@ main() {
     sync-issues)  cmd_sync_issues "$@" ;;   # upsert blocker issues + dashboard for held promotions
     autocut)      cmd_autocut "$@" ;;       # cut a new candidate when a reusable changes on main (#1069)
     drift)        cmd_drift "$@" ;;         # report reusables present on a host but unregistered, + stale registry entries (#1082)
-    *) echo "::error::usage: canary-rollout.sh {autocut|evaluate|evaluate-all|promote|promote-all|rollback|resolve|sync-issues|drift} <agent> ..." >&2; return 2 ;;
+    *) echo "::error::usage: canary-rollout.sh {autocut|drift|evaluate|evaluate-all|promote|promote-all|rollback|resolve|sync-issues} [args]" >&2; return 2 ;;
   esac
 }
 

--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -26,6 +26,7 @@ set -euo pipefail
 #   canary-rollout.sh rollback <agent> <ring> --to <vX.Y.Z> [--dry-run]
 #   canary-rollout.sh resolve  <agent> <channel>       # debug: print resolved member repos
 #   canary-rollout.sh sync-issues [--dry-run]          # blocker issue per BLOCKED agent + fleet-status table to the job summary (auto-triage)
+#   canary-rollout.sh drift    [--emit-stub]           # read-only: report *-reusable.yml on a host but unregistered, + stale registry entries (#1082)
 #
 # Gate standard: .github#548 — graduated per-transition dwell/sample floors over a
 # per-candidate cumulative window (since the candidate's OWN vX.Y.Z cut), a robust
@@ -918,6 +919,156 @@ cmd_autocut() {
   return 0
 }
 
+# ── drift: registry vs host reusables (read-only audit, #1082) ──────────────────
+# canary-rings.json's .agents{} is the MANUAL source of truth for what the canary
+# pipeline manages — both autocut and evaluate-all iterate `.agents | keys`, so ANY
+# reusable not registered is covered by nothing (no cut, no soak, no gate, no dashboard).
+# There is otherwise no scan of the hosts' .github/workflows/*-reusable.yml, so a
+# first-party reusable that was added/renamed but never registered ships with ZERO staged
+# rollout until a human remembers to register it.
+#
+# `drift` closes that observability gap: it enumerates the *-reusable.yml on every
+# registered host repo, diffs against the registry's reusable paths, and REPORTS (stdout +
+# job summary) two classes of drift. It is read-only — it never registers anything (ring
+# topology/members need human intent); `--emit-stub` optionally prints a scaffold
+# .agents[<name>] block for a maintainer to fill in.
+#   - unregistered: a *-reusable.yml present on a host but absent from canary-rings.json.
+#   - missing-file: a registry entry whose reusable file no longer exists on its host.
+
+# _registered_hosts — the set of host repos to scan: the union of every agent's `host`
+# and the org_infra_repos list, deduped (one repo per line).
+_registered_hosts() {
+  _jq -r '([.agents[]?.host // empty] + (.org_infra_repos // []))
+          | map(select(. != "")) | unique | .[]'
+}
+
+# _gh_list_reusables <repo> — the full paths of *-reusable.yml files under the repo's
+# .github/workflows (one per line). Reads the directory listing via the contents API and
+# filters locally (mirrors _run_json: raw fetch, jq in the caller). Returns non-zero when
+# the listing could NOT be enumerated (the API errored or did not return a JSON array), so
+# the caller can distinguish "no reusables here" from "could not read the host" — the latter
+# must NOT be treated as every registered reusable having been deleted (a false missing-file
+# avalanche). A genuinely empty (but readable) workflows dir returns success with no output.
+_gh_list_reusables() {
+  local repo="$1" json
+  json="$(gh api "repos/$repo/contents/.github/workflows" 2>/dev/null)" || return 1
+  jq -e 'type=="array"' >/dev/null 2>&1 <<< "$json" || return 1
+  jq -r '[.[]? | select(.type=="file") | select((.name // "") | endswith("-reusable.yml")) | .path] | .[]' \
+    2>/dev/null <<< "$json" || true
+  return 0
+}
+
+# _registered_reusables_for_host <host> — the reusable paths registered to <host> (one
+# per line, deduped).
+_registered_reusables_for_host() {
+  _jq -r --arg h "$1" '[.agents[]? | select(.host==$h) | .reusable // empty] | unique | .[]'
+}
+
+# _agents_for_reusable <host> <path> — the registry agent name(s) whose (host,reusable)
+# match, joined by ", " (for the missing-file finding message).
+_agents_for_reusable() {
+  _jq -r --arg h "$1" --arg p "$2" \
+    '[.agents | to_entries[] | select(.value.host==$h and .value.reusable==$p) | .key] | join(", ")'
+}
+
+# _drift_scaffold <host> <path> — a scaffold .agents[<name>] JSON block for an unregistered
+# reusable, keyed by the name derived from the filename (foo-reusable.yml → foo). Clones an
+# existing agent's ring topology + gate defaults as a starting point (members need human
+# intent), resets host/reusable/run_workflow, and empties the per-reusable benign allowlist
+# so a new reusable does not silently inherit another agent's benign classes. --emit-stub only.
+_drift_scaffold() {
+  local host="$1" path="$2" name
+  name="$(basename "$path")"; name="${name%-reusable.yml}"
+  _jq --arg h "$host" --arg p "$path" --arg n "$name" '
+    (.agents | to_entries | (map(select(.value.host==$h)) + .) | .[0].value) as $tpl
+    | { ($n): ($tpl
+        | .host = $h
+        | .reusable = $p
+        | .run_workflow = "TODO: set to the reusable workflow name (the name: value)"
+        | (.gate.benign_failure_classes) = []) }'
+}
+
+# cmd_drift [--emit-stub] — the read-only registry/host drift audit. Exits 0 (report-only);
+# each finding is a ::warning:: annotation and a job-summary row. --emit-stub additionally
+# prints a scaffold .agents[<name>] block per unregistered reusable.
+cmd_drift() {
+  local emit_stub=false
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --emit-stub) emit_stub=true ;;
+      *) echo "::error::unknown drift flag: $1" >&2; return 2 ;;
+    esac; shift
+  done
+  echo "== canary-rollout drift: registry vs host reusables (read-only; gate standard: .github#548) =="
+  local hosts host rows="" stubs="" u_total=0 m_total=0
+  hosts="$(_registered_hosts)"
+  if [ -z "$hosts" ]; then
+    echo "no host repos resolved from $CANARY_RINGS — nothing to audit."; return 0
+  fi
+  while IFS= read -r host; do
+    [ -z "$host" ] && continue
+    echo "──────── host: $host ────────"
+    local present registered unregistered missing p agents
+    if ! present="$(_gh_list_reusables "$host")"; then
+      # Could not read the host's workflows dir — skip it rather than false-flag every
+      # registered reusable as missing-file. Read-only + best-effort: a warning, not a failure.
+      echo "::warning::drift $host: could not enumerate .github/workflows (API error / no access) — skipping host this cycle"
+      continue
+    fi
+    registered="$(_registered_reusables_for_host "$host")"
+    echo "  registered reusables ($(printf '%s' "$registered" | grep -c . || true)):$(printf '%s' "$registered" | paste -sd' ' - | sed 's/^/ /;s/^ $//')"
+    echo "  present *-reusable.yml ($(printf '%s' "$present" | grep -c . || true)):$(printf '%s' "$present" | paste -sd' ' - | sed 's/^/ /;s/^ $//')"
+    # unregistered = present on the host but not in the registry.
+    unregistered="$(set_difference "$present" "$registered")"
+    while IFS= read -r p; do
+      [ -z "$p" ] && continue
+      echo "::warning::DRIFT[unregistered] $host: $p present on host but absent from canary-rings.json (no cut/soak/gate/dashboard until registered)"
+      rows+="| \`$host\` | unregistered | \`$p\` | not in \`.agents{}\` — register it or delete the file |"$'\n'
+      u_total=$((u_total + 1))
+      if [ "$emit_stub" = true ]; then stubs+="$(_drift_scaffold "$host" "$p")"$'\n'; fi
+    done <<< "$unregistered"
+    # missing-file = registered in the registry but the file is gone from the host.
+    missing="$(set_difference "$registered" "$present")"
+    while IFS= read -r p; do
+      [ -z "$p" ] && continue
+      agents="$(_agents_for_reusable "$host" "$p")"
+      echo "::warning::DRIFT[missing-file] $host: registry agent '${agents:-?}' -> $p not found on host (deleted/renamed reusable; stale registry entry)"
+      rows+="| \`$host\` | missing-file | \`$p\` | registry agent \`${agents:-?}\` points at a file that no longer exists |"$'\n'
+      m_total=$((m_total + 1))
+    done <<< "$missing"
+  done <<< "$hosts"
+
+  echo "----"
+  local total=$((u_total + m_total))
+  echo "drift summary: $u_total unregistered, $m_total missing-file ($total total findings)"
+  if [ "$total" -eq 0 ]; then
+    echo "no reusable drift detected — the registry and host reusables are in sync."
+  fi
+  if [ "$emit_stub" = true ] && [ -n "$stubs" ]; then
+    echo "---- scaffold .agents[<name>] stubs for unregistered reusables (--emit-stub) ----"
+    echo "Paste into standards/canary-rings.json under .agents, then set run_workflow + review ring members:"
+    printf '%s' "$stubs"
+  fi
+
+  # Render the fleet-drift table into the run's job summary (a read-only snapshot). Falls
+  # back to stdout when GITHUB_STEP_SUMMARY is unset (local/manual runs).
+  local ts dmd
+  ts="$(date -u +%Y-%m-%dT%H:%MZ 2>/dev/null || echo unknown)"
+  if [ "$total" -eq 0 ]; then
+    dmd="$(printf '# Canary Rollout — reusable drift\n\nLast updated: `%s` · gate standard: .github#548.\n\n_No reusable drift — the registry and host `*-reusable.yml` are in sync._\n' "$ts")"
+  else
+    dmd="$(printf '# Canary Rollout — reusable drift\n\nLast updated: `%s` · gate standard: .github#548 · findings: **%s** (%s unregistered, %s missing-file).\n\n| host | class | reusable | note |\n|---|---|---|---|\n%s\n> `unregistered` ships with ZERO staged rollout until added to `.agents{}`; `missing-file` is a stale registry entry pointing at a deleted reusable. Report-only — no auto-registration.\n' "$ts" "$total" "$u_total" "$m_total" "${rows%$'\n'}")"
+  fi
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    if printf '\n%s\n' "$dmd" >> "$GITHUB_STEP_SUMMARY"; then
+      echo "  wrote reusable-drift table to the job summary"
+    else
+      echo "::warning::could not write the reusable-drift job summary"
+    fi
+  fi
+  return 0
+}
+
 main() {
   local cmd
   for cmd in jq gh git; do
@@ -940,7 +1091,8 @@ main() {
     resolve)      [ $# -ge 2 ] || { echo "usage: resolve <agent> <channel>" >&2; return 2; }; resolve_members "$@" ;;
     sync-issues)  cmd_sync_issues "$@" ;;   # upsert blocker issues + dashboard for held promotions
     autocut)      cmd_autocut "$@" ;;       # cut a new candidate when a reusable changes on main (#1069)
-    *) echo "::error::usage: canary-rollout.sh {autocut|evaluate|evaluate-all|promote|promote-all|rollback|resolve|sync-issues} <agent> ..." >&2; return 2 ;;
+    drift)        cmd_drift "$@" ;;         # report reusables present on a host but unregistered, + stale registry entries (#1082)
+    *) echo "::error::usage: canary-rollout.sh {autocut|evaluate|evaluate-all|promote|promote-all|rollback|resolve|sync-issues|drift} <agent> ..." >&2; return 2 ;;
   esac
 }
 

--- a/scripts/lib/canary-rollout.sh
+++ b/scripts/lib/canary-rollout.sh
@@ -218,6 +218,22 @@ transition_key() {
   echo ""
 }
 
+# ── set-diff core (drift detection, #1082) ────────────────────────────────────
+# The registry (.agents{}) is the MANUAL source of truth for what the canary pipeline
+# manages; drift detection diffs it against the *-reusable.yml actually present on each
+# host. Both sides of that diff are a plain set difference over whole-line strings.
+
+# set_difference <set_a_newlines> <set_b_newlines> — echo each line of A that is NOT
+# present in B (whole-line match; order + duplicates of A preserved, blank lines dropped).
+# Pure: bash + grep only, no gh/git I/O — deterministically unit-testable.
+set_difference() {
+  local a="$1" b="$2" line
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    if ! grep -qxF -- "$line" <<< "$b"; then printf '%s\n' "$line"; fi
+  done <<< "$a"
+}
+
 # gate_summary_line <transition> <state> <dwell_h> <dwell_floor> <sample> <sample_target> <cum_fail> <cum_startup> [cum_benign]
 # One-line human/observability row (used by `evaluate`, doubling as the #502 report).
 # cum_benign (allowlisted failures excluded from cum_fail) is shown when provided.

--- a/scripts/lib/canary-rollout.sh
+++ b/scripts/lib/canary-rollout.sh
@@ -225,12 +225,18 @@ transition_key() {
 
 # set_difference <set_a_newlines> <set_b_newlines> — echo each line of A that is NOT
 # present in B (whole-line match; order + duplicates of A preserved, blank lines dropped).
-# Pure: bash + grep only, no gh/git I/O — deterministically unit-testable.
+# Pure: bash only (associative-array lookup), no gh/git I/O — deterministically unit-testable.
 set_difference() {
   local a="$1" b="$2" line
+  declare -A b_map
+  while IFS= read -r line; do
+    [ -n "$line" ] && b_map["$line"]=1
+  done <<< "$b"
   while IFS= read -r line; do
     [ -z "$line" ] && continue
-    if ! grep -qxF -- "$line" <<< "$b"; then printf '%s\n' "$line"; fi
+    if [[ -z "${b_map["$line"]:-}" ]]; then
+      printf '%s\n' "$line"
+    fi
   done <<< "$a"
 }
 

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -873,3 +873,165 @@ GITEOF
   [ "$status" -eq 0 ]
   grep -q "auto-rebase 2.1.1 --ref ece45480ece45480ece45480ece45480ece45480 --channel next --push" "$CUT_LOG"
 }
+
+# ── set_difference (pure set-diff core for drift detection, #1082) ─────────────
+# args: <set_a_newlines> <set_b_newlines> — echo lines in A that are NOT in B.
+@test "set_difference: A minus B keeps only A-only elements" {
+  run set_difference "$(printf 'a\nb\nc\n')" "$(printf 'b\n')"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf 'a\nc')" ]
+}
+@test "set_difference: no overlap returns all of A" {
+  run set_difference "$(printf 'x\ny\n')" "$(printf 'p\nq\n')"
+  [ "$output" = "$(printf 'x\ny')" ]
+}
+@test "set_difference: full overlap returns nothing" {
+  run set_difference "$(printf 'a\nb\n')" "$(printf 'a\nb\n')"
+  [ -z "$output" ]
+}
+@test "set_difference: empty A returns nothing" {
+  run set_difference "" "$(printf 'a\n')"
+  [ -z "$output" ]
+}
+@test "set_difference: empty B returns all of A (nothing removed)" {
+  run set_difference "$(printf 'a\nb\n')" ""
+  [ "$output" = "$(printf 'a\nb')" ]
+}
+@test "set_difference: matches whole lines only (a path is not a prefix match)" {
+  # '.github/workflows/foo-reusable.yml' must not be swallowed by a partial 'foo'.
+  run set_difference "$(printf '.github/workflows/foo-reusable.yml\n')" "$(printf 'foo\n')"
+  [ "$output" = ".github/workflows/foo-reusable.yml" ]
+}
+
+# ── orchestrator: drift — registry vs host reusables (read-only audit, #1082) ──
+# The registry (.agents{}) is the MANUAL source of truth for what the canary pipeline
+# manages. `drift` scans each registered host repo's .github/workflows/*-reusable.yml
+# and diffs it against the registry so an unregistered reusable (zero staged rollout) OR
+# a registry entry pointing at a deleted reusable surfaces within one scheduled cycle.
+#
+# The stub answers `gh api repos/<host>/contents/.github/workflows` with a per-host JSON
+# array (env HOSTPRIV_JSON / HOSTPUB_JSON); the orchestrator filters *-reusable.yml itself.
+_drift_stub() {
+  # $1 = JSON array for petry-projects/.github-private ; $2 = JSON array for petry-projects/.github
+  local priv_json="$1" pub_json="${2:-[]}"
+  STUB_BIN="$(mktemp -d "$BATS_TEST_TMPDIR/stub.XXXXXX")"; export PATH="$STUB_BIN:$PATH"
+  # '.github' is a substring of '.github-private', so match the more specific repo FIRST.
+  cat > "$STUB_BIN/gh" <<GHEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"repos/petry-projects/.github-private/contents/.github/workflows"*) cat <<'JSON'
+$priv_json
+JSON
+    ;;
+  *"repos/petry-projects/.github/contents/.github/workflows"*) cat <<'JSON'
+$pub_json
+JSON
+    ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN/gh"
+  cat > "$STUB_BIN/git" <<'GITEOF'
+#!/usr/bin/env bash
+: # drift never touches git
+GITEOF
+  chmod +x "$STUB_BIN/git"
+}
+
+# A registry with a single this-repo agent (dev-lead) so the present/registered sets are
+# fully controlled: registered on .github-private = {dev-lead-reusable.yml}, none on .github.
+_drift_rings_one_agent() {
+  DRIFT_RINGS="$BATS_TEST_TMPDIR/drift-rings.json"
+  jq '{version, description, org_infra_repos, member_tokens, agents: {"dev-lead": .agents["dev-lead"]}}' \
+    "$RINGS" > "$DRIFT_RINGS"
+}
+
+@test "orchestrator: drift flags a reusable present on a host but absent from the registry (unregistered)" {
+  _drift_rings_one_agent
+  # .github-private hosts an EXTRA foo-reusable.yml that no .agents{} block registers.
+  _drift_stub '[
+    {"type":"file","name":"dev-lead-reusable.yml","path":".github/workflows/dev-lead-reusable.yml"},
+    {"type":"file","name":"foo-reusable.yml","path":".github/workflows/foo-reusable.yml"},
+    {"type":"file","name":"ci.yml","path":".github/workflows/ci.yml"}
+  ]' '[]'
+  run env CANARY_RINGS="$DRIFT_RINGS" bash "$ORCH" drift
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRIFT[unregistered]"* ]]
+  [[ "$output" == *".github/workflows/foo-reusable.yml"* ]]
+  # the registered reusable and the non-reusable ci.yml are NOT flagged
+  [[ "$output" != *"DRIFT[unregistered] petry-projects/.github-private: .github/workflows/dev-lead-reusable.yml"* ]]
+  [[ "$output" != *"ci.yml present on host"* ]]
+}
+
+@test "orchestrator: drift flags a registry entry whose reusable file no longer exists on the host (missing-file)" {
+  # Registry has 'ghost' pointing at a reusable that is NOT present on the host.
+  DRIFT_RINGS="$BATS_TEST_TMPDIR/drift-ghost.json"
+  jq '{version, description, org_infra_repos, member_tokens,
+       agents: {"ghost": (.agents["dev-lead"] + {reusable: ".github/workflows/ghost-reusable.yml"})}}' \
+    "$RINGS" > "$DRIFT_RINGS"
+  # Host lists only an unrelated (registered-elsewhere-none) file — ghost-reusable.yml is gone.
+  _drift_stub '[
+    {"type":"file","name":"dev-lead-reusable.yml","path":".github/workflows/dev-lead-reusable.yml"}
+  ]' '[]'
+  run env CANARY_RINGS="$DRIFT_RINGS" bash "$ORCH" drift
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRIFT[missing-file]"* ]]
+  [[ "$output" == *"ghost"* ]]
+  [[ "$output" == *".github/workflows/ghost-reusable.yml"* ]]
+}
+
+@test "orchestrator: drift reports NO drift when the registry and host reusables are in sync" {
+  _drift_rings_one_agent
+  # Host lists exactly the one registered reusable — nothing extra, nothing missing.
+  _drift_stub '[
+    {"type":"file","name":"dev-lead-reusable.yml","path":".github/workflows/dev-lead-reusable.yml"}
+  ]' '[]'
+  run env CANARY_RINGS="$DRIFT_RINGS" bash "$ORCH" drift
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"DRIFT["* ]]
+  [[ "$output" == *"no reusable drift"* ]]
+  [[ "$output" == *"0 unregistered, 0 missing-file"* ]]
+}
+
+@test "orchestrator: drift --emit-stub prints a scaffold .agents[<name>] block for an unregistered reusable" {
+  _drift_rings_one_agent
+  _drift_stub '[
+    {"type":"file","name":"dev-lead-reusable.yml","path":".github/workflows/dev-lead-reusable.yml"},
+    {"type":"file","name":"foo-reusable.yml","path":".github/workflows/foo-reusable.yml"}
+  ]' '[]'
+  run env CANARY_RINGS="$DRIFT_RINGS" bash "$ORCH" drift --emit-stub
+  [ "$status" -eq 0 ]
+  # A scaffold JSON object keyed by the derived agent name 'foo' the maintainer can fill in.
+  [[ "$output" == *"\"foo\""* ]]
+  [[ "$output" == *"\"reusable\": \".github/workflows/foo-reusable.yml\""* ]]
+  [[ "$output" == *"petry-projects/.github-private"* ]]
+}
+
+@test "orchestrator: drift skips a host it cannot enumerate — no false missing-file avalanche" {
+  # Registry has 'ghost' on .github-private, but the contents API returns a non-array error
+  # body (no access / API error). The host must be SKIPPED, NOT reported as every registered
+  # reusable having been deleted.
+  DRIFT_RINGS="$BATS_TEST_TMPDIR/drift-noaccess.json"
+  jq '{version, description, org_infra_repos, member_tokens,
+       agents: {"ghost": (.agents["dev-lead"] + {reusable: ".github/workflows/ghost-reusable.yml"})}}' \
+    "$RINGS" > "$DRIFT_RINGS"
+  _drift_stub '{"message":"Not Found"}' '[]'
+  run env CANARY_RINGS="$DRIFT_RINGS" bash "$ORCH" drift
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"could not enumerate"* ]]
+  [[ "$output" != *"DRIFT[missing-file]"* ]]
+  [[ "$output" == *"0 unregistered, 0 missing-file"* ]]
+}
+
+@test "orchestrator: drift renders a fleet-drift table into the job summary when GITHUB_STEP_SUMMARY is set" {
+  _drift_rings_one_agent
+  _drift_stub '[
+    {"type":"file","name":"dev-lead-reusable.yml","path":".github/workflows/dev-lead-reusable.yml"},
+    {"type":"file","name":"foo-reusable.yml","path":".github/workflows/foo-reusable.yml"}
+  ]' '[]'
+  local summ="$BATS_TEST_TMPDIR/drift-summary.md"; : > "$summ"
+  run env CANARY_RINGS="$DRIFT_RINGS" GITHUB_STEP_SUMMARY="$summ" bash "$ORCH" drift
+  [ "$status" -eq 0 ]
+  grep -q "Canary Rollout — reusable drift" "$summ"
+  grep -q "foo-reusable.yml" "$summ"
+}


### PR DESCRIPTION
Closes #1082

Implemented by dev-lead agent. Please review.