### PR TITLE
fix(feature-ideation): route caller inputs through a prep job (#571)

### DIFF
--- a/.github/workflows/feature-ideation.yml
+++ b/.github/workflows/feature-ideation.yml
@@ -143,9 +143,51 @@ jobs:
           gh workflow run feature-ideation.yml --repo "${REPO}" \
             -f target_discussion="${DISCUSSION_NUMBER}"
 
+  # ── #571 input resolution — keep `inputs` out of the reusable `with:` ────────
+  # A reusable-workflow call graph (its `uses:` + `with:`) is validated at
+  # WORKFLOW SETUP, before — and regardless of — the calling job's `if:`. The
+  # `inputs` context is only populated for workflow_dispatch/workflow_call, so a
+  # `with:` that references `${{ inputs.* }}` trips a zero-job startup failure on
+  # the `discussion` event even though `ideate` is gated off it. We resolve the
+  # dispatch inputs in this ordinary job (whose step expressions run at run time
+  # and are skipped on `discussion`) and hand them to `ideate` via
+  # `needs.prep.outputs.*` — an always-valid context that defers the `with:`
+  # evaluation to run time. Do not reference `inputs` in `ideate.with`.
+  prep:
+    if: github.event_name != 'discussion'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    outputs:
+      target_discussion: ${{ steps.resolve.outputs.target_discussion }}
+      focus_area: ${{ steps.resolve.outputs.focus_area }}
+      research_depth: ${{ steps.resolve.outputs.research_depth }}
+      dry_run: ${{ steps.resolve.outputs.dry_run }}
+      enhance_backlog: ${{ steps.resolve.outputs.enhance_backlog }}
+    steps:
+      - name: Resolve dispatch inputs
+        id: resolve
+        # `github.event.inputs.*` (not the `inputs` context) so this reads
+        # cleanly on schedule too, where it is simply null → the defaults below.
+        env:
+          TARGET_DISCUSSION: ${{ github.event.inputs.target_discussion }}
+          FOCUS_AREA: ${{ github.event.inputs.focus_area }}
+          RESEARCH_DEPTH: ${{ github.event.inputs.research_depth }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          ENHANCE_BACKLOG: ${{ github.event.inputs.enhance_backlog }}
+        run: |
+          {
+            echo "target_discussion=${TARGET_DISCUSSION:-}"
+            echo "focus_area=${FOCUS_AREA:-}"
+            echo "research_depth=${RESEARCH_DEPTH:-standard}"
+            echo "dry_run=${DRY_RUN:-false}"
+            echo "enhance_backlog=${ENHANCE_BACKLOG:-false}"
+          } >> "$GITHUB_OUTPUT"
+
   ideate:
     # Runs on workflow_dispatch (incl. the redispatch bridge above) and schedule
     # only — never inline on a discussion event, where claude-code-action aborts.
+    needs: [prep]
     if: github.event_name != 'discussion'
     # Permissions cascade from the calling job to the reusable workflow.
     # The reusable workflow's two jobs (gather-signals + analyze) need:
@@ -175,11 +217,13 @@ jobs:
     # Precedent: auto-rebase.yml intentionally pins its reusable @v2 ahead of canon.
     uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@feature-ideation/next
     with:
+      # All values below come from `needs.prep.outputs.*` (resolved in the `prep`
+      # job) — NOT the `inputs` context — so this reusable `with:` compiles on the
+      # `discussion` event without a zero-job startup failure (#571).
       # Carries the Idea's Discussion number → the reusable runs single-idea
-      # enhancement mode. Populated by the `redispatch` bridge (which forwards
-      # the new discussion's number into this dispatch input); empty on
-      # schedule/manual dispatch → normal scan. Do not edit this line.
-      target_discussion: ${{ inputs.target_discussion || '' }}
+      # enhancement mode. Forwarded by the `redispatch` bridge on
+      # `discussion: created`; empty on schedule/manual dispatch → normal scan.
+      target_discussion: ${{ needs.prep.outputs.target_discussion }}
       # === CUSTOMISE THIS PER REPO — the only required edit ===
       project_context: |
         petry-projects/.github-private is the org-level private automation
@@ -206,12 +250,14 @@ jobs:
       # === OPTIONAL: repo-local reputable source list ===
       # This repo ships .github/feature-ideation-sources.md, which is the
       # reusable workflow's default path — so no sources_file override is needed.
-      focus_area: ${{ inputs.focus_area || '' }}
-      research_depth: ${{ inputs.research_depth || 'standard' }}
-      dry_run: ${{ inputs.dry_run || false }}
+      focus_area: ${{ needs.prep.outputs.focus_area }}
+      research_depth: ${{ needs.prep.outputs.research_depth }}
+      # prep emits the string 'true'/'false'; fromJSON casts it to the boolean
+      # the reusable's typed inputs require.
+      dry_run: ${{ fromJSON(needs.prep.outputs.dry_run) }}
       # Operator-triggered backlog sweep (#934). Empty on schedule/discussion
       # triggers → false → normal scan/single-idea enhancement. Pair with
       # dry_run=true to preview the intended comments without posting.
-      enhance_backlog: ${{ inputs.enhance_backlog || false }}
+      enhance_backlog: ${{ fromJSON(needs.prep.outputs.enhance_backlog) }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/tests/test_feature_ideation.bats
+++ b/tests/test_feature_ideation.bats
@@ -41,14 +41,18 @@ setup() {
 # and forwards it, matching the canonical stub template so the sync is drift-free.
 
 @test "feature-ideation.yml exposes the enhance_backlog backfill-sweep input" {
-  # Declared as a workflow_dispatch input AND forwarded in with: → two occurrences.
-  run grep -c "enhance_backlog:" "$FEATURE_IDEATION_YML"
-  [ "$status" -eq 0 ]
-  [ "$output" -eq 2 ]
+  # Declared as a workflow_dispatch input…
+  grep -qE '^[[:space:]]+enhance_backlog:' "$FEATURE_IDEATION_YML"
+  # …and forwarded to the reusable via the prep job's output (not the `inputs`
+  # context — see the #571 guard below).
+  grep -qE 'enhance_backlog:[[:space:]]*\$\{\{[[:space:]]*fromJSON\(needs\.prep\.outputs\.enhance_backlog\)[[:space:]]*\}\}' "$FEATURE_IDEATION_YML"
 }
 
 @test "feature-ideation.yml forwards enhance_backlog to the reusable workflow" {
-  grep -qE 'enhance_backlog:[[:space:]]*"?\$\{\{[[:space:]]*inputs\.enhance_backlog[[:space:]]*\|\|[[:space:]]*false[[:space:]]*\}\}"?' "$FEATURE_IDEATION_YML"
+  # Routed through the prep job's output; fromJSON casts the 'true'/'false' string
+  # back to the boolean the reusable's typed input requires. Sourcing it from
+  # ${{ inputs.enhance_backlog }} would fail at workflow setup on discussion (#571).
+  grep -qE 'enhance_backlog:[[:space:]]*\$\{\{[[:space:]]*fromJSON\(needs\.prep\.outputs\.enhance_backlog\)[[:space:]]*\}\}' "$FEATURE_IDEATION_YML"
 }
 
 # ── #963: discussion→dispatch redispatch bridge ──────────────────────────────
@@ -61,10 +65,9 @@ setup() {
 @test "feature-ideation.yml declares a target_discussion workflow_dispatch input" {
   # The dispatched run carries the new Discussion number through this input so
   # single-idea enhancement runs under workflow_dispatch (where the action works).
-  run grep -cE '^[[:space:]]+target_discussion:' "$FEATURE_IDEATION_YML"
-  [ "$status" -eq 0 ]
-  # Declared as a dispatch input AND forwarded in the reusable's with: block.
-  [ "$output" -eq 2 ]
+  # The redispatch bridge forwards it (-f target_discussion=) and the prep job
+  # surfaces it to the reusable's with: block.
+  grep -qE '^[[:space:]]+target_discussion:' "$FEATURE_IDEATION_YML"
 }
 
 @test "feature-ideation.yml has a redispatch job that runs only on the discussion event" {
@@ -95,8 +98,21 @@ setup() {
   grep -qE "github\.event_name[[:space:]]*!=[[:space:]]*['\"]discussion['\"]" "$FEATURE_IDEATION_YML"
 }
 
-@test "feature-ideation.yml sources target_discussion from inputs.target_discussion" {
-  grep -qE 'target_discussion:[[:space:]]*"?\$\{\{[[:space:]]*inputs\.target_discussion' "$FEATURE_IDEATION_YML"
+@test "feature-ideation.yml sources target_discussion from the prep job output" {
+  # Routed via needs.prep.outputs (not ${{ inputs.target_discussion }}) so the
+  # reusable with: compiles on the discussion event instead of failing at setup
+  # with zero jobs (#571).
+  grep -qE 'target_discussion:[[:space:]]*\$\{\{[[:space:]]*needs\.prep\.outputs\.target_discussion[[:space:]]*\}\}' "$FEATURE_IDEATION_YML"
+}
+
+@test "feature-ideation.yml routes every reusable input through prep — no inputs.* in with: (#571)" {
+  # A reusable with: that references ${{ inputs.* }} is evaluated at workflow
+  # setup regardless of the calling job's if:, so it fails the whole run (zero
+  # jobs) on the discussion trigger. All dispatch inputs must be resolved in the
+  # prep job and passed via needs.prep.outputs.*. Comments are excluded so this
+  # guard does not trip on the explanatory notes in the stub.
+  run bash -c "grep -vE '^[[:space:]]*#' '$FEATURE_IDEATION_YML' | grep -qE '\\\$\{\{[[:space:]]*inputs\\.'"
+  [ "$status" -ne 0 ]
 }
 
 # ── #985: structural guard binding the off-discussion gate to the reusable call ──


### PR DESCRIPTION
Applies the petry-projects/.github#615 fix to **this repo's own** feature-ideation caller — it carried the identical #571 defect: the `ideate` job's reusable `with:` referenced `${{ inputs.* }}`, which is validated at workflow **setup** regardless of the job `if:` and fails the whole run with **zero jobs** on the `discussion: created` trigger (the new-Idea auto-enhancement path).

**Fix:** resolve dispatch inputs in a gated `prep` job and pass them to `ideate` via `needs.prep.outputs.*` (booleans cast with `fromJSON`). The `feature-ideation/next` channel pin is **unchanged**.

As feature-ideation's **`next` ring**, this repo dogfoods the fix ahead of the fleet rollout (petry-projects/.github#614). After merge, opening a human Idea Discussion here is the live end-to-end validation of #571 — the run should now produce jobs (redispatch → dispatch) instead of a zero-job startup failure.

**Validation:** `actionlint` clean; the new `lint-caller.sh` guard (from #615) passes; no `inputs`-context references remain in the reusable `with:`.

Refs: petry-projects/.github#571 · petry-projects/.github#614

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow handling so scheduled and manually triggered runs use the correct settings reliably.
  * Fixed cases where optional parameters could be missing or passed with the wrong type during execution.
* **Chores**
  * Updated automation behavior to better support different trigger types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->