### PR TITLE
feat: implement issue #706 — [Phase 3] Materialize accepted critic findings as sub-issues + native blocked_by edges (not just gate)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -82,6 +82,7 @@ jobs:
             tests/test_pr_diff_dispatch.bats \
             tests/test_plan_review.bats \
             tests/test_plan_critic.bats \
+            tests/test_plan_materialize.bats \
             tests/test_skill_review.bats \
             tests/test_skill_evals.bats \
             tests/test_triage_prompt.bats \

--- a/scripts/initiative-planner/README.md
+++ b/scripts/initiative-planner/README.md
@@ -79,6 +79,21 @@ cat /tmp/plan.jsonl | jq .
   #650→#659, #666→#667). Re-running after the questions are answered then
   materializes the real plan. Plain-string `open_questions` stay advisory and do
   **not** gate — only objects shaped `{"question": "...", "blocking": true}` do.
+- **Materialize accepted critic findings (#706).** An `open_questions` object may
+  carry a `proposed_story` (a whole story the plan is missing — `title` +
+  `acceptance_criteria` scaffold) and a `proposed_blocked_by` (the existing issue
+  that story gates), surfaced by a plan-critic finding whose resolution is "add
+  story X". Until a maintainer sets **`accepted:true`** it gates exactly like a
+  blocking open-question (creates nothing). On acceptance, `apply-plan.sh`
+  materializes it: it creates the `proposed_story` as a **sub-issue of the epic**
+  and wires a **native** `blocked_by` edge (`<proposed_blocked_by> blocked_by
+  <new sub-issue>`, so the new story must land first) via `lib/mutations.sh`
+  `add_blocked_by` — instead of leaving it as advisory prose a human must wire by
+  hand (the #581 → #691/#692 gap). Acceptance is the human gate: materialization
+  never happens automatically, and the epic still lands **inert** (no
+  `initiative:auto`). A plan with no accepted `proposed_story` findings creates
+  zero extra issues/edges. An accepted finding with no `proposed_story` is
+  rejected by `validate-plan.py` (acceptance must have something to materialize).
 - **Idempotency + supersede (default-safe re-planning).** Every epic carries a
   deterministic back-reference (`Planned from idea discussion #<src>`).
   `apply-plan.sh` uses it to detect its own prior output, so re-approving /

--- a/scripts/initiative-planner/apply-plan.sh
+++ b/scripts/initiative-planner/apply-plan.sh
@@ -49,7 +49,12 @@ DISCUSSION_NODE_ID="${DISCUSSION_NODE_ID:-}"
 # discussion with "not yet planned" framing and exit cleanly (DRY_RUN honored
 # via comment_on_discussion). Re-running once the questions are answered then
 # materializes the real plan. Plain-string questions stay advisory only.
-blocking_count="$(jq '[(.open_questions // [])[] | select(type=="object" and .blocking==true)] | length' "$PLAN_PATH")"
+#
+# A finding a maintainer has explicitly accepted (`accepted:true`, #706) is no
+# longer an open blocker — it is resolved by materialization (see below) — so it
+# is excluded here. An un-accepted proposed_story finding still gates like any
+# other blocking open_question until the human accepts it.
+blocking_count="$(jq '[(.open_questions // [])[] | select(type=="object" and .blocking==true and (.accepted // false) != true)] | length' "$PLAN_PATH")"
 if [ "$blocking_count" -gt 0 ]; then
   src_g="$(jq -r '.source_discussion // empty' "$PLAN_PATH")"
   [ -n "$src_g" ] || src_g="$DISCUSSION_NUMBER"
@@ -198,6 +203,40 @@ for lid in "${local_ids[@]}"; do
     echo "  edge: #${issue_num} blocked_by existing #${dep_existing}"
   done < <(jq -r --argjson i "$lid" '.stories[] | select(.id==$i) | (.blocked_by_existing_issues // [])[]' "$PLAN_PATH")
 done
+
+# ── materialize accepted proposed-story findings (#706) ───────────────────────
+# A plan-critic finding may carry a proposed_story (a whole story the plan is
+# missing) + proposed_blocked_by (the existing issue that story gates). Until a
+# maintainer sets accepted:true it gates like any blocking open_question (the
+# gate above); on ACCEPTANCE we turn it into a real sub-issue of THIS epic and
+# wire the native blocked_by edge — instead of leaving it as advisory prose that
+# had to be created by hand (the #581 -> #691/#692 gap). Materialization happens
+# ONLY on explicit acceptance, never automatically. A plan with no accepted
+# proposed_story findings runs this loop zero times (clean no-op).
+while IFS= read -r q_index; do
+  [ -n "$q_index" ] || continue
+  ps_title="$(jq -r --argjson i "$q_index" '.open_questions[$i].proposed_story.title' "$PLAN_PATH")"
+  ps_body="$(jq -r --argjson i "$q_index" '
+    .open_questions[$i].proposed_story
+    | "## Story\n" + .title
+      + "\n\n## Acceptance Criteria\n"
+      + ([.acceptance_criteria | to_entries[] | "\(.key + 1). \(.value)"] | join("\n"))
+  ' "$PLAN_PATH")"
+  ps_body="${ps_body}"$'\n\n'"_Materialized from a maintainer-accepted plan-critic finding for epic #${epic_number} (issue #706). Status: ready-for-dev._"
+
+  ps_out="$(create_issue "$REPO" "$ps_title" "$ps_body" "initiative")"
+  read -r ps_number ps_id <<< "$ps_out"
+  echo "  materialized proposed_story: #${ps_number} (id ${ps_id}) — ${ps_title}"
+  link_sub_issue "$REPO" "$epic_number" "$ps_id"
+
+  # proposed_blocked_by is the EXISTING issue this new story gates; wire it so
+  # that issue becomes blocked_by the new story (the new story must land first).
+  pbb="$(jq -r --argjson i "$q_index" '.open_questions[$i].proposed_blocked_by // empty' "$PLAN_PATH")"
+  if [ -n "$pbb" ]; then
+    add_blocked_by "$REPO" "$pbb" "$ps_number"
+    echo "  edge: #${pbb} blocked_by materialized #${ps_number} (proposed_blocked_by)"
+  fi
+done < <(jq -r '(.open_questions // []) | to_entries[] | select(.value | type=="object" and (.accepted // false)==true and (.proposed_story != null)) | .key' "$PLAN_PATH")
 
 # ── post the plan back to the discussion ──────────────────────────────────────
 if [ -n "$DISCUSSION_NODE_ID" ]; then

--- a/scripts/initiative-planner/apply-plan.sh
+++ b/scripts/initiative-planner/apply-plan.sh
@@ -54,12 +54,12 @@ DISCUSSION_NODE_ID="${DISCUSSION_NODE_ID:-}"
 # longer an open blocker — it is resolved by materialization (see below) — so it
 # is excluded here. An un-accepted proposed_story finding still gates like any
 # other blocking open_question until the human accepts it.
-blocking_count="$(jq '[(.open_questions // [])[] | select(type=="object" and .blocking==true and (.accepted // false) != true)] | length' "$PLAN_PATH")"
+blocking_count="$(jq '[(.open_questions // [])[] | select(type=="object" and .blocking==true and .accepted != true)] | length' "$PLAN_PATH")"
 if [ "$blocking_count" -gt 0 ]; then
   src_g="$(jq -r '.source_discussion // empty' "$PLAN_PATH")"
   [ -n "$src_g" ] || src_g="$DISCUSSION_NUMBER"
   if [ -n "$DISCUSSION_NODE_ID" ]; then
-    blocking_list="$(jq -r '[(.open_questions // [])[] | select(type=="object" and .blocking==true) | .question] | map("- " + .) | join("\n")' "$PLAN_PATH")"
+    blocking_list="$(jq -r '[(.open_questions // [])[] | select(type=="object" and .blocking==true and .accepted != true) | .question] | map("- " + .) | join("\n")' "$PLAN_PATH")"
     other_list="$(jq -r '(.open_questions // []) | map(select((type=="string") or (type=="object" and .blocking != true))) | map(if type=="string" then . else .question end) | if length>0 then "\n\n_Also worth confirming (non-blocking):_\n" + (map("- " + .) | join("\n")) else "" end' "$PLAN_PATH")"
     printf -v gate_comment '<!-- initiative-planner -->\n**⏸️ Not yet planned — the BMAD Scrum Master (Bob) has blocking open questions.**\n\nThis idea cannot be turned into an epic until these are answered:\n\n%s%s\n\n---\n**No epic or stories were created.** Answer the questions above, then re-approve / re-dispatch the planner and Bob will materialize the full epic + sub-issue DAG.' \
       "$blocking_list" "$other_list"
@@ -236,7 +236,7 @@ while IFS= read -r q_index; do
     add_blocked_by "$REPO" "$pbb" "$ps_number"
     echo "  edge: #${pbb} blocked_by materialized #${ps_number} (proposed_blocked_by)"
   fi
-done < <(jq -r '(.open_questions // []) | to_entries[] | select(.value | type=="object" and (.accepted // false)==true and (.proposed_story != null)) | .key' "$PLAN_PATH")
+done < <(jq -r '(.open_questions // []) | to_entries[] | select(.value | type=="object") | select(.value?.accepted == true and .value?.proposed_story != null) | .key' "$PLAN_PATH")
 
 # ── post the plan back to the discussion ──────────────────────────────────────
 if [ -n "$DISCUSSION_NODE_ID" ]; then

--- a/scripts/initiative-planner/plan.schema.json
+++ b/scripts/initiative-planner/plan.schema.json
@@ -160,7 +160,7 @@
               "proposed_blocked_by": {
                 "type": "integer",
                 "minimum": 1,
-                "description": "Existing repo issue number that the proposed_story gates (blocks). On acceptance apply-plan.sh wires a NATIVE `<proposed_blocked_by> blocked_by <new sub-issue>` edge (the new story must land first). Worked example: #587 blocked_by the two materialized #581 stories (#706)."
+                "description": "The existing issue that will become BLOCKED BY the materialized story — i.e., the new story is the prerequisite and this issue is the downstream dependent (it waits for the new story to land first). On acceptance, apply-plan.sh wires: `<proposed_blocked_by> blocked_by <new sub-issue>`. Despite the field name, this is NOT the upstream blocker of the new story; it is the issue that depends on it. Worked example: #587 blocked_by the two materialized #581 stories, meaning the new stories must land before #587 can proceed (#706)."
               },
               "accepted": {
                 "type": "boolean",

--- a/scripts/initiative-planner/plan.schema.json
+++ b/scripts/initiative-planner/plan.schema.json
@@ -141,6 +141,31 @@
                 "items": { "type": "integer", "minimum": 1 },
                 "description": "Local story ids this open question concerns. Set when a critic finding (see prompts/plan-review.md) could not be folded back into the plan and was routed here by route-findings.sh, so the question names which stories it gates. Empty/absent for epic- or plan-level questions.",
                 "default": []
+              },
+              "proposed_story": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["title", "acceptance_criteria"],
+                "description": "A whole story the plan is missing, surfaced by a plan-critic finding whose resolution is 'add story X' (#706). Until a maintainer sets `accepted:true` it gates like any blocking open_question; on acceptance apply-plan.sh materializes it as a sub-issue of the epic (title + acceptance-criteria scaffold), rather than dropping it into prose.",
+                "properties": {
+                  "title": { "type": "string", "minLength": 8 },
+                  "acceptance_criteria": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": { "type": "string", "minLength": 5 },
+                    "description": "Numbered, testable outcomes for the proposed story."
+                  }
+                }
+              },
+              "proposed_blocked_by": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Existing repo issue number that the proposed_story gates (blocks). On acceptance apply-plan.sh wires a NATIVE `<proposed_blocked_by> blocked_by <new sub-issue>` edge (the new story must land first). Worked example: #587 blocked_by the two materialized #581 stories (#706)."
+              },
+              "accepted": {
+                "type": "boolean",
+                "default": false,
+                "description": "Maintainer acceptance marker (#706). When true, the finding no longer gates and apply-plan.sh materializes its proposed_story + proposed_blocked_by edge. NEVER set automatically — the human gate: the epic stays inert until a maintainer reviews and accepts."
               }
             }
           }

