### PR TITLE
feat: teach cut-release.sh about pr-auto-review (canary onboarding)

### DIFF
--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -10,7 +10,7 @@
 #                                    [--push] [--dry-run]
 #
 #   <agent>      this repo: pr-review | dev-lead
-#                cross-repo (reusable in petry-projects/.github): feature-ideation | idea-enhancer | add-to-project |
+#                cross-repo (reusable in petry-projects/.github): feature-ideation | idea-enhancer | add-to-project | pr-auto-review |
 #                  agent-shield | auto-rebase | dependency-audit |
 #                  dependabot-automerge | dependabot-rebase | pr-review-mention
 #   <version>    semantic version without the leading v, e.g. 1.2.0
@@ -72,7 +72,7 @@ valid_agent() {
 # docs/release/versioning.md "Cross-repo reusables".
 cross_repo_agent() {
   case "$1" in
-    feature-ideation | idea-enhancer | add-to-project) return 0 ;;
+    feature-ideation | idea-enhancer | add-to-project | pr-auto-review) return 0 ;;
     agent-shield | auto-rebase | dependency-audit) return 0 ;;
     dependabot-automerge | dependabot-rebase | pr-review-mention) return 0 ;;
     *) return 1 ;;
@@ -189,7 +189,7 @@ main() {
   done
 
   if ! valid_agent "$agent"; then
-    echo "::error::unknown agent '$agent' (expected: pr-review | dev-lead | feature-ideation | idea-enhancer | add-to-project | agent-shield | auto-rebase | dependency-audit | dependabot-automerge | dependabot-rebase | pr-review-mention)" >&2
+    echo "::error::unknown agent '$agent' (expected: pr-review | dev-lead | feature-ideation | idea-enhancer | add-to-project | pr-auto-review | agent-shield | auto-rebase | dependency-audit | dependabot-automerge | dependabot-rebase | pr-review-mention)" >&2
     return 2
   fi
   if ! validate_version "$version"; then

--- a/tests/test_cut_release.bats
+++ b/tests/test_cut_release.bats
@@ -79,6 +79,17 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
+@test "valid_agent: pr-auto-review is accepted" {
+  run valid_agent "pr-auto-review"
+  [ "$status" -eq 0 ]
+}
+
+@test "agent_host_repo: pr-auto-review resolves to petry-projects/.github (cross-repo)" {
+  run agent_host_repo "pr-auto-review"
+  [ "$status" -eq 0 ]
+  [ "$output" = "petry-projects/.github" ]
+}
+
 @test "agent_host_repo: add-to-project resolves to petry-projects/.github (cross-repo)" {
   run agent_host_repo "add-to-project"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Prereq to bring pr-auto-review under the canary/ring model (per the decision that it needs staged, blast-radius-contained rollout, not big-bang `@v2` moves). Adds it to `cross_repo_agent`. Tests 52/52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)