### PR TITLE
feat(#515): teach cut-release.sh about idea-enhancer (cross-repo)

### DIFF
--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -10,7 +10,7 @@
 #                                    [--push] [--dry-run]
 #
 #   <agent>      this repo: pr-review | dev-lead
-#                cross-repo (reusable in petry-projects/.github): feature-ideation |
+#                cross-repo (reusable in petry-projects/.github): feature-ideation | idea-enhancer |
 #                  agent-shield | auto-rebase | dependency-audit |
 #                  dependabot-automerge | dependabot-rebase | pr-review-mention
 #   <version>    semantic version without the leading v, e.g. 1.2.0
@@ -72,7 +72,7 @@ valid_agent() {
 # docs/release/versioning.md "Cross-repo reusables".
 cross_repo_agent() {
   case "$1" in
-    feature-ideation) return 0 ;;
+    feature-ideation | idea-enhancer) return 0 ;;
     agent-shield | auto-rebase | dependency-audit) return 0 ;;
     dependabot-automerge | dependabot-rebase | pr-review-mention) return 0 ;;
     *) return 1 ;;
@@ -189,7 +189,7 @@ main() {
   done
 
   if ! valid_agent "$agent"; then
-    echo "::error::unknown agent '$agent' (expected: pr-review | dev-lead | feature-ideation | agent-shield | auto-rebase | dependency-audit | dependabot-automerge | dependabot-rebase | pr-review-mention)" >&2
+    echo "::error::unknown agent '$agent' (expected: pr-review | dev-lead | feature-ideation | idea-enhancer | agent-shield | auto-rebase | dependency-audit | dependabot-automerge | dependabot-rebase | pr-review-mention)" >&2
     return 2
   fi
   if ! validate_version "$version"; then

--- a/tests/test_cut_release.bats
+++ b/tests/test_cut_release.bats
@@ -67,6 +67,19 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
+# idea-enhancer's reusable is hosted cross-repo in petry-projects/.github, brought
+# under the versioned-release model in #515.
+@test "valid_agent: idea-enhancer is accepted" {
+  run valid_agent "idea-enhancer"
+  [ "$status" -eq 0 ]
+}
+
+@test "agent_host_repo: idea-enhancer resolves to petry-projects/.github (cross-repo)" {
+  run agent_host_repo "idea-enhancer"
+  [ "$status" -eq 0 ]
+  [ "$output" = "petry-projects/.github" ]
+}
+
 # The six .github-hosted reusables migrated by #482, brought under the ring model (#870).
 @test "valid_agent: agent-shield is accepted" {
   run valid_agent "agent-shield"


### PR DESCRIPTION
PR-A of #515. idea-enhancer's reusable is hosted cross-repo in `petry-projects/.github` but wasn't in `cross_repo_agent`, so `cut-release.sh idea-enhancer …` was rejected — blocking the initial v1.0.0 cut (the template already pins `@idea-enhancer/stable`, which doesn't exist yet). Adds it to `cross_repo_agent` + the usage/error agent lists. Dry-run resolves `idea-enhancer/v1.0.0` + `stable` against `.github`. Tests 48/48.

Next: cut v1.0.0 + channels → register in canary-rings.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `idea-enhancer` cross-repository release agent.

* **Bug Fixes**
  * Improved release handling and validation for tags associated with `idea-enhancer`.

* **Tests**
  * Added coverage confirming the agent is recognized and correctly resolved to its repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->