--- a/scripts/initiative-planner/validate-plan.py
+++ b/scripts/initiative-planner/validate-plan.py
@@ -164,12 +164,17 @@ def main() -> None:
 
     # open_questions object form may carry affected_story_ids (critic findings
     # routed here by route-findings.sh); each must reference a real story id.
+    # It may also carry a proposed_story (#706): an accepted finding must have
+    # one, else acceptance would silently materialize nothing.
     for q in plan.get("open_questions", []) or []:
         if isinstance(q, dict):
             for sid in q.get("affected_story_ids", []) or []:
                 if sid not in id_set:
                     fail(f"open question affected_story_ids references {sid}, "
                          "which is not a story id in this plan")
+            if q.get("accepted") and not q.get("proposed_story"):
+                fail("open question is accepted but carries no proposed_story to "
+                     "materialize — acceptance would create nothing")
 
     check_grounding(stories, repo_root())
 

--- a/tests/fixtures/initiative-planner/plan-581-accepted.json
+++ b/tests/fixtures/initiative-planner/plan-581-accepted.json
@@ -1,0 +1,115 @@
+{
+  "source_discussion": 572,
+  "epic": {
+    "title": "Initiative: Eval-gated, human-reviewed self-improving skills (SkillOpt-style)",
+    "body": "Stand up an eval-gated, human-reviewed self-improvement loop for agent skills/prompts, modeled on Microsoft SkillOpt and Anthropic skill-creator (discussion #572). An agent proposes a bounded edit to a skill markdown file, an offline eval gate decides on a held-out set, and the winner rides the existing idea->initiative->pr-review pipeline as a normal CODEOWNER-reviewed PR. Nothing self-promotes; no release-tag ruleset changes. Phase 1 lands the keystone with no loop; Phase 2 generalizes the harness; Phase 3 automates the scheduled proposer behind safe-rollout prerequisites."
+  },
+  "stories": [
+    {
+      "id": 1,
+      "title": "[Phase 1] Held-out eval set + deterministic scorer for prompts/triage.md",
+      "user_story": {
+        "role": "skill maintainer",
+        "action": "a versioned held-out eval set and a deterministic scorer for the triage prompt",
+        "benefit": "a proposed prompt edit can be scored offline before it ships"
+      },
+      "acceptance_criteria": [
+        "A held-out eval set for prompts/triage.md is committed under evals/ with a deterministic scorer",
+        "The scorer runs in CI as a non-blocking report"
+      ],
+      "tasks": [
+        { "task": "Author the held-out cases and commit them under evals/", "ac_refs": [1] },
+        { "task": "Write the deterministic scorer and wire a non-blocking CI report", "ac_refs": [2] }
+      ],
+      "dev_notes": [
+        "Eval cases and judge prompts are owned separately via CODEOWNERS and never writable by the proposer.",
+        "Testing: extend tests/test_validate_cases.bats for the dev/holdout split hygiene."
+      ],
+      "references": ["prompts/triage.md", "evals/README.md", "evals/validate-cases.py"],
+      "target_surface": ["evals/", "scripts/evals"],
+      "size": "M",
+      "blocked_by": []
+    },
+    {
+      "id": 2,
+      "title": "[Phase 2] Generalize the harness to prompts/deep-review.md with an LLM judge and a strict-improvement gate",
+      "user_story": {
+        "role": "skill maintainer",
+        "action": "the eval harness extended to the deep-review prompt with an LLM-judge scorer and a strict-improvement gate that rejects regressions",
+        "benefit": "prompt edits to the heavier reviewer are gated on proven, non-regressing quality"
+      },
+      "acceptance_criteria": [
+        "The harness scores prompts/deep-review.md via an LLM judge and promotes only strict winners",
+        "The judge prompt and rubric are tuned against a frozen held-out set with an immutable baseline artifact"
+      ],
+      "tasks": [
+        { "task": "Add the LLM-judge scorer for deep-review", "ac_refs": [1] },
+        { "task": "Tune the judge prompt and rubric against the frozen held-out set", "ac_refs": [2] }
+      ],
+      "dev_notes": [
+        "The judge prompt is iterated against a held-out set the candidate scorer never sees.",
+        "Testing: add a harness smoke test."
+      ],
+      "references": ["prompts/deep-review.md", "evals/README.md"],
+      "target_surface": ["evals/", "scripts/evals"],
+      "size": "M",
+      "blocked_by": [1]
+    },
+    {
+      "id": 3,
+      "title": "[Phase 3] Automate the scheduled proposer end-to-end behind safe-rollout guards",
+      "user_story": {
+        "role": "platform operator",
+        "action": "a scheduled proposer that drafts skill edits, runs them through shadow-mode dual-run, promotes via the health-gated workflow, and exposes dashboards plus a rollback path",
+        "benefit": "the self-improvement loop runs unattended behind safe-rollout guards"
+      },
+      "acceptance_criteria": [
+        "A scheduled workflow drafts bounded skill edits and opens PRs",
+        "Promotion is gated on the health-gated promotion workflow"
+      ],
+      "tasks": [
+        { "task": "Build the scheduled proposer workflow", "ac_refs": [1] },
+        { "task": "Wire promotion behind the health-gated promotion workflow", "ac_refs": [2] }
+      ],
+      "dev_notes": [
+        "Hands-off: activation is a human decision; the proposer never self-promotes.",
+        "Depends on health-gated promotion (#501) and shadow-mode dual-run being in place."
+      ],
+      "references": ["docs/initiatives/idea-to-initiative-pipeline.md"],
+      "target_surface": [".github/workflows/"],
+      "size": "L",
+      "blocked_by": [2],
+      "hands_off": true
+    }
+  ],
+  "open_questions": [
+    {
+      "question": "[eval_safeguards] The plan lacks held-out-set hygiene: the CODEOWNERS guard blocks editing the held-out cases but not overfitting to them, since the proposer can read them. A dev/test split is missing.",
+      "affected_story_ids": [1, 2],
+      "blocking": true,
+      "accepted": true,
+      "proposed_story": {
+        "title": "[Phase 1] Held-out-set hygiene: dev/test split so the proposer cannot overfit to eval cases",
+        "acceptance_criteria": [
+          "Eval cases are split into a proposer-visible dev set and a proposer-blind held-out test set",
+          "The scorer reports on the held-out test set the proposer never reads, closing the overfitting gap CODEOWNERS alone cannot"
+        ]
+      },
+      "proposed_blocked_by": 587
+    },
+    {
+      "question": "[eval_safeguards] There is no hard CI check enforcing case-immutability. CODEOWNERS only requests review; it is not a hard block on the automated proposer editing held-out cases.",
+      "affected_story_ids": [1, 2],
+      "blocking": true,
+      "accepted": true,
+      "proposed_story": {
+        "title": "[Phase 1] Hard CI case-immutability check enforcing held-out immutability for the proposer identity",
+        "acceptance_criteria": [
+          "A required CI check fails any PR authored by the automated proposer identity that changes a held-out case path",
+          "The check is keyed on PR author + changed paths and runs on every PR as a stable required status"
+        ]
+      },
+      "proposed_blocked_by": 587
+    }
+  ]
+}

