### PR TITLE
test(#1133): guard PP_REQUIRED_SA_SETTINGS against drift from the org standard

### DIFF
--- a/tests/test_push_protection.bats
+++ b/tests/test_push_protection.bats
@@ -44,6 +44,24 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
+# Drift guard (#1133): the enforced key set must stay in lock-step with the org
+# standard — petry-projects/.github → standards/push-protection.md (the
+# security_and_analysis table). This repo's lean key list and .github's larger
+# structured apply/audit list are purpose-built variants of the SAME standard
+# (kept separate on purpose, epic #613), so an "includes" test per key is not
+# enough: adding or dropping a key here without updating the standard would let a
+# repo sync clean while missing (or over-asserting) a required security setting.
+# This asserts the EXACT set, catching both additions and removals.
+# ---------------------------------------------------------------------------
+@test "PP_REQUIRED_SA_SETTINGS matches the canonical standard set exactly (no drift)" {
+  # Canonical keys per standards/push-protection.md. Update BOTH together.
+  local expected="dependabot_security_updates secret_scanning secret_scanning_ai_detection secret_scanning_non_provider_patterns secret_scanning_push_protection"
+  local actual
+  actual="$(printf '%s\n' "${PP_REQUIRED_SA_SETTINGS[@]}" | sort | tr '\n' ' ' | sed 's/ $//')"
+  [ "$actual" = "$expected" ]
+}
+
+# ---------------------------------------------------------------------------
 # pp_apply_security_and_analysis — dry-run mode
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #1133. Follow-up to epic #613.

## Why
Epic #613 kept this repo's lean `scripts/lib/push-protection.sh` (sourced by `aw-standards-sync.sh`) separate from `petry-projects/.github`'s larger structured apply/audit lib of the same name — **purpose-built variants of the same standard** (`standards/push-protection.md`), not true duplicates. The residual risk is the enforced key set silently drifting.

## Change
The existing per-key "includes" tests don't catch an **extra** or **dropped** key. This adds one exact-set guard: assert `PP_REQUIRED_SA_SETTINGS` equals the canonical key set from the standard (order-independent).

Verified the guard **fails on additions, removals, and renames** (and passes on the exact set in any order). Full suite: **16/16**.

No risky cross-repo-sourcing refactor — the files stay purpose-built; drift is now caught in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)