### PR TITLE
fix(dev-lead): skip Dependabot dispatch at job level (#864) — fix-forward for canary regression

### DIFF
--- a/.github/workflows/dev-lead-reusable.yml
+++ b/.github/workflows/dev-lead-reusable.yml
@@ -71,9 +71,16 @@ jobs:
   # 2. Runs dev-lead-intent.sh to classify the event into an intent.
   # 3. Routes to the appropriate handler based on intent.
   dispatch:
+    # Skip Dependabot-triggered events (#864): a Dependabot `pull_request` run has no
+    # access to GH_PAT_WORKFLOWS, so the cross-repo dev-lead scripts checkout fails at
+    # startup — before dev-lead-intent.sh can classify the event (which already resolves
+    # a bot-authored PR to intent=skip, reason=bot-pr; see tests/dev-lead/e2e/scenarios/
+    # 01-skip-bot-pr.sh). Guarding at the job level skips cleanly before that checkout.
+    # dev-lead is not a required check, and dependabot-automerge handles these PRs.
     if: >-
-      (inputs.event_name == '' && github.event_name != 'check_run') ||
-      (inputs.event_name != '' && inputs.event_name != 'check_run')
+      github.actor != 'dependabot[bot]' &&
+      ((inputs.event_name == '' && github.event_name != 'check_run') ||
+       (inputs.event_name != '' && inputs.event_name != 'check_run'))
     runs-on: ubuntu-latest
     # Job backstop for a hung/stuck run — NOT a cost control (#1017, epic #901).
     # 120 min gives legitimately large issues room to finish across all engine


### PR DESCRIPTION
Closes #864. **Fix-forward** for dev-lead's canary regression (BLOCKED+REGRESSION at `next→ring0`).

## Why the canary was blocked
dev-lead's `next` candidate had `cum_fail` from only **Dependabot dep-bump PRs** ("chore(deps): bump the actions group") — the known-benign #864 class. Because the candidate legitimately changed the reusable (`differs=1`), the #548 gate disables the benign-failure allowlist (so it can't mask a real regression), so those benign failures counted → **stuck rollout**.

## Root cause (#864)
A Dependabot `pull_request` run has no `GH_PAT_WORKFLOWS`, so the reusable's cross-repo **"Checkout dev-lead scripts"** step fails at startup — *before* `dev-lead-intent.sh` can classify the event (it already resolves a bot-authored PR to `intent=skip, reason=bot-pr` — see `tests/dev-lead/e2e/scenarios/01-skip-bot-pr.sh`). The `dispatch` job `if:` only filtered `check_run`, so the job ran and died on the checkout.

## Fix
```diff
   dispatch:
     if: >-
-      (inputs.event_name == '' && github.event_name != 'check_run') ||
-      (inputs.event_name != '' && inputs.event_name != 'check_run')
+      github.actor != 'dependabot[bot]' &&
+      ((inputs.event_name == '' && github.event_name != 'check_run') ||
+       (inputs.event_name != '' && inputs.event_name != 'check_run'))
```
Skips cleanly *before* the failing checkout. **dev-lead is not a required status check** (verified against the ruleset), so a skipped job is green; `dependabot-automerge` owns these PRs. Central reusable fix → all callers benefit via their channel pin.

## Rollout
On merge, autocut cuts a new dev-lead version from main; the new candidate no longer fails on Dependabot PRs → `cum_fail=0` → soaks clean → promotes, clearing the block.

Note: the canary automation did **not** auto-file a blocker issue for this regression (a `sync-issues` gap — likely the release-manager App's Issues:write limitation on `.github-private`); #864 already tracked the underlying bug. Optional follow-up: harden the caller-stub template too (defense-in-depth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)