### PR TITLE
feat: implement issue #1099 — [Phase 2] Assess simplifying the sonnet->opus in-engine fallback given rate-limit equalization

### DIFF
--- a/scripts/engine.sh
+++ b/scripts/engine.sh
@@ -20,6 +20,12 @@ set -euo pipefail
 #   2. Cross-provider fallback — run_writer_with_fallback / review-batch.sh
 #      walk claude → copilot → gemini only after the in-engine chain is fully
 #      rate-limited (exit code 2 from the engine-layer call).
+# Sonnet 5 rate-limit equalization (#1099): equalization makes each model's
+# RPM/TPM bucket the same SIZE across tiers, but does NOT merge them into one
+# shared bucket — layer-1 recovery above depends on the buckets being SEPARATE,
+# not on differing sizes, so the sonnet → opus hop stays useful and is retained.
+# It changes only per-model rate LIMITS, so it has no bearing on the shared
+# daily subscription cap (#206), which layer-2 alone covers via the exit-2 path.
 #
 # Token logging (opt-in):
 #   Set TOKEN_LOG_FILE=<path> to capture per-call JSONL token records.

--- a/tests/dev-lead/unit/test_engine_chain.bats
+++ b/tests/dev-lead/unit/test_engine_chain.bats
@@ -222,6 +222,50 @@ _source_engine() {
   [[ "$CLAUDE_ACTION_MODEL_CHAIN" != *"claude-sonnet-5"* ]]
 }
 