--- a/tests/test_plan_materialize.bats
+++ b/tests/test_plan_materialize.bats
@@ -21,7 +21,7 @@ setup() {
   FIXTURE_DIR="$ROOT/tests/fixtures/initiative-planner"
   PLAN_581="$FIXTURE_DIR/plan-581.json"
   PLAN_ACCEPTED="$FIXTURE_DIR/plan-581-accepted.json"
-  TMP="$(mktemp -d)"
+  TMP="$(mktemp -d "${BATS_TEST_TMPDIR}/test-XXXXXX")"
   LOG="$TMP/dry.jsonl"
 }
 
@@ -104,9 +104,9 @@ apply_dry() { # apply_dry <plan.json>
     DISCUSSION_NUMBER=572 DISCUSSION_NODE_ID="D_test" PLAN_PATH="$TMP/pending.json" \
     run bash "$APPLY"
   [ "$status" -eq 0 ]
-  [ "$(grep -c '"op":"create_issue"' "$LOG")" -eq 0 ]
-  [ "$(grep -c '"op":"add_sub_issue"' "$LOG")" -eq 0 ]
-  [ "$(grep -c '"op":"add_blocked_by"' "$LOG")" -eq 0 ]
+  [ "$(grep -c '"op":"create_issue"' "$LOG" || true)" -eq 0 ]
+  [ "$(grep -c '"op":"add_sub_issue"' "$LOG" || true)" -eq 0 ]
+  [ "$(grep -c '"op":"add_blocked_by"' "$LOG" || true)" -eq 0 ]
 }
 
 @test "an un-accepted proposed_story finding posts 'not yet planned' back to the discussion" {
@@ -133,7 +133,7 @@ apply_dry() { # apply_dry <plan.json>
     "$PLAN_ACCEPTED" > "$TMP/unaccepted.json"
   apply_dry "$TMP/unaccepted.json"
   # both findings are blocking:true & now accepted:false -> gate, create nothing
-  [ "$(grep -c '"op":"create_issue"' "$LOG")" -eq 0 ]
+  [ "$(grep -c '"op":"create_issue"' "$LOG" || true)" -eq 0 ]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/test_plan_materialize.bats
+++ b/tests/test_plan_materialize.bats
@@ -1,0 +1,179 @@
+#!/usr/bin/env bats
+# Tests for materializing accepted plan-critic findings as sub-issues + native
+# blocked_by edges (issue #706, epic #597 Phase 3).
+#
+# A plan-critic finding may carry an optional proposed_story (a whole story the
+# plan is missing) + proposed_blocked_by (the existing issue that story gates),
+# routed onto an open_questions object. Until a maintainer sets accepted:true it
+# gates exactly like a #682 blocking open_question (apply-plan creates NOTHING);
+# on acceptance apply-plan.sh turns it into a real sub-issue of the epic and
+# wires the native blocked_by edge via lib/mutations.sh add_blocked_by — instead
+# of dropping it into prose. Everything is proven offline via the DRY_RUN
+# mutation log; no new network path is introduced.
+#
+# Run with: bats tests/test_plan_materialize.bats
+
+setup() {
+  ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  PLANNER_DIR="$ROOT/scripts/initiative-planner"
+  VALIDATE="$PLANNER_DIR/validate-plan.py"
+  APPLY="$PLANNER_DIR/apply-plan.sh"
+  FIXTURE_DIR="$ROOT/tests/fixtures/initiative-planner"
+  PLAN_581="$FIXTURE_DIR/plan-581.json"
+  PLAN_ACCEPTED="$FIXTURE_DIR/plan-581-accepted.json"
+  TMP="$(mktemp -d)"
+  LOG="$TMP/dry.jsonl"
+}
+
+teardown() { rm -rf "$TMP"; }
+
+apply_dry() { # apply_dry <plan.json>
+  DRY_RUN=1 DRY_RUN_LOG="$LOG" REPO="petry-projects/.github-private" \
+    DISCUSSION_NUMBER=572 DISCUSSION_NODE_ID="D_test" PLAN_PATH="$1" \
+    bash "$APPLY"
+}
+
+# ---------------------------------------------------------------------------
+# AC1 — schema + validator accept the new fields; reject a malformed one
+# ---------------------------------------------------------------------------
+
+@test "validate-plan accepts a finding carrying proposed_story + proposed_blocked_by" {
+  run python3 "$VALIDATE" "$PLAN_ACCEPTED"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"plan OK"* ]]
+}
+
+@test "validate-plan accepts a single un-accepted proposed_story finding" {
+  jq '.open_questions = [{"question":"[eval_safeguards] plan is missing a held-out split","affected_story_ids":[1],"blocking":true,"proposed_story":{"title":"[Phase 1] Add a held-out split","acceptance_criteria":["dev/test split exists"]},"proposed_blocked_by":587}]' \
+    "$PLAN_581" > "$TMP/one.json"
+  run python3 "$VALIDATE" "$TMP/one.json"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"plan OK"* ]]
+}
+
+@test "validate-plan rejects a malformed proposed_story (missing acceptance_criteria)" {
+  jq '.open_questions = [{"question":"malformed","proposed_story":{"title":"[Phase 1] Add a held-out split"}}]' \
+    "$PLAN_581" > "$TMP/malformed.json"
+  run python3 "$VALIDATE" "$TMP/malformed.json"
+  [ "$status" -ne 0 ]
+}
+
+@test "validate-plan rejects an accepted finding with no proposed_story to materialize" {
+  jq '.open_questions = [{"question":"accepted but nothing to build","blocking":true,"accepted":true}]' \
+    "$PLAN_581" > "$TMP/emptyaccept.json"
+  run python3 "$VALIDATE" "$TMP/emptyaccept.json"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"proposed_story"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC2 — materialize on acceptance: sub-issue + native blocked_by edge
+# ---------------------------------------------------------------------------
+
+@test "apply-plan materializes each accepted proposed_story as a sub-issue of the epic" {
+  apply_dry "$PLAN_ACCEPTED"
+  # base: epic + 3 stories = 4 create_issue; + 2 materialized proposed stories = 6
+  [ "$(grep -c '"op":"create_issue"' "$LOG")" -eq 6 ]
+  # each materialized story is linked under the epic as a native sub-issue
+  # (3 plan stories + 2 materialized = 5 add_sub_issue)
+  [ "$(grep -c '"op":"add_sub_issue"' "$LOG")" -eq 5 ]
+}
+
+@test "apply-plan wires proposed_blocked_by as a native blocked_by edge via add_blocked_by" {
+  apply_dry "$PLAN_ACCEPTED"
+  # 2 intra-plan edges (story2<-1, story3<-2) + 2 materialized edges onto #587
+  [ "$(grep -c '"op":"add_blocked_by"' "$LOG")" -eq 4 ]
+  [ "$(grep '"op":"add_blocked_by"' "$LOG" | jq -c 'select(.issue==587)' | wc -l)" -eq 2 ]
+}
+
+@test "the materialized sub-issue body carries the proposed_story title + acceptance criteria" {
+  apply_dry "$PLAN_ACCEPTED"
+  body="$(grep '"op":"create_issue"' "$LOG" | jq -r 'select(.title|test("Held-out-set hygiene")) | .body')"
+  [[ "$body" == *"## Acceptance Criteria"* ]]
+  [[ "$body" == *"proposer-visible dev set"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC3 — gate until accepted: an un-accepted finding gates like a #600 question
+# ---------------------------------------------------------------------------
+
+@test "an un-accepted proposed_story finding gates: apply-plan creates ZERO issues" {
+  jq '.open_questions = [{"question":"[eval_safeguards] missing held-out split","affected_story_ids":[1],"blocking":true,"proposed_story":{"title":"[Phase 1] Add a held-out split","acceptance_criteria":["dev/test split exists"]},"proposed_blocked_by":587}]' \
+    "$PLAN_581" > "$TMP/pending.json"
+  DRY_RUN=1 DRY_RUN_LOG="$LOG" REPO="petry-projects/.github-private" \
+    DISCUSSION_NUMBER=572 DISCUSSION_NODE_ID="D_test" PLAN_PATH="$TMP/pending.json" \
+    run bash "$APPLY"
+  [ "$status" -eq 0 ]
+  [ "$(grep -c '"op":"create_issue"' "$LOG")" -eq 0 ]
+  [ "$(grep -c '"op":"add_sub_issue"' "$LOG")" -eq 0 ]
+  [ "$(grep -c '"op":"add_blocked_by"' "$LOG")" -eq 0 ]
+}
+
+@test "an un-accepted proposed_story finding posts 'not yet planned' back to the discussion" {
+  jq '.open_questions = [{"question":"[eval_safeguards] missing held-out split","affected_story_ids":[1],"blocking":true,"proposed_story":{"title":"[Phase 1] Add a held-out split","acceptance_criteria":["dev/test split exists"]},"proposed_blocked_by":587}]' \
+    "$PLAN_581" > "$TMP/pending.json"
+  apply_dry "$TMP/pending.json"
+  body="$(grep '"op":"comment_on_discussion"' "$LOG" | jq -r '.body')"
+  [[ "$body" == *"Not yet planned"* ]]
+  [[ "$body" == *"missing held-out split"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC4 — human gate preserved: never auto; epic stays inert
+# ---------------------------------------------------------------------------
+
+@test "materialization NEVER applies initiative:auto to any created issue" {
+  apply_dry "$PLAN_ACCEPTED"
+  created_labels="$(grep '"op":"create_issue"' "$LOG" | jq -r '.labels[]')"
+  ! grep -qx 'initiative:auto' <<<"$created_labels"
+}
+
+@test "flipping accepted to false re-gates the finding (no materialization)" {
+  jq '(.open_questions[] | select(has("proposed_story"))).accepted = false' \
+    "$PLAN_ACCEPTED" > "$TMP/unaccepted.json"
+  apply_dry "$TMP/unaccepted.json"
+  # both findings are blocking:true & now accepted:false -> gate, create nothing
+  [ "$(grep -c '"op":"create_issue"' "$LOG")" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# AC5 — #581 regression fixture: two findings round-trip into two sub-issues +
+#       blocked_by edges onto the Phase-3 proposer story (#587)
+# ---------------------------------------------------------------------------
+
+@test "#581: finding-1 (held-out hygiene) + finding-2 (case-immutability) both materialize" {
+  apply_dry "$PLAN_ACCEPTED"
+  grep '"op":"create_issue"' "$LOG" | jq -e 'select(.title|test("Held-out-set hygiene"))' >/dev/null
+  grep '"op":"create_issue"' "$LOG" | jq -e 'select(.title|test("case-immutability"))' >/dev/null
+}
+
+@test "#581: each materialized story is wired as a native blocked_by edge onto #587" {
+  apply_dry "$PLAN_ACCEPTED"
+  # resolve the two materialized story numbers from their create_issue ops
+  n1="$(grep '"op":"create_issue"' "$LOG" | jq -r 'select(.title|test("Held-out-set hygiene")) | .number')"
+  n2="$(grep '"op":"create_issue"' "$LOG" | jq -r 'select(.title|test("case-immutability")) | .number')"
+  [ -n "$n1" ] && [ -n "$n2" ]
+  # #587 becomes blocked_by each new story (the new stories must land first)
+  grep '"op":"add_blocked_by"' "$LOG" | jq -e --argjson n "$n1" 'select(.issue==587 and .blocked_by==$n)' >/dev/null
+  grep '"op":"add_blocked_by"' "$LOG" | jq -e --argjson n "$n2" 'select(.issue==587 and .blocked_by==$n)' >/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# AC6 — no-op safety: zero accepted findings => zero materialization ops
+# ---------------------------------------------------------------------------
+
+@test "a plan with zero accepted proposed_story findings produces zero materialization ops" {
+  # plan-581.json has no open_questions at all -> clean no-op for materialization
+  apply_dry "$PLAN_581"
+  # base only: epic + 3 stories, 2 intra-plan edges; no edge references #587
+  [ "$(grep -c '"op":"create_issue"' "$LOG")" -eq 4 ]
+  [ "$(grep '"op":"add_blocked_by"' "$LOG" | jq -c 'select(.issue==587)' | wc -l)" -eq 0 ]
+}
+
+@test "a plan with only advisory (non-accepted, non-blocking) findings materializes nothing extra" {
+  jq '.open_questions = [{"question":"advisory: consider a held-out split later","affected_story_ids":[1],"blocking":false}]' \
+    "$PLAN_581" > "$TMP/advisory.json"
+  apply_dry "$TMP/advisory.json"
+  [ "$(grep -c '"op":"create_issue"' "$LOG")" -eq 4 ]
+  [ "$(grep '"op":"add_blocked_by"' "$LOG" | jq -c 'select(.issue==587)' | wc -l)" -eq 0 ]
+}


### PR DESCRIPTION
Closes #706

Implemented by dev-lead agent. Please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accepted plan-review findings can now materialize into new initiative sub-issues, including linked blocker relationships when specified.
  * Plans can provide proposed story scaffolds with acceptance criteria for review-driven materialization.
* **Bug Fixes**
  * Planning “Not yet planned” gating now correctly ignores accepted blocking open-questions.
  * Validation is stricter: accepted entries must include proposed story details.
* **Documentation**
  * Updated initiative-planner invariants documentation for proposed/accepted materialization rules.
* **Tests**
  * Added offline DRY_RUN coverage for validation and materialization behavior.
  * CI now runs the new materialization test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->