### PR TITLE
feat(#1159): teach cut-release.sh about ci-failure-analyst (PR-1 of versioning)

### DIFF
--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -54,13 +54,13 @@ CROSS_REPO_TARGET="petry-projects/.github"
 
 # ── pure helpers (sourced by tests; no side effects) ─────────────────────────
 
-# valid_agent <agent> — return 0 iff agent is a known agent name. Covers the two
-# agents hosted in this repo (pr-review, dev-lead) plus the cross-repo reusables
-# hosted in petry-projects/.github (feature-ideation and the six #482 reusables
-# brought under the ring model in #870).
+# valid_agent <agent> — return 0 iff agent is a known agent name. Covers the
+# agents hosted in this repo (pr-review, dev-lead, ci-failure-analyst) plus the
+# cross-repo reusables hosted in petry-projects/.github (feature-ideation and the
+# six #482 reusables brought under the ring model in #870).
 valid_agent() {
   case "$1" in
-    pr-review | dev-lead) return 0 ;;
+    pr-review | dev-lead | ci-failure-analyst) return 0 ;;
     *) cross_repo_agent "$1" ;;
   esac
 }

--- a/tests/test_cut_release.bats
+++ b/tests/test_cut_release.bats
@@ -48,6 +48,20 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
+# ci-failure-analyst is hosted in THIS repo (.github-private), brought under the
+# versioned-release model in #1159.
+@test "valid_agent: ci-failure-analyst is accepted" {
+  run valid_agent "ci-failure-analyst"
+  [ "$status" -eq 0 ]
+}
+
+@test "agent_host_repo: ci-failure-analyst resolves to this repo (not cross-repo)" {
+  export GITHUB_REPOSITORY="petry-projects/.github-private"
+  run agent_host_repo "ci-failure-analyst"
+  [ "$status" -eq 0 ]
+  [ "$output" = "petry-projects/.github-private" ]
+}
+
 @test "valid_agent: feature-ideation is accepted" {
   run valid_agent "feature-ideation"
   [ "$status" -eq 0 ]
@@ -85,7 +99,7 @@ setup() {
 }
 
 @test "valid_agent: unknown agent is rejected" {
-  run valid_agent "ci-failure-analyst"
+  run valid_agent "totally-not-an-agent"
   [ "$status" -ne 0 ]
 }
 


### PR DESCRIPTION
PR-1 of #1159 (version ci-failure-analyst — Option A). Prerequisite that unblocks cutting its first release.

`cut-release.sh`'s `valid_agent` recognizes only `pr-review | dev-lead` (this-repo) + `feature-ideation` + the six #482 reusables (cross-repo), so `cut-release.sh ci-failure-analyst …` is **rejected**. ci-failure-analyst's reusable is hosted in **this repo** (`.github-private`), so it's added to the this-repo `valid_agent` case → `agent_host_repo` resolves to `.github-private`. Dry-run now resolves `ci-failure-analyst/v1.0.0` + `ci-failure-analyst/stable`.

Tests: `test_cut_release.bats` **46/46** (added accept + host-resolution; fixed the "unknown agent is rejected" fixture, which used `ci-failure-analyst` as its negative example — now valid).

**Next (this issue):** cut `v1.0.0`+channels → register in `.github/canary-rings.json` → repin the 4 consumers (TalkTerm, bmad, google-app-scripts, template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)