### PR TITLE
fix(release): unify channel-tag moves onto the gh-api/App-token path (#1076)

### DIFF
--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 # canary-rollout.sh — ring-staged, health-gated promotion of agent releases by
 # moving channel tags only (initiative #495, issue #501; rollback/observability #502).
 #
-# The ONLY action this performs is moving a channel tag (`git tag -f <agent>/<ring>
-# <vX.Y.Z-commit> && git push -f`) — it never writes consumer files. A ring advances
+# The ONLY action this performs is moving a channel tag (via `gh api` on the agent's host
+# repo, with the release-manager App token — #1076) — it never writes consumer files. A ring advances
 # only when the rings already on the candidate pass the soak/health gate (see
 # scripts/lib/canary-rollout.sh for the pure decision core).
 #
@@ -105,11 +105,12 @@ _gh_tag_commit() {
 }
 
 # _gh_move_tag <repo> <tag> <sha> — force-move (or create) the lightweight ref
-# refs/tags/<tag> on <repo> to <sha> via the GitHub API. The cross-repo counterpart of
-# `git tag -f <tag> <sha> && git push --force`: a cross-repo agent's channel tags live on
-# ITS host, so the promote/rollback move must go through gh api, not local git — local
-# `git tag -f` fails with "nonexistent object" for a host commit absent from this checkout
-# (#1054). Tries PATCH (existing ref) then falls back to POST (create the ref).
+# refs/tags/<tag> on <repo> to <sha> via the GitHub API. THE channel-tag mover for every
+# agent (promote + rollback), this-repo and cross-repo alike (#1076): the API path is
+# granted the release-manager App's ruleset bypass for tag UPDATEs, whereas a local
+# `git push --force` is not (013 on protected channel tags) and also fails with
+# "nonexistent object" for a cross-repo host commit absent from this checkout (#1054).
+# Tries PATCH (existing ref) then falls back to POST (create the ref).
 _gh_move_tag() {
   [ $# -lt 3 ] && return 1
   local repo="$1" tag="$2" sha="$3"
@@ -510,36 +511,27 @@ cmd_promote() {
     return 0
   fi
   [ "$state" != "PROMOTE" ] && echo "::warning::advancing $agent/$frontier despite gate state '$state' (triage=$triage)"
-  # Host-aware move: an agent hosted in THIS repo moves its channel tag via local git; a
-  # cross-repo agent (host != THIS_REPO, e.g. the #482 reusables on petry-projects/.github)
-  # keeps its tags on ITS host and must move them there via gh api — local `git tag -f`
-  # fails with "nonexistent object" for a host commit absent from this checkout (#1054).
-  local host cross=false
+  # Consistent move (#1076): EVERY agent moves its channel tag via `gh api` on its HOST
+  # repo — never a local `git push`. A local force-push is NOT granted the release-manager
+  # App's ruleset bypass for a tag UPDATE, so it 013s on a protected channel tag such as
+  # dev-lead/next; the API path (same App token) IS honored as a bypass actor. host
+  # defaults to THIS_REPO for an agent whose registry entry omits it.
+  local host
   host="$(_jq -r --arg a "$agent" '.agents[$a].host // "" | tostring')"
-  [ -n "$host" ] && [ "$host" != "$THIS_REPO" ] && cross=true
-  echo "advancing $agent/$frontier -> ${cand:0:12}$( [ "$cross" = true ] && echo " on $host" )"
+  host="${host:-$THIS_REPO}"
+  echo "advancing $agent/$frontier -> ${cand:0:12} on $host"
   if [ "$dry" = true ]; then
-    if [ "$cross" = true ]; then
-      echo "[DRY-RUN] would: gh api PATCH repos/$host/git/refs/tags/$agent/$frontier sha=$cand (force)"
-    else
-      echo "[DRY-RUN] would: git tag -f $agent/$frontier $cand && git push --force origin $agent/$frontier"
-    fi
+    echo "[DRY-RUN] would: gh api PATCH repos/$host/git/refs/tags/$agent/$frontier sha=$cand (force)"
     return 0
   fi
-  if [ "$cross" = true ]; then
-    _gh_move_tag "$host" "$agent/$frontier" "$cand" \
-      || { echo "::error::failed to move $agent/$frontier -> ${cand:0:12} on $host" >&2; return 1; }
-  else
-    git tag -f "$agent/$frontier" "$cand" \
-      && git push --force origin "$agent/$frontier" \
-      || { echo "::error::failed to move $agent/$frontier -> ${cand:0:12} locally" >&2; return 1; }
-  fi
+  _gh_move_tag "$host" "$agent/$frontier" "$cand" \
+    || { echo "::error::failed to move $agent/$frontier -> ${cand:0:12} on $host" >&2; return 1; }
   echo "promoted $agent/$frontier -> ${cand:0:12}"
   # Expose the move for the workflow's GitHub Deployment (traceability, #502). The
   # deployment must be created on the repo that OWNS the moved commit: a cross-repo agent's
   # candidate SHA lives on its host, NOT on THIS_REPO — creating the deployment against
   # GITHUB_REPOSITORY 422s with "No ref found" (#1059). So emit the owning repo too.
-  local deploy_repo="$THIS_REPO"; [ "$cross" = true ] && deploy_repo="$host"
+  local deploy_repo="$host"   # the repo that OWNS the moved commit (#1059); host==THIS_REPO for this-repo agents
   # GITHUB_OUTPUT is single-valued (last write wins), fine for a single `promote`. For
   # `promote-all` (many promotions per run) the workflow reads CANARY_PROMOTIONS_LOG — one
   # TSV line per promotion — so it can record a deployment for EVERY move, not just the last.
@@ -588,35 +580,22 @@ cmd_rollback() {
     esac; shift
   done
   [ -z "$to" ] && { echo "::error::rollback requires --to <vX.Y.Z>" >&2; return 2; }
-  # Host-aware, mirroring cmd_promote: a cross-repo agent's release + channel tags live on
-  # ITS host, so both the target lookup and the move go through gh api, not local git (#1054).
-  local host cross=false
+  # Consistent path (#1076), mirroring cmd_promote: the target lookup AND the move both go
+  # through gh api on the agent's HOST repo for every agent — never local git. host defaults
+  # to THIS_REPO for an agent whose registry entry omits it.
+  local host
   host="$(_jq -r --arg a "$agent" '.agents[$a].host // "" | tostring')"
-  [ -n "$host" ] && [ "$host" != "$THIS_REPO" ] && cross=true
+  host="${host:-$THIS_REPO}"
   local target
-  if [ "$cross" = true ]; then
-    target="$(_gh_tag_commit "$host" "$agent/$to")"
-  else
-    target="$(git rev-parse -q --verify "refs/tags/$agent/$to^{commit}" 2>/dev/null || true)"
-  fi
-  [ -z "$target" ] && { echo "::error::release tag $agent/$to not found" >&2; return 1; }
-  echo "rolling back $agent/$ring -> $to (${target:0:12})$( [ "$cross" = true ] && echo " on $host" )"
+  target="$(_gh_tag_commit "$host" "$agent/$to")"
+  [ -z "$target" ] && { echo "::error::release tag $agent/$to not found on $host" >&2; return 1; }
+  echo "rolling back $agent/$ring -> $to (${target:0:12}) on $host"
   if [ "$dry" = true ]; then
-    if [ "$cross" = true ]; then
-      echo "[DRY-RUN] would: gh api PATCH repos/$host/git/refs/tags/$agent/$ring sha=$target (force)"
-    else
-      echo "[DRY-RUN] would: git tag -f $agent/$ring $target && git push --force origin $agent/$ring"
-    fi
+    echo "[DRY-RUN] would: gh api PATCH repos/$host/git/refs/tags/$agent/$ring sha=$target (force)"
     return 0
   fi
-  if [ "$cross" = true ]; then
-    _gh_move_tag "$host" "$agent/$ring" "$target" \
-      || { echo "::error::failed to move $agent/$ring -> $to on $host" >&2; return 1; }
-  else
-    git tag -f "$agent/$ring" "$target" \
-      && git push --force origin "$agent/$ring" \
-      || { echo "::error::failed to move $agent/$ring -> $to locally" >&2; return 1; }
-  fi
+  _gh_move_tag "$host" "$agent/$ring" "$target" \
+    || { echo "::error::failed to move $agent/$ring -> $to on $host" >&2; return 1; }
   echo "rolled back $agent/$ring -> $to"
 }
 

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -14,18 +14,15 @@
 #                  agent-shield | auto-rebase | dependency-audit |
 #                  dependabot-automerge | dependabot-rebase | pr-review-mention
 #   <version>    semantic version without the leading v, e.g. 1.2.0
-#   --ref        commit/ref to tag (default: main). For this-repo agents it is
-#                resolved against local git (e.g. origin/main); for cross-repo
-#                agents it is resolved against petry-projects/.github via the API
-#                (an `origin/` prefix is stripped — `origin/main` means its `main`).
+#   --ref        commit/ref to tag (default: main). Resolved against the agent's
+#                HOST repo via the API for EVERY agent (an `origin/` prefix is
+#                stripped — `origin/main` means the host's `main`).
 #   --channel    also move <agent>/<name> (e.g. stable) to the new release
 #   --promote    move <agent>/<channel> to the EXISTING <agent>/vX.Y.Z release
 #                instead of cutting a new one (ring-to-ring promotion). Requires
 #                --channel; errors if the release tag does not already exist;
 #                --ref is ignored (the release's own commit is authoritative).
-#   --push       publish the created/moved tags (default: print only). For
-#                this-repo agents this pushes to origin; for cross-repo agents it
-#                creates/moves the tags on petry-projects/.github via the API.
+#   --push       publish the created/moved tags (default: print only).
 #   --dry-run    print what would happen; touch nothing
 #
 # Examples:
@@ -34,28 +31,23 @@
 #   cut-release.sh dev-lead  2.0.0 --channel stable --dry-run
 #   cut-release.sh agent-shield 2.1.0 --channel next --push   # cross-repo → .github
 #
-# Cross-repo agents (#872): feature-ideation + the six #482 reusables are hosted in
-# petry-projects/.github (this repo holds only the thin caller stubs), so their
-# tags are cut against THAT repo. Resolution + publish go through `gh api`
-# (requires GH_TOKEN with contents:write on petry-projects/.github). See
+# ONE consistent path for every agent (#1076). All tag operations — resolve,
+# create, and channel-move — go through `gh api` against the agent's HOST repo
+# (this-repo agents included). This matters because a local `git push --force`
+# is NOT granted the release-manager App's ruleset bypass for a tag UPDATE, so it
+# GH013s ("Cannot update this protected ref") when moving a protected channel tag
+# such as `dev-lead/next`; the API path, authenticated with the same App token,
+# IS honored as a bypass actor. Requires GH_TOKEN with contents:write on the host
+# repo. The host is petry-projects/.github for cross-repo agents (#872) and the
+# current repo (GITHUB_REPOSITORY / origin) otherwise. See
 # docs/release/versioning.md "Cross-repo reusables".
 #
-# The pure helpers (valid_agent, cross_repo_agent, validate_version, release_ref,
-# channel_ref, strip_origin) are defined at the top level so tests can `source`
-# this file without executing it (see the source-guard at the bottom and
-# tests/test_cut_release.bats).
+# The pure helpers (valid_agent, cross_repo_agent, agent_host_repo, this_repo,
+# validate_version, release_ref, channel_ref, strip_origin) are defined at the
+# top level so tests can `source` this file without executing it (see the
+# source-guard at the bottom and tests/test_cut_release.bats).
 #
 set -euo pipefail
-
-# Shared bot git identity — a THIS_REPO cut creates a LOCAL annotated tag (`git tag -a`),
-# which aborts with "fatal: empty ident name" on a GitHub-hosted runner that has no
-# user.name/user.email configured. Cross-repo cuts go through `gh api` (App identity) and
-# are unaffected; only the local path needs this. Sourced (no side effects) so tests can
-# still `source` this file; setup_git_identity is invoked lazily in the this-repo cut path.
-_CRHERE="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" && pwd -P)"
-readonly _CRHERE
-# shellcheck source=lib/git-identity.sh
-source "${_CRHERE}/lib/git-identity.sh"
 
 # The repo whose git refs hold cross-repo agents' release/channel tags.
 CROSS_REPO_TARGET="petry-projects/.github"
@@ -76,8 +68,8 @@ valid_agent() {
 # cross_repo_agent <agent> — return 0 iff the agent's reusable workflow lives in
 # petry-projects/.github (this repo holds only the thin caller stub). For these,
 # a "release" is a commit on that public repo, so its release/channel tags are
-# resolved and cut against THAT repo (CROSS_REPO_TARGET) via `gh api`, not this
-# repo's `origin` (#872, wired). See docs/release/versioning.md "Cross-repo reusables".
+# resolved and cut against THAT repo (CROSS_REPO_TARGET). See
+# docs/release/versioning.md "Cross-repo reusables".
 cross_repo_agent() {
   case "$1" in
     feature-ideation) return 0 ;;
@@ -85,6 +77,28 @@ cross_repo_agent() {
     dependabot-automerge | dependabot-rebase | pr-review-mention) return 0 ;;
     *) return 1 ;;
   esac
+}
+
+# this_repo — echo the owner/repo of the repository this script runs against.
+# Prefers GITHUB_REPOSITORY (always set on a runner); falls back to the `origin`
+# remote for local use. Both git@ and https:// remote URL forms are normalized.
+this_repo() {
+  if [ -n "${GITHUB_REPOSITORY:-}" ]; then
+    printf '%s\n' "$GITHUB_REPOSITORY"; return 0
+  fi
+  local url
+  url="$(git remote get-url origin 2>/dev/null)" || {
+    echo "::error::cannot determine the current repo (GITHUB_REPOSITORY unset and no 'origin' remote)" >&2
+    return 1
+  }
+  url="${url%.git}"; url="${url#*github.com[:/]}"
+  printf '%s\n' "$url"
+}
+
+# agent_host_repo <agent> — echo the owner/repo whose refs hold this agent's tags:
+# petry-projects/.github for cross-repo agents (#872), else the current repo.
+agent_host_repo() {
+  if cross_repo_agent "$1"; then printf '%s\n' "$CROSS_REPO_TARGET"; else this_repo; fi
 }
 
 # validate_version <version> — return 0 iff strictly MAJOR.MINOR.PATCH numerics.
@@ -99,11 +113,11 @@ release_ref() { printf '%s/v%s\n' "$1" "$2"; }
 channel_ref() { printf '%s/%s\n' "$1" "$2"; }
 
 # strip_origin <ref> — normalize a local-style ref to a remote-repo ref name for
-# the cross-repo API path: `origin/main` → `main`, a bare ref/SHA passes through.
+# the API path: `origin/main` → `main`, a bare ref/SHA passes through.
 # (`git rev-parse` understands `origin/main`; the GitHub API does not.)
 strip_origin() { printf '%s\n' "${1#origin/}"; }
 
-# ── cross-repo tag operations (gh api; require GH_TOKEN with contents:write) ───
+# ── tag operations (gh api; require GH_TOKEN with contents:write on the host) ──
 # Thin wrappers kept separate from the pure helpers so the network surface is
 # explicit. Each targets an arbitrary <repo> so tests can mock `gh`.
 
@@ -183,6 +197,16 @@ main() {
     return 2
   fi
 
+  # Every agent's tags live on its HOST repo; ALL writes go through `gh api` with
+  # the App token so the release-channel-tags ruleset bypass is applied uniformly
+  # (a local `git push` is not granted the App's bypass for a tag UPDATE → GH013
+  # on protected channel moves, #1076). One path, this-repo and cross-repo alike.
+  command -v gh >/dev/null 2>&1 || {
+    echo "::error::'gh' CLI is required (all tag operations go through the GitHub API) but was not found in PATH" >&2
+    return 1
+  }
+  local host; host="$(agent_host_repo "$agent")" || return 1
+
   local rel chan sha pushrefs
   rel="$(release_ref "$agent" "$version")"
   pushrefs=("$rel")
@@ -194,52 +218,28 @@ main() {
   # immutable release tag is left untouched (and MUST exist).
   if [ "$promote" = true ]; then
     [ -z "$channel" ] && { echo "::error::--promote requires --channel <name> (the ring to advance to the existing release)" >&2; return 2; }
+    gh_tag_exists "$host" "$rel" || { echo "::error::cannot promote: release tag '$rel' does not exist on $host — cut it first." >&2; return 1; }
     local pcommit
-    if cross_repo_agent "$agent"; then
-      command -v gh >/dev/null 2>&1 || { echo "::error::'gh' CLI is required for cross-repo agents but was not found in PATH" >&2; return 1; }
-      gh_tag_exists "$CROSS_REPO_TARGET" "$rel" || { echo "::error::cannot promote: release tag '$rel' does not exist on $CROSS_REPO_TARGET — cut it first." >&2; return 1; }
-      if ! pcommit="$(gh_release_commit "$CROSS_REPO_TARGET" "$rel")" || [ -z "$pcommit" ]; then
-        echo "::error::failed to resolve commit for release tag '$rel' on $CROSS_REPO_TARGET" >&2
-        return 1
-      fi
-      echo "promote $chan -> $rel ($pcommit) on $CROSS_REPO_TARGET"
-      [ "$dry" = true ] && { echo "(dry-run) channel not moved."; return 0; }
-      [ "$do_push" != true ] && { echo "print only — re-run with --push to move $chan on $CROSS_REPO_TARGET"; return 0; }
-      gh_move_tag "$CROSS_REPO_TARGET" "$chan" "$pcommit"
-      echo "moved $chan -> $pcommit on $CROSS_REPO_TARGET"
-      return 0
+    if ! pcommit="$(gh_release_commit "$host" "$rel")" || [ -z "$pcommit" ]; then
+      echo "::error::failed to resolve commit for release tag '$rel' on $host" >&2
+      return 1
     fi
-    git rev-parse -q --verify "refs/tags/$rel" >/dev/null || { echo "::error::cannot promote: release tag '$rel' does not exist — cut it first." >&2; return 1; }
-    pcommit="$(git rev-parse --verify "$rel^{commit}")"
-    echo "promote $chan -> $rel ($pcommit)"
+    echo "promote $chan -> $rel ($pcommit) on $host"
     [ "$dry" = true ] && { echo "(dry-run) channel not moved."; return 0; }
-    git tag -f "$chan" "$pcommit"; echo "moved $chan -> $pcommit"
-    if [ "$do_push" = true ]; then git push --force origin "$chan"; echo "pushed $chan"; else echo "local only — re-run with --push to publish $chan"; fi
+    [ "$do_push" != true ] && { echo "print only — re-run with --push to move $chan on $host"; return 0; }
+    gh_move_tag "$host" "$chan" "$pcommit"
+    echo "moved $chan -> $pcommit on $host"
     return 0
   fi
 
-  # Resolve the target SHA. This-repo agents resolve against local git; cross-repo
-  # agents (#872) resolve against petry-projects/.github via the API.
-  if cross_repo_agent "$agent"; then
-    if ! command -v gh >/dev/null 2>&1; then
-      echo "::error::'gh' CLI is required for cross-repo agents but was not found in PATH" >&2
-      return 1
-    fi
-    local rref; rref="$(strip_origin "$ref")"
-    if ! sha="$(gh_resolve_sha "$CROSS_REPO_TARGET" "$rref")" || [ -z "$sha" ]; then
-      echo "::error::ref '$rref' could not be resolved on $CROSS_REPO_TARGET (check the ref exists and GH_TOKEN has access)" >&2
-      return 1
-    fi
-  else
-    if ! sha="$(git rev-parse --verify "$ref^{commit}")"; then
-      echo "::error::ref '$ref' could not be resolved — verify the ref exists and the remote has been fetched" >&2
-      return 1
-    fi
+  # Resolve the target SHA against the host repo via the API (`origin/` stripped).
+  local rref; rref="$(strip_origin "$ref")"
+  if ! sha="$(gh_resolve_sha "$host" "$rref")" || [ -z "$sha" ]; then
+    echo "::error::ref '$rref' could not be resolved on $host (check the ref exists and GH_TOKEN has access)" >&2
+    return 1
   fi
 
-  local target="origin (this repo)"
-  cross_repo_agent "$agent" && target="$CROSS_REPO_TARGET (cross-repo)"
-  echo "agent=$agent version=$version ref=$ref ($sha) target=$target"
+  echo "agent=$agent version=$version ref=$ref ($sha) target=$host"
   echo "release tag: $rel"
   [ -n "$channel" ] && echo "channel tag: $chan -> $rel"
 
@@ -248,52 +248,23 @@ main() {
     return 0
   fi
 
-  # ── cross-repo agents: create/move tags on petry-projects/.github via the API ──
-  if cross_repo_agent "$agent"; then
-    if gh_tag_exists "$CROSS_REPO_TARGET" "$rel"; then
-      echo "::error::release tag '$rel' already exists on $CROSS_REPO_TARGET — immutable tags are never overwritten." >&2
-      return 1
-    fi
-    if [ "$do_push" != true ]; then
-      echo "print only — re-run with --push to publish to $CROSS_REPO_TARGET: ${pushrefs[*]}"
-      return 0
-    fi
-    gh_create_annotated_tag "$CROSS_REPO_TARGET" "$rel" "$sha" "$agent release v$version"
-    echo "created $rel on $CROSS_REPO_TARGET"
-    if [ -n "$channel" ]; then
-      gh_move_tag "$CROSS_REPO_TARGET" "$chan" "$sha"
-      echo "moved $chan -> $sha on $CROSS_REPO_TARGET"
-    fi
-    echo "published to $CROSS_REPO_TARGET: ${pushrefs[*]}"
-    return 0
-  fi
-
-  # ── this-repo agents: local annotated tag + force-moved channel, pushed to origin ──
-  if git rev-parse -q --verify "refs/tags/$rel" >/dev/null; then
-    echo "::error::release tag '$rel' already exists — immutable tags are never overwritten." >&2
+  # Immutable release tags are never overwritten.
+  if gh_tag_exists "$host" "$rel"; then
+    echo "::error::release tag '$rel' already exists on $host — immutable tags are never overwritten." >&2
     return 1
   fi
-  # An annotated tag needs a tagger identity; a bare GitHub-hosted runner has none, so the
-  # local `git tag -a` aborts with "fatal: empty ident name" (autocut dev-lead cut, #1069).
-  setup_git_identity
-  git tag -a "$rel" "$sha" -m "$agent release v$version"
-  echo "created $rel"
+  if [ "$do_push" != true ]; then
+    echo "print only — re-run with --push to publish to $host: ${pushrefs[*]}"
+    return 0
+  fi
+  gh_create_annotated_tag "$host" "$rel" "$sha" "$agent release v$version"
+  echo "created $rel on $host"
   if [ -n "$channel" ]; then
-    git tag -f "$chan" "$sha"
-    echo "moved $chan -> $sha"
+    gh_move_tag "$host" "$chan" "$sha"
+    echo "moved $chan -> $sha on $host"
   fi
-
-  if [ "$do_push" = true ]; then
-    # Push the immutable release tag without --force to prevent accidental remote overwrites
-    git push origin "$rel"
-    if [ -n "$channel" ]; then
-      # --force is required to move the mutable channel tag
-      git push --force origin "$chan"
-    fi
-    echo "pushed: ${pushrefs[*]}"
-  else
-    echo "local only — re-run with --push to publish: ${pushrefs[*]}"
-  fi
+  echo "published to $host: ${pushrefs[*]}"
+  return 0
 }
 
 # Run main only when executed directly, so tests can source the helpers.

--- a/scripts/lib/premature-closure-detect.sh
+++ b/scripts/lib/premature-closure-detect.sh
@@ -33,7 +33,8 @@
 
 # Soft threshold — an issue must have closed within this many minutes of opening
 # to count as the fast dev-lead task-attempt close. Env-overridable.
-: "${PC_MAX_OPEN_MINUTES:=30}"   # closed < this many minutes after open
+readonly _PC_THRESHOLD_DEFAULT=30
+: "${PC_MAX_OPEN_MINUTES:=$_PC_THRESHOLD_DEFAULT}"   # closed < this many minutes after open
 
 # _pc_int <value>
 #   Echo the value as a non-negative integer, or 0 for empty/non-numeric input.
@@ -79,7 +80,7 @@ premature_closure_reasons() {
   state_reason="${state_reason,,}"
   minutes=$(_pc_int "${2:-0}")
   has_pr="${3:-}"
-  max_minutes=$(_pc_threshold "${PC_MAX_OPEN_MINUTES}" 30)
+  max_minutes=$(_pc_threshold "${PC_MAX_OPEN_MINUTES}" "$_PC_THRESHOLD_DEFAULT")
 
   # 1. Only a "completed" close is premature; "not_planned"/other are legitimate.
   [ "$state_reason" = "completed" ] || return 0
@@ -127,7 +128,7 @@ minutes_between() {
 generate_premature_closure_report() {
   local f="${1:-}"
   local max_minutes
-  max_minutes=$(_pc_threshold "${PC_MAX_OPEN_MINUTES}" 30)
+  max_minutes=$(_pc_threshold "${PC_MAX_OPEN_MINUTES}" "$_PC_THRESHOLD_DEFAULT")
 
   printf '## Premature-Closure Candidates\n\n'
   printf 'Issues closed as `completed` within %sm of opening with **no merged closing PR** ' "$max_minutes"

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -284,6 +284,17 @@ GITEOF
   [ ! -f "$pushlog" ]
   [[ "$output" == *"DRY-RUN"* ]]
   [[ "$output" == *"ring1"* ]]
+  # dev-lead is a this-repo agent, but the move now goes through gh api on its host — the
+  # dry-run must show the API PATCH, never a local `git tag -f`/`git push` (#1076).
+  [[ "$output" == *"gh api PATCH"* ]]
+  [[ "$output" != *"git tag -f"* ]]
+}
+
+@test "orchestrator: no local git tag/push in the promote/rollback move paths — gh api only (#1076)" {
+  # Structural guard: the channel-tag move for EVERY agent (this-repo and cross-repo) goes
+  # through gh api so the release-manager App's ruleset bypass is applied; a local force-push
+  # is not a bypass actor for a tag UPDATE and 013s on protected tags such as dev-lead/next.
+  ! grep -Ev '^[[:space:]]*#' "$ORCH" | grep -Eq '\bgit[[:space:]]+(tag|push)\b'
 }
 
 # ── orchestrator: full graduated verdicts (cut date + gh run data → gate state) ─

--- a/tests/test_cut_release.bats
+++ b/tests/test_cut_release.bats
@@ -16,7 +16,7 @@ setup() {
 
 # Consistent-path invariant (#1076): EVERY tag operation — this-repo AND cross-repo —
 # goes through `gh api`, never a local `git push`/`git tag`. A local push is not granted
-# the release-manager App's ruleset bypass for a tag UPDATE, so it 013s ("Cannot update
+# the release-manager App's ruleset bypass for a tag UPDATE, so it GH013s ("Cannot update
 # this protected ref") on protected channel moves such as dev-lead/next. This guard fails
 # if the local-git path is ever reintroduced.
 @test "cut-release: no local git tag/push path — all tag ops go through gh api (#1076)" {

--- a/tests/test_cut_release.bats
+++ b/tests/test_cut_release.bats
@@ -14,24 +14,28 @@ setup() {
 # valid_agent
 # ---------------------------------------------------------------------------
 
-# A this-repo cut creates a LOCAL annotated tag (`git tag -a`), which aborts with
-# "fatal: empty ident name" on a bare runner. cut-release.sh must source the shared
-# git-identity helper so the this-repo path can set a tagger identity (#1069 regression).
-@test "cut-release wires the shared git-identity helper for the this-repo annotated-tag cut" {
-  run declare -F setup_git_identity
-  [ "$status" -eq 0 ]
+# Consistent-path invariant (#1076): EVERY tag operation — this-repo AND cross-repo —
+# goes through `gh api`, never a local `git push`/`git tag`. A local push is not granted
+# the release-manager App's ruleset bypass for a tag UPDATE, so it 013s ("Cannot update
+# this protected ref") on protected channel moves such as dev-lead/next. This guard fails
+# if the local-git path is ever reintroduced.
+@test "cut-release: no local git tag/push path — all tag ops go through gh api (#1076)" {
+  local script; script="$(dirname "$BATS_TEST_FILENAME")/../scripts/cut-release.sh"
+  ! grep -Ev '^[[:space:]]*#' "$script" | grep -Eq '\bgit[[:space:]]+(tag|push)\b'
+  grep -q 'agent_host_repo' "$script"
 }
 
-@test "cut-release: setup_git_identity call precedes git tag -a in the this-repo annotated-tag path" {
-  # Regression guard: asserts the call ordering in source so this test fails
-  # if setup_git_identity is ever removed from before git tag -a (#1069).
-  local script id_line tag_line
-  script="$(dirname "$BATS_TEST_FILENAME")/../scripts/cut-release.sh"
-  id_line=$(grep -n '^[[:space:]]*setup_git_identity[[:space:]]*$' "$script" | cut -d: -f1)
-  tag_line=$(grep -n '^[[:space:]]*git tag -a' "$script" | cut -d: -f1)
-  [ -n "$id_line" ]
-  [ -n "$tag_line" ]
-  [ "$id_line" -lt "$tag_line" ]
+@test "agent_host_repo: cross-repo agent resolves to petry-projects/.github" {
+  run agent_host_repo "agent-shield"
+  [ "$status" -eq 0 ]
+  [ "$output" = "petry-projects/.github" ]
+}
+
+@test "agent_host_repo: this-repo agent resolves to the current repo (GITHUB_REPOSITORY)" {
+  export GITHUB_REPOSITORY="petry-projects/.github-private"
+  run agent_host_repo "dev-lead"
+  [ "$status" -eq 0 ]
+  [ "$output" = "petry-projects/.github-private" ]
 }
 
 @test "valid_agent: pr-review is accepted" {

--- a/tests/test_cut_release_cross_repo.bats
+++ b/tests/test_cut_release_cross_repo.bats
@@ -11,6 +11,8 @@ setup() {
   SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/cut-release.sh"
   GH_CALLS="${TT_TMP}/gh-calls.log"; export GH_CALLS
   : > "$GH_CALLS"
+  # A this-repo agent resolves its host from GITHUB_REPOSITORY (#1076 unified path).
+  export GITHUB_REPOSITORY="petry-projects/.github-private"
   install_gh_stub
 }
 
@@ -73,11 +75,24 @@ STUB
   ! grep -qE 'POST .*git/tags' "$GH_CALLS"
 }
 
-@test "a this-repo agent still uses the local-git path (no gh api), dry-run" {
+@test "a this-repo agent also resolves via gh api against its own host (#1076), dry-run" {
   run env GH_TOKEN=x bash "$SCRIPT" pr-review 9.9.9 --dry-run
   [ "$status" -eq 0 ]
-  echo "$output" | grep -q 'target=origin (this repo)'
-  ! grep -q 'commits/' "$GH_CALLS"
+  # host is the current repo (GITHUB_REPOSITORY), and resolution goes through the API —
+  # the consistent gh-api path, not a local git resolve.
+  echo "$output" | grep -q 'target=petry-projects/.github-private'
+  grep -q 'commits/' "$GH_CALLS"
+  ! grep -qE 'POST .*git/(tags|refs)' "$GH_CALLS"
+}
+
+@test "a this-repo agent --push creates+moves tags via gh api on its host, not git push (#1076)" {
+  run env GH_TOKEN=x bash "$SCRIPT" dev-lead 1.5.4 --channel next --push
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'created dev-lead/v1.5.4 on petry-projects/.github-private'
+  echo "$output" | grep -q 'moved dev-lead/next'
+  # the create + channel move both went through the API on the this-repo host
+  grep -qE 'POST repos/petry-projects/\.github-private/git/tags' "$GH_CALLS"
+  grep -qE '(POST|PATCH) repos/petry-projects/\.github-private/git/refs' "$GH_CALLS"
 }
 
 # ── --promote (ring-to-ring channel move of an existing release) ──────────────


### PR DESCRIPTION
Fixes #1076 (re-scoped — see the issue for full root-cause).

## Why
The dev-lead orphan-tag spam is a symptom of a **split move path**: cross-repo agents move channel tags via `gh api` (App token → `release-channel-tags` ruleset bypass → works), but the this-repo agent (dev-lead) moved via local `git push --force`, which is **not** granted the App's bypass for a tag UPDATE and 013s on `dev-lead/next`. The release-tag *create* (unrestricted) still succeeds, so every autocut tick mints a fresh orphaned `vX.Y.Z`.

## What
One consistent path: **every** tag op — resolve, create, channel-move, promote, rollback — goes through `gh api` against the agent's **host** repo, this-repo and cross-repo alike. Migration-robust (correctness no longer depends on where the workflow runs).

- `cut-release.sh`: single gh-api path; `this_repo`/`agent_host_repo` host resolution; dropped the local git-tag/push branch + git-identity source.
- `canary-rollout.sh`: `cmd_promote` + `cmd_rollback` move via `_gh_move_tag` on the host for all agents.
- Tests: consistent-path invariant, `agent_host_repo` coverage, this-repo cut/promote assert the gh-api move, structural guards against reintroducing local git moves. **130/130 bats pass.**

## Config caveat (cannot self-apply)
Assumes the App bypass is honored via `gh api` on `.github-private`'s ruleset (it is a bypass actor, `mode=always`). If a channel move still 013s via the API, the **ruleset bypass list** needs fixing — surfaced separately, not workaroundable in code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added premature-closure detection and reporting for issues, including a markdown summary of candidates and a clear “no candidates” message.
* **Bug Fixes**
  * Standardized canary promotion, rollback, and release cut flows to use GitHub API-based tag updates consistently.
  * Improved dry-run output so it accurately reflects what would be changed.
* **Tests**
  * Expanded coverage for release/tag workflows and added tests for premature-closure detection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->