+# ── #1099: sonnet->opus in-engine hop retained under rate-limit equalization ──
+# Assessment outcome (issue #1099): Sonnet 5's rate-limit equalization makes each
+# model's RPM/TPM bucket the same SIZE, but does NOT merge them into one shared
+# bucket. Layer-1 recovery (engine.sh:13-22) depends on buckets being SEPARATE,
+# not on differing sizes — a saturated sonnet-4-6 bucket is still relieved by
+# hopping to opus-4-8's independent bucket. So the hop is NOT redundant for
+# RPM/TPM and is retained (no chain edit). The shared daily subscription cap
+# (#206) is a per-account pool no per-model hop can address; it stays handled by
+# the layer-2 cross-provider fallback via the exit-2 contract, guarded below.
+
+@test "issue-1099: action chain retains the sonnet->opus RPM/TPM hop (not trimmed)" {
+  _source_engine "claude"
+  # Equalization did NOT collapse the per-model bucket independence, so the hop
+  # stays. Trimming to a single model would silently drop layer-1 RPM/TPM cover.
+  [ "$CLAUDE_ACTION_MODEL_CHAIN" = "claude-sonnet-4-6,claude-opus-4-8" ]
+}
+
+@test "issue-1099: sonnet RPM/TPM limit still recovers via the opus hop (layer-1 intact)" {
+  _source_engine "claude"
+  # A per-model rate limit on sonnet-4-6 must still be relieved by opus-4-8's
+  # separate bucket without leaving the provider (no exit 2).
+  export STUB_ENGINE_EXIT_BY_MODEL="claude-sonnet-4-6=1|claude-opus-4-8=0"
+  export STUB_ENGINE_RESPONSE_BY_MODEL="claude-sonnet-4-6=429 too many requests|claude-opus-4-8=opus recovered"
+
+  run run_writer "$TEST_PROMPT"
+
+  [ "$status" -eq 0 ]
+  grep -q "claude-sonnet-4-6" "$MODEL_RECORD"
+  grep -q "claude-opus-4-8" "$MODEL_RECORD"
+}
+
+@test "issue-1099: daily-cap/exhaustion still yields exit 2 (cross-provider contract preserved)" {
+  _source_engine "claude"
+  # When BOTH per-model buckets are exhausted (the daily-cap-style case the hop
+  # cannot fix), the chain must still return 2 so layer-2 cross-provider fallback
+  # fires. This contract must survive the #1099 assessment unchanged.
+  export STUB_ENGINE_EXIT_BY_MODEL="claude-sonnet-4-6=1|claude-opus-4-8=1"
+  export STUB_ENGINE_RESPONSE_BY_MODEL="claude-sonnet-4-6=quota exceeded|claude-opus-4-8=quota exceeded"
+
+  run run_writer "$TEST_PROMPT"
+
+  [ "$status" -eq 2 ]
+}
+
 # ── Gemini/Copilot unchanged: no chain applied ────────────────────────────────
 
 @test "gemini: in-engine chain uses gemini model (not claude)" {

--- a/tests/dev-lead/unit/test_engine_chain.bats
+++ b/tests/dev-lead/unit/test_engine_chain.bats
@@ -128,6 +128,7 @@ _source_engine() {
 @test "writer: sonnet rate-limited → opus-4-8 tried via CLAUDE_ACTION_MODEL_CHAIN" {
   _source_engine "claude"
   # Defaults from set_engine_config: CLAUDE_ACTION_MODEL_CHAIN=sonnet,opus-4-8
+  # (#1099) guard: per-model RPM/TPM recovery via the hop survives equalization.
   export STUB_ENGINE_EXIT_BY_MODEL="claude-sonnet-4-6=1|claude-opus-4-8=0"
   export STUB_ENGINE_RESPONSE_BY_MODEL="claude-sonnet-4-6=too many requests (429)|claude-opus-4-8=opus-4-8 did the work"
 
@@ -140,6 +141,7 @@ _source_engine() {
 
 @test "writer: sonnet rate-limited and opus-4-8 rate-limited → exit 2 (cross-provider fallback signal)" {
   _source_engine "claude"
+  # (#1099) guard: the exit-2 contract for daily-cap exhaustion survives the assessment.
   export STUB_ENGINE_EXIT_BY_MODEL="claude-sonnet-4-6=1|claude-opus-4-8=1"
   export STUB_ENGINE_RESPONSE_BY_MODEL="claude-sonnet-4-6=quota exceeded|claude-opus-4-8=quota exceeded"
 
@@ -218,6 +220,7 @@ _source_engine() {
 @test "sonnet-5 candidate: action chain default is NOT touched (scope guard)" {
   _source_engine "claude"
   # Action tier is out of scope for #1098 — must stay sonnet-4-6 → opus-4-8.
+  # (#1099) guard: equalization does not remove this hop.
   [ "$CLAUDE_ACTION_MODEL_CHAIN" = "claude-sonnet-4-6,claude-opus-4-8" ]
   [[ "$CLAUDE_ACTION_MODEL_CHAIN" != *"claude-sonnet-5"* ]]
 }
@@ -225,46 +228,16 @@ _source_engine() {
 # ── #1099: sonnet->opus in-engine hop retained under rate-limit equalization ──
 # Assessment outcome (issue #1099): Sonnet 5's rate-limit equalization makes each
 # model's RPM/TPM bucket the same SIZE, but does NOT merge them into one shared
-# bucket. Layer-1 recovery (engine.sh:13-22) depends on buckets being SEPARATE,
-# not on differing sizes — a saturated sonnet-4-6 bucket is still relieved by
-# hopping to opus-4-8's independent bucket. So the hop is NOT redundant for
-# RPM/TPM and is retained (no chain edit). The shared daily subscription cap
-# (#206) is a per-account pool no per-model hop can address; it stays handled by
-# the layer-2 cross-provider fallback via the exit-2 contract, guarded below.
-
-@test "issue-1099: action chain retains the sonnet->opus RPM/TPM hop (not trimmed)" {
-  _source_engine "claude"
-  # Equalization did NOT collapse the per-model bucket independence, so the hop
-  # stays. Trimming to a single model would silently drop layer-1 RPM/TPM cover.
-  [ "$CLAUDE_ACTION_MODEL_CHAIN" = "claude-sonnet-4-6,claude-opus-4-8" ]
-}
-
-@test "issue-1099: sonnet RPM/TPM limit still recovers via the opus hop (layer-1 intact)" {
-  _source_engine "claude"
-  # A per-model rate limit on sonnet-4-6 must still be relieved by opus-4-8's
-  # separate bucket without leaving the provider (no exit 2).
-  export STUB_ENGINE_EXIT_BY_MODEL="claude-sonnet-4-6=1|claude-opus-4-8=0"
-  export STUB_ENGINE_RESPONSE_BY_MODEL="claude-sonnet-4-6=429 too many requests|claude-opus-4-8=opus recovered"
-
-  run run_writer "$TEST_PROMPT"
-
-  [ "$status" -eq 0 ]
-  grep -q "claude-sonnet-4-6" "$MODEL_RECORD"
-  grep -q "claude-opus-4-8" "$MODEL_RECORD"
-}
-
-@test "issue-1099: daily-cap/exhaustion still yields exit 2 (cross-provider contract preserved)" {
-  _source_engine "claude"
-  # When BOTH per-model buckets are exhausted (the daily-cap-style case the hop
-  # cannot fix), the chain must still return 2 so layer-2 cross-provider fallback
-  # fires. This contract must survive the #1099 assessment unchanged.
-  export STUB_ENGINE_EXIT_BY_MODEL="claude-sonnet-4-6=1|claude-opus-4-8=1"
-  export STUB_ENGINE_RESPONSE_BY_MODEL="claude-sonnet-4-6=quota exceeded|claude-opus-4-8=quota exceeded"
-
-  run run_writer "$TEST_PROMPT"
-
-  [ "$status" -eq 2 ]
-}
+# bucket. The "Rate-limit fallback (two layers)" section in engine.sh depends on
+# buckets being SEPARATE, not on differing sizes — a saturated sonnet-4-6 bucket
+# is still relieved by hopping to opus-4-8's independent bucket. So the hop is
+# NOT redundant for RPM/TPM and is retained (no chain edit). The shared daily
+# subscription cap (#206) is a per-account pool that no per-model hop can address;
+# it stays handled by the layer-2 cross-provider fallback via the exit-2 contract.
+# The existing tests below already cover these behaviors and also guard #1099:
+#   • "sonnet-5 candidate: action chain default is NOT touched" — chain unchanged
+#   • "writer: sonnet rate-limited → opus-4-8 tried" — layer-1 RPM/TPM recovery
+#   • "writer: sonnet rate-limited and opus-4-8 rate-limited → exit 2" — layer-2 contract
 
 # ── Gemini/Copilot unchanged: no chain applied ────────────────────────────────
 


### PR DESCRIPTION
Closes #1099

Implemented by dev-lead agent. Please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model rate-limit handling so equalized per-model limits stay separate across tiers while preserving the existing recovery path between models.
  * Clarified behavior for subscription caps versus per-model limits to keep fallback behavior consistent when models are exhausted